### PR TITLE
feat: extend mod-mode with panel snapping

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9318,6 +9318,19 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
 .mod-snap-zone.right { right: 0; top: 0; width: 80px; height: 100vh; }
 .mod-snap-zone.top { left: 0; top: 0; width: 100vw; height: 56px; }
 .mod-snap-zone.bottom { left: 0; bottom: 0; width: 100vw; height: 56px; }
+.mod-snap-zone.center {
+  left: 50%; top: 50%; width: 160px; height: 80px;
+  transform: translate(-50%, -50%);
+  border-radius: 12px;
+}
+.mod-snap-zone.right-sidebar {
+  right: 0; top: 30%; width: 80px; height: 40vh;
+  border-radius: 8px 0 0 8px;
+}
+.mod-snap-zone.left-sidebar {
+  left: 0; top: 30%; width: 80px; height: 40vh;
+  border-radius: 0 8px 8px 0;
+}
 
 #app[data-status-pos="top"] #status-bar {
   order: -1;
@@ -9347,6 +9360,65 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
 #app-body .sidebar[data-panel-pos="left"] { order: 1; }
 #app-body .main { order: 2; }
 #app-body .right-sidebar { order: 3; }
+
+/* Right sidebar — snapped left */
+#app-body .right-sidebar[data-panel-pos="left"] {
+  order: 1;
+  border-left: none;
+  border-right: 1px solid var(--border);
+}
+#app-body .right-sidebar[data-panel-pos="left"] .right-sidebar-resize-handle {
+  left: auto; right: -3px;
+  cursor: col-resize;
+}
+#app-body .right-sidebar[data-panel-pos="right"] { order: 3; }
+
+/* Floating panel (center) — any panel */
+.mod-float {
+  position: fixed !important;
+  z-index: 500;
+  border-radius: 10px;
+  border: 1px solid var(--border-light) !important;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.45), 0 0 0 1px rgba(255,255,255,0.04);
+  resize: both;
+  overflow: auto;
+}
+.right-sidebar.mod-float {
+  top: 80px; right: 24px;
+  width: 280px; height: 420px;
+  max-width: 50vw; max-height: 70vh;
+}
+
+/* Voice panel — floating */
+#voice-panel.mod-float {
+  position: fixed !important;
+  bottom: 80px; right: 24px;
+  width: 220px;
+  z-index: 600;
+  border-radius: 12px;
+  border: 1px solid var(--border-light);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  background: var(--bg-secondary);
+}
+
+/* Voice panel — docked to bottom of screen */
+#voice-panel.mod-voice-bottom {
+  position: fixed !important;
+  bottom: 0; left: 50%;
+  transform: translateX(-50%);
+  width: 400px; max-width: 90vw;
+  z-index: 600;
+  border-radius: 12px 12px 0 0;
+  border: 1px solid var(--border-light);
+  border-bottom: none;
+  box-shadow: 0 -4px 24px rgba(0,0,0,0.3);
+  background: var(--bg-secondary);
+}
+
+/* Voice panel — moved to left sidebar */
+#voice-panel.mod-voice-left {
+  border-top: 1px solid var(--border);
+}
 
 .mod-toast {
   position: fixed;


### PR DESCRIPTION
## Summary

- **Right sidebar** can now be snapped to left, right, or center (floating) position via mod mode
- **Voice panel** can now be repositioned to right-sidebar, left-sidebar, bottom dock, or center (floating)
- New snap zone overlays for `center`, `right-sidebar`, and `left-sidebar` positions
- Floating panels get rounded corners, resize handles, and drop shadows
- Voice panel DOM properly moves between sidebars when repositioned
- Layout persists in localStorage and resets cleanly

## Changes

| File | What changed |
|------|-------------|
| `public/js/modmode.js` | Extended `panelDefs` and `panelLayout` with right-sidebar and voice-panel entries. Updated `applyPanelLayout()` to handle float, bottom dock, and sidebar DOM moves. Improved snap zone labels and toast messages. |
| `public/css/style.css` | Added snap zone styles for center/right-sidebar/left-sidebar. Added `.mod-float` floating panel class. Added voice panel styles for float, bottom dock, and left-sidebar positions. Added right-sidebar left-snap ordering. |

## Test plan

- [ ] Enable mod mode, drag right-sidebar handle to left/center/right snap zones
- [ ] Drag voice panel handle to all 4 positions (right-sidebar, left-sidebar, bottom, center)
- [ ] Verify floating panels can be resized and have proper z-index
- [ ] Verify layout persists after page reload
- [ ] Verify "Reset Layout" restores defaults and moves voice panel back
- [ ] Test on different viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)