### PR TITLE
v1.9.1: Custom emojis, DM deletion, settings nav, reply scroll, quickbar fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force Unix line endings for shell scripts so Docker builds
+# work regardless of the user's core.autocrlf setting.
+*.sh text eol=lf
+docker-entrypoint.sh text eol=lf
+Dockerfile text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [1.9.1] — 2026-02-18
+
+### Added
+- **Custom server emojis** — admins can upload PNG/GIF/WebP images as custom emojis (`:emoji_name:` syntax). Works in messages, reactions, and the emoji picker.
+- **Emoji quickbar customization** — click the ⚙️ gear icon on the reaction picker to swap any of the 8 quick-react slots with any emoji (including custom ones). Saved per-user in localStorage.
+- **DM deletion** — right-click (or click "...") on any DM conversation to delete it. Removes from your sidebar only.
+- **Reply banner click-to-scroll** — clicking the reply preview above a message now smooth-scrolls to the original message and highlights it briefly.
+- **Settings navigation sidebar** — the settings modal now has a left-side index with clickable categories (Layout, Sounds, Push, Password, and all admin subsections). Hidden on mobile.
+- **Popout modals for sounds & emojis** — Custom Sounds and Custom Emojis management moved out of the inline settings panel into their own dedicated modals (like Bots/Roles). Keeps the settings menu lean.
+- **JWT identity cross-check** — tokens are now validated against the actual database user, preventing token reuse across accounts (security hardening).
+
+### Fixed
+- **Docker entrypoint CRLF crash** — added `.gitattributes` to force LF line endings on shell scripts, plus a `sed` fallback in the Dockerfile.
+- **Quick emoji editor immediately closing** — click events inside the editor propagated to the document-level close handler. Added `stopPropagation()` to all interactive elements.
+- **Gear icon placement** — moved the ⚙️ customization button to the right of the "⋯" more-emojis button so frequent "..." clicks aren't blocked.
+
+---
+
 ## [1.9.0] — 2026-02-17
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN npm ci --omit=dev && \
 
 # Copy entrypoint (auto-generates SSL certs, fixes volume permissions)
 COPY docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
 # Copy application source
 COPY . .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haven",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Self-hosted private chat — your server, your rules",
   "license": "MIT-NC",
   "main": "server.js",

--- a/public/app.html
+++ b/public/app.html
@@ -29,6 +29,9 @@
         <button class="server-icon add-server" id="add-server-btn" title="Add Server">
           <span class="server-icon-text">+</span>
         </button>
+        <button class="server-icon manage-servers" id="manage-servers-btn" title="Manage Servers">
+          <span class="server-icon-text">⚙</span>
+        </button>
       </nav>
 
       <!-- ─── Left Sidebar ────────────────────────────── -->
@@ -711,8 +714,31 @@
         <button class="settings-close-btn" id="close-settings-btn">&times;</button>
       </div>
 
+      <div class="settings-layout">
+        <nav class="settings-nav" id="settings-nav">
+          <div class="settings-nav-group">User</div>
+          <div class="settings-nav-item active" data-target="section-density">📐 Layout</div>
+          <div class="settings-nav-item" data-target="section-sounds">🔔 Sounds</div>
+          <div class="settings-nav-item" data-target="section-push">📲 Push</div>
+          <div class="settings-nav-item" data-target="section-password">🔒 Password</div>
+          <div class="settings-nav-group settings-nav-admin" style="display:none">Admin</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-branding" style="display:none">🏠 Branding</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-members" style="display:none">👥 Members</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-whitelist" style="display:none">🛡️ Whitelist</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-invite" style="display:none">🌐 Invite Code</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-cleanup" style="display:none">🗑️ Cleanup</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-uploads" style="display:none">📁 Uploads</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-sounds-admin" style="display:none">🔊 Sounds</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-emojis" style="display:none">😎 Emojis</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-roles" style="display:none">👑 Roles</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-tunnel" style="display:none">🧭 Tunnel</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-bots" style="display:none">🤖 Bots</div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-modmode" style="display:none">🔧 Mod Mode</div>
+        </nav>
+        <div class="settings-body">
+
       <!-- Layout Density Section -->
-      <div class="settings-section">
+      <div class="settings-section" id="section-density">
         <h5 class="settings-section-title">📐 Layout Density</h5>
         <div class="density-picker" id="density-picker">
           <button type="button" class="density-btn" data-density="compact" title="Compact — tighter spacing, smaller avatars">
@@ -731,7 +757,7 @@
       </div>
 
       <!-- Sounds Section -->
-      <div class="settings-section">
+      <div class="settings-section" id="section-sounds">
         <h5 class="settings-section-title">🔔 Sounds</h5>
         <div class="notif-settings">
           <label class="toggle-row">
@@ -799,7 +825,7 @@
       </div>
 
       <!-- Push Notifications Section -->
-      <div class="settings-section">
+      <div class="settings-section" id="section-push">
         <h5 class="settings-section-title">📲 Push Notifications</h5>
         <div class="notif-settings">
           <label class="toggle-row">
@@ -812,7 +838,7 @@
       </div>
 
       <!-- Password Change Section -->
-      <div class="settings-section">
+      <div class="settings-section" id="section-password">
         <h5 class="settings-section-title">🔒 Password</h5>
         <div class="password-change-form">
           <div class="form-group compact">
@@ -834,7 +860,7 @@
         <h5 class="settings-section-title">🛡️ Admin</h5>
 
         <!-- Server Branding -->
-        <div class="admin-settings">
+        <div class="admin-settings" id="section-branding">
           <h5 class="settings-section-subtitle">🏠 Server Branding</h5>
           <label class="select-row">
             <span>Server Name</span>
@@ -855,7 +881,7 @@
           </div>
         </div>
 
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+        <div class="admin-settings" id="section-members" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <label class="select-row">
             <span>Show Members</span>
             <select id="member-visibility-select">
@@ -866,8 +892,8 @@
           </label>
           <button class="btn-sm btn-full" id="view-bans-btn">📋 View Bans</button>
         </div>
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
-          <h5 class="settings-section-subtitle">� Whitelist</h5>
+        <div class="admin-settings" id="section-whitelist" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+          <h5 class="settings-section-subtitle">🛡️ Whitelist</h5>
           <label class="toggle-row">
             <span>Enabled</span>
             <input type="checkbox" id="whitelist-enabled">
@@ -883,7 +909,7 @@
             </div>
           </div>
         </div>
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+        <div class="admin-settings" id="section-invite" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">🌐 Server Invite Code</h5>
           <small class="settings-hint">A single code that adds people to every channel &amp; sub-channel on the server</small>
           <div style="margin-top:8px;">
@@ -897,7 +923,7 @@
             </div>
           </div>
         </div>
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+        <div class="admin-settings" id="section-cleanup" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">🗑️ Auto-Cleanup</h5>
           <label class="toggle-row">
             <span>Enabled</span>
@@ -915,30 +941,30 @@
           <small class="settings-hint">Trim oldest messages when DB exceeds N MB (0 = off)</small>
           <button class="btn-sm btn-full" id="run-cleanup-now-btn" style="margin-top:4px;">🧹 Run Cleanup Now</button>
         </div>
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
-          <h5 class="settings-section-subtitle">� File Uploads</h5>
+        <div class="admin-settings" id="section-uploads" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+          <h5 class="settings-section-subtitle">📁 File Uploads</h5>
           <label class="select-row">
             <span>Max Upload Size (MB)</span>
             <input type="number" id="max-upload-mb" min="1" max="2048" value="25" class="settings-number-input">
           </label>
           <small class="settings-hint">Maximum file size users can upload (1–2048 MB / 2 GB, default 25)</small>
         </div>
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
-          <h5 class="settings-section-subtitle">�🔊 Custom Sounds</h5>
-          <small class="settings-hint">Upload audio files for custom notification sounds (max 1 MB each)</small>
+        <div class="admin-settings" id="section-sounds-admin" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+          <h5 class="settings-section-subtitle">🔊 Custom Sounds</h5>
+          <small class="settings-hint">Upload audio files for custom notification sounds</small>
           <div style="margin-top:8px;">
-            <div class="whitelist-add-row">
-              <input type="text" id="sound-name-input" placeholder="Sound name..." maxlength="30" class="settings-text-input">
-              <input type="file" id="sound-file-input" accept="audio/*" style="max-width:120px;font-size:11px">
-              <button class="btn-sm btn-accent" id="sound-upload-btn">Upload</button>
-            </div>
-            <div id="custom-sounds-list" style="margin-top:8px;">
-              <p class="muted-text">No custom sounds uploaded</p>
-            </div>
+            <button class="btn-sm btn-full btn-accent" id="open-sound-manager-btn">⚙️ Manage Sounds</button>
+          </div>
+        </div>
+        <div class="admin-settings" id="section-emojis" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+          <h5 class="settings-section-subtitle">😎 Custom Emojis</h5>
+          <small class="settings-hint">Upload images for custom server emojis</small>
+          <div style="margin-top:8px;">
+            <button class="btn-sm btn-full btn-accent" id="open-emoji-manager-btn">⚙️ Manage Emojis</button>
           </div>
         </div>
         <!-- Role Management (Admin only) -->
-        <div class="admin-settings" id="role-mgmt-section" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+        <div class="admin-settings" id="section-roles" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">👑 Role Management</h5>
           <small class="settings-hint">Create and manage roles. Assign roles to users from the user list context menu.</small>
           <div style="margin-top:8px;">
@@ -949,7 +975,7 @@
           </div>
         </div>
         <!-- Tunnel settings (Admin only) -->
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+        <div class="admin-settings" id="section-tunnel" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">🧭 Tunnel</h5>
           <label class="toggle-row">
             <span>Enabled</span>
@@ -965,7 +991,7 @@
           <div id="tunnel-status-display" class="muted-text" style="margin-top:4px;font-size:11px;">Inactive</div>
         </div>
         <!-- Webhooks / Bots (Admin only) -->
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+        <div class="admin-settings" id="section-bots" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">🤖 Webhooks / Bots</h5>
           <small class="settings-hint">Create and manage webhook bots that can post messages to channels.</small>
           <div style="margin-top:8px;">
@@ -976,7 +1002,7 @@
           </div>
         </div>
         <!-- Mod Mode (Admin only) -->
-        <div class="admin-settings" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+        <div class="admin-settings" id="section-modmode" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">🔧 Mod Mode</h5>
           <small class="settings-hint">Rearrange sidebar sections and snap server/sidebar/status panels</small>
           <button class="btn-sm btn-full" id="mod-mode-settings-toggle" style="margin-top:6px;">🔧 Toggle Mod Mode</button>
@@ -988,6 +1014,8 @@
           <small class="settings-hint" style="text-align:center;margin-top:4px">Changes only apply when you click Save. Close (✕) to cancel.</small>
         </div>
       </div>
+        </div><!-- /settings-body -->
+      </div><!-- /settings-layout -->
     </div>
   </div>
 
@@ -1052,6 +1080,44 @@
     </div>
   </div>
 
+  <!-- Sound Management Modal -->
+  <div class="modal-overlay" id="sound-modal" style="display:none">
+    <div class="modal" style="max-width:520px">
+      <h3>🔊 Sound Management</h3>
+      <small class="settings-hint" style="display:block;margin-bottom:12px">Upload audio files for custom notification sounds (max 1 MB each)</small>
+      <div class="whitelist-add-row">
+        <input type="text" id="sound-name-input" placeholder="Sound name..." maxlength="30" class="settings-text-input">
+        <input type="file" id="sound-file-input" accept="audio/*" style="max-width:120px;font-size:11px">
+        <button class="btn-sm btn-accent" id="sound-upload-btn">Upload</button>
+      </div>
+      <div id="custom-sounds-list" style="margin-top:12px;">
+        <p class="muted-text">No custom sounds uploaded</p>
+      </div>
+      <div class="modal-actions">
+        <button class="btn-sm" id="close-sound-modal-btn">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Emoji Management Modal -->
+  <div class="modal-overlay" id="emoji-modal" style="display:none">
+    <div class="modal" style="max-width:520px">
+      <h3>😎 Emoji Management</h3>
+      <small class="settings-hint" style="display:block;margin-bottom:12px">Upload images for custom server emojis (max 256 KB, png/gif/webp). Name must be lowercase, no spaces.</small>
+      <div class="whitelist-add-row">
+        <input type="text" id="emoji-name-input" placeholder="emoji_name" maxlength="30" class="settings-text-input">
+        <input type="file" id="emoji-file-input" accept="image/png,image/gif,image/webp,image/jpeg" style="max-width:120px;font-size:11px">
+        <button class="btn-sm btn-accent" id="emoji-upload-btn">Upload</button>
+      </div>
+      <div id="custom-emojis-list" style="margin-top:12px;">
+        <p class="muted-text">No custom emojis uploaded</p>
+      </div>
+      <div class="modal-actions">
+        <button class="btn-sm" id="close-emoji-modal-btn">Close</button>
+      </div>
+    </div>
+  </div>
+
   <div class="modal-overlay" id="bans-modal" style="display:none">
     <div class="modal modal-wide">
       <h3>Banned Users</h3>
@@ -1086,9 +1152,24 @@
     </div>
   </div>
 
+  <!-- Manage Servers Modal -->
+  <div class="modal-overlay" id="manage-servers-modal" style="display:none">
+    <div class="modal" style="max-width:480px">
+      <h3>⚙ Manage Servers</h3>
+      <p class="modal-desc">Edit or remove your linked servers</p>
+      <div id="manage-servers-list" class="manage-servers-list"></div>
+      <div class="modal-actions" style="justify-content:space-between">
+        <button class="btn-sm btn-accent" id="manage-servers-add-btn">+ Add Server</button>
+        <button class="btn-sm" id="manage-servers-close-btn">Close</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Channel context menu (appears on "..." hover button) -->
   <div id="channel-ctx-menu" class="channel-ctx-menu" style="display:none">
     <button class="channel-ctx-item" data-action="mute">🔔 Mute Channel</button>
+    <button class="channel-ctx-item" data-action="join-voice">🎙️ Join Voice</button>
+    <button class="channel-ctx-item" data-action="leave-voice" style="display:none">📴 Disconnect Voice</button>
     <hr class="channel-ctx-sep">
     <button class="channel-ctx-item mod-only" data-action="rename-channel">✏️ Rename Channel</button>
     <button class="channel-ctx-item mod-only" data-action="create-sub-channel">📁 Create Sub-channel</button>
@@ -1101,6 +1182,13 @@
     <button class="channel-ctx-item admin-only" data-action="webhooks">🤖 Webhooks</button>
     <hr class="channel-ctx-sep admin-only">
     <button class="channel-ctx-item admin-only danger" data-action="delete">🗑️ Delete Channel</button>
+  </div>
+
+  <!-- DM context menu -->
+  <div id="dm-ctx-menu" class="channel-ctx-menu" style="display:none">
+    <button class="channel-ctx-item" data-action="dm-mute">🔔 Mute DM</button>
+    <hr class="channel-ctx-sep">
+    <button class="channel-ctx-item danger" data-action="dm-delete">🗑️ Delete DM</button>
   </div>
 
   <!-- Organize Sub-channels Modal -->

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4109,6 +4109,137 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
 
 .server-icon.remote:hover .server-remove { display: flex; }
 
+/* Manage Servers gear button */
+.server-icon.manage-servers {
+  background: transparent;
+  border: 2px dashed var(--border-light);
+  margin-top: 2px;
+}
+.server-icon.manage-servers:hover {
+  border-color: var(--accent);
+  background: transparent;
+  border-radius: 12px;
+}
+.server-icon.manage-servers .server-icon-text {
+  font-size: 18px;
+  color: var(--text-secondary);
+  transition: color 0.15s;
+}
+.server-icon.manage-servers:hover .server-icon-text {
+  color: var(--accent);
+}
+
+/* Manage Servers modal list */
+.manage-servers-list {
+  max-height: 360px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 12px 0;
+}
+.manage-servers-list:empty::before {
+  content: 'No servers added yet. Click "+ Add Server" below.';
+  color: var(--text-muted);
+  text-align: center;
+  padding: 24px 0;
+  font-size: 13px;
+}
+.manage-server-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  transition: background 0.15s;
+}
+.manage-server-row:hover {
+  background: var(--bg-hover);
+}
+.manage-server-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  overflow: hidden;
+}
+.manage-server-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+}
+.manage-server-info {
+  flex: 1;
+  min-width: 0;
+}
+.manage-server-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.manage-server-url {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono);
+}
+.manage-server-status {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 9px;
+  flex-shrink: 0;
+}
+.manage-server-status.online {
+  background: rgba(67, 181, 129, 0.15);
+  color: var(--success);
+}
+.manage-server-status.offline {
+  background: rgba(240, 71, 71, 0.12);
+  color: var(--text-muted);
+}
+.manage-server-status.unknown {
+  background: rgba(250, 166, 26, 0.12);
+  color: var(--warning);
+}
+.manage-server-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.manage-server-actions button {
+  background: none;
+  border: none;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  transition: background 0.15s, color 0.15s;
+}
+.manage-server-actions button:hover {
+  background: var(--bg-active);
+  color: var(--text-primary);
+}
+.manage-server-actions button.danger-action:hover {
+  background: #3a1515;
+  color: var(--danger);
+}
+
 
 /* ═══════════════════════════════════════════════════════════
    MODAL
@@ -4813,6 +4944,31 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
   transform: scale(1.2);
 }
 
+/* Custom emoji (inline in messages + pickers) */
+.custom-emoji {
+  width: 1.4em;
+  height: 1.4em;
+  vertical-align: middle;
+  object-fit: contain;
+  display: inline;
+  margin: 0 1px;
+}
+.reaction-custom-emoji {
+  width: 1em;
+  height: 1em;
+}
+.emoji-item .custom-emoji {
+  width: 24px;
+  height: 24px;
+}
+.reaction-full-btn .custom-emoji {
+  width: 22px;
+  height: 22px;
+}
+.custom-emoji-preview {
+  border-radius: 4px;
+}
+
 
 /* ═══════════════════════════════════════════════════════════
    GIF PICKER
@@ -5078,6 +5234,42 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
   font-weight: 700;
   color: var(--text-muted);
   letter-spacing: 1px;
+}
+
+.reaction-pick-sep {
+  color: var(--text-muted);
+  font-size: 16px;
+  opacity: 0.4;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  padding: 0 1px;
+}
+
+.reaction-gear-btn {
+  font-size: 14px;
+  color: var(--text-muted);
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+.reaction-gear-btn:hover {
+  opacity: 1;
+}
+
+.quick-emoji-slots {
+  display: flex;
+  gap: 4px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+.quick-emoji-slot {
+  border: 2px solid transparent;
+  border-radius: var(--radius-sm);
+}
+.quick-emoji-slot.active {
+  border-color: var(--accent);
+  background: var(--accent-glow);
 }
 
 /* ── Full Reaction Emoji Picker (opened via "...") ── */
@@ -5947,13 +6139,6 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
    SETTINGS POPOUT MODAL
    ═══════════════════════════════════════════════════════════ */
 
-.modal-settings {
-  max-width: 460px;
-  max-height: 85vh;
-  overflow-y: auto;
-  padding: 0;
-}
-
 .settings-header {
   display: flex;
   align-items: center;
@@ -5991,6 +6176,72 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
 .settings-close-btn:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
+}
+
+/* ── Settings Layout (Nav + Body) ─────────────────────── */
+.settings-layout {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.settings-nav {
+  width: 150px;
+  min-width: 150px;
+  padding: 8px 0 8px 8px;
+  overflow-y: auto;
+  border-right: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.settings-nav-group {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 10px 10px 4px;
+  user-select: none;
+}
+
+.settings-nav-item {
+  padding: 5px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  margin-bottom: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 0.15s, color 0.15s;
+}
+
+.settings-nav-item:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.settings-nav-item.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.settings-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+  min-width: 0;
+}
+
+.modal-settings {
+  max-width: 640px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
 }
 
 /* ── Activities / Games Launcher ──────────────────────── */
@@ -6735,8 +6986,10 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
   .modal { padding: 20px; width: 95%; max-height: 85vh; overflow-y: auto; }
   .modal h3 { font-size: 18px; }
 
-  /* Settings modal — scrollable on phone */
-  .modal-settings { max-height: 80vh; overflow-y: auto; }
+  /* Settings modal — scrollable on phone, hide nav */
+  .modal-settings { max-height: 80vh; }
+  .settings-nav { display: none; }
+  .settings-body { overflow-y: auto; }
 
   /* Toasts — full width */
   #toast-container { left: 50%; right: auto; top: calc(8px + env(safe-area-inset-top, 0px)); transform: translateX(-50%); }
@@ -9151,6 +9404,12 @@ input[type="range"]:not(.rgb-slider)::-moz-range-track {
   width: 28px;
   height: 28px;
   font-size: 11px;
+}
+[data-density="compact"] .message-compact {
+  padding-left: 44px;
+}
+[data-density="compact"] .message-compact .compact-time {
+  font-size: 9px;
 }
 [data-density="compact"] .msg-body {
   font-size: 13px;

--- a/src/database.js
+++ b/src/database.js
@@ -229,6 +229,17 @@ function initDatabase() {
     );
   `);
 
+  // ── Migration: custom_emojis table (admin-uploaded server emojis) ──
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS custom_emojis (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT UNIQUE NOT NULL,
+      filename TEXT NOT NULL,
+      uploaded_by INTEGER REFERENCES users(id),
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+
   // ── Migration: channel topic column ─────────────────────
   try {
     db.prepare("SELECT topic FROM channels LIMIT 0").get();


### PR DESCRIPTION
## What's New in 1.9.1\n\n### Added\n- **Custom server emojis** — admins can upload PNG/GIF/WebP images as custom emojis (`:emoji_name:` syntax). Works in messages, reactions, and the emoji picker.\n- **Emoji quickbar customization** — click the ⚙️ gear icon on the reaction picker to swap any of the 8 quick-react slots with any emoji (including custom ones). Saved per-user in localStorage.\n- **DM deletion** — right-click (or click \"...\") on any DM conversation to delete it. Removes from your sidebar only.\n- **Reply banner click-to-scroll** — clicking the reply preview above a message now smooth-scrolls to the original message and highlights it briefly.\n- **Settings navigation sidebar** — the settings modal now has a left-side index with clickable categories.\n- **Popout modals for sounds & emojis** — Custom Sounds and Custom Emojis management moved into their own dedicated modals.\n- **JWT identity cross-check** — security hardening.\n\n### Fixed\n- Docker entrypoint CRLF crash (`.gitattributes` + `sed` fallback)\n- Quick emoji editor immediately closing (event propagation fix)\n- Gear icon placement (moved right of \"⋯\" button)