### PR TITLE
Expanded permissions system

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -213,8 +213,10 @@ class HavenApp {
     if (this.user.isAdmin || this._hasPerm('create_channel')) {
       document.getElementById('admin-controls').style.display = 'block';
     }
-    if (this.user.isAdmin) {
+    if (this.user.isAdmin || this._hasPerm('manage_roles') || this._hasPerm('manage_server')) {
       document.getElementById('admin-mod-panel').style.display = 'block';
+    }
+    if (this.user.isAdmin) {
       const organizeBtn = document.getElementById('organize-channels-btn');
       if (organizeBtn) organizeBtn.style.display = '';
     }

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -312,7 +312,7 @@ _applyServerSettings() {
   // Re-evaluate update banner visibility whenever settings change
   this._applyUpdateBanner();
 
-  if (!modalOpen && this.user && this.user.isAdmin) {
+  if (!modalOpen && this.user && (this.user.isAdmin || this._hasPerm('manage_server'))) {
     this.socket.emit('get-whitelist');
   }
 },
@@ -337,19 +337,28 @@ _renderWebhooksList(webhooks) {
 },
 
 _syncSettingsNav() {
-  const isAdmin = document.getElementById('admin-mod-panel')?.style.display !== 'none';
+  const isAdmin = !!this.user?.isAdmin;
   document.querySelectorAll('.settings-nav-admin').forEach(el => {
     el.style.display = isAdmin ? '' : 'none';
   });
-  // Show the Emojis settings tab for users with manage_emojis permission even if not full admin/mod
-  const emojiNavItem = document.querySelector('.settings-nav-item[data-target="section-emojis"]');
-  if (emojiNavItem && !isAdmin && this._hasPerm('manage_emojis')) {
-    emojiNavItem.style.display = '';
-  }
-  // Show the Sounds admin tab for users with manage_soundboard permission
-  const soundsNavItem = document.querySelector('.settings-nav-item[data-target="section-sounds-admin"]');
-  if (soundsNavItem && !isAdmin && this._hasPerm('manage_soundboard')) {
-    soundsNavItem.style.display = '';
+  // Per-permission nav reveals for non-admins
+  if (!isAdmin) {
+    // manage_emojis
+    const emojiNavItem = document.querySelector('.settings-nav-item[data-target="section-emojis"]');
+    if (emojiNavItem && this._hasPerm('manage_emojis')) emojiNavItem.style.display = '';
+    // manage_soundboard
+    const soundsNavItem = document.querySelector('.settings-nav-item[data-target="section-sounds-admin"]');
+    if (soundsNavItem && this._hasPerm('manage_soundboard')) soundsNavItem.style.display = '';
+    // manage_roles
+    const rolesNavItem = document.querySelector('.settings-nav-item[data-target="section-roles"]');
+    if (rolesNavItem && this._hasPerm('manage_roles')) rolesNavItem.style.display = '';
+    // manage_server
+    if (this._hasPerm('manage_server')) {
+      ['section-branding', 'section-whitelist', 'section-invite', 'section-cleanup', 'section-uploads', 'section-tunnel'].forEach(target => {
+        const item = document.querySelector(`.settings-nav-item[data-target="${target}"]`);
+        if (item) item.style.display = '';
+      });
+    }
   }
 },
 
@@ -372,7 +381,7 @@ _snapshotAdminSettings() {
 },
 
 _saveAdminSettings() {
-  if (!this.user?.isAdmin) {
+  if (!this.user?.isAdmin && !this._hasPerm('manage_server')) {
     document.getElementById('settings-modal').style.display = 'none';
     return;
   }
@@ -2262,12 +2271,14 @@ _renderRoleDetail() {
     return;
   }
 
+  const rolePerms = role.permissions || [];
   const allPerms = [
     'edit_own_messages', 'delete_own_messages', 'delete_message', 'delete_lower_messages',
     'pin_message', 'archive_messages', 'kick_user', 'mute_user', 'ban_user',
     'rename_channel', 'rename_sub_channel', 'set_channel_topic', 'manage_sub_channels',
     'create_channel', 'upload_files', 'use_voice', 'manage_webhooks', 'mention_everyone', 'view_history',
-    'manage_emojis', 'manage_soundboard', 'promote_user', 'transfer_admin'
+    'manage_emojis', 'manage_soundboard', 'promote_user', 'transfer_admin',
+    'manage_roles', 'manage_server', 'delete_channel'
   ];
   const permLabels = {
     edit_own_messages: 'Edit Own Messages', delete_own_messages: 'Delete Own Messages',
@@ -2282,9 +2293,12 @@ _renderRoleDetail() {
     view_history: 'View Message History',
     manage_emojis: 'Manage Custom Emojis',
     manage_soundboard: 'Manage Soundboard',
-    promote_user: 'Promote Users', transfer_admin: 'Transfer Admin'
+    promote_user: 'Promote Users',
+    transfer_admin: 'Transfer Admin',
+    manage_roles: 'Manage Roles',
+    manage_server: 'Manage Server',
+    delete_channel: 'Delete Channels'
   };
-  const rolePerms = role.permissions || [];
 
   panel.innerHTML = `
     <div class="role-detail-form">
@@ -2681,7 +2695,8 @@ _renderChannelRolesRoleDetail() {
     'pin_message', 'archive_messages', 'kick_user', 'mute_user', 'ban_user',
     'rename_channel', 'rename_sub_channel', 'set_channel_topic', 'manage_sub_channels',
     'create_channel', 'upload_files', 'use_voice', 'manage_webhooks', 'mention_everyone', 'view_history',
-    'manage_emojis', 'manage_soundboard', 'promote_user', 'transfer_admin'
+    'manage_emojis', 'manage_soundboard', 'promote_user', 'transfer_admin',
+    'manage_roles', 'manage_server', 'delete_channel'
   ];
   const permLabels = {
     edit_own_messages: 'Edit Own Messages', delete_own_messages: 'Delete Own Messages',
@@ -2696,7 +2711,8 @@ _renderChannelRolesRoleDetail() {
     view_history: 'View Message History',
     manage_emojis: 'Manage Custom Emojis',
     manage_soundboard: 'Manage Soundboard',
-    promote_user: 'Promote Users', transfer_admin: 'Transfer Admin'
+    promote_user: 'Promote Users', transfer_admin: 'Transfer Admin',
+    manage_roles: 'Manage Roles', manage_server: 'Manage Server', delete_channel: 'Delete Channels'
   };
   const rolePerms = role.permissions || [];
 
@@ -2855,7 +2871,7 @@ _openRoleAssignCenter(preSelectUserId = null) {
 
   // Show admin-only buttons
   const manageBtn = document.getElementById('rac-manage-roles-btn');
-  if (manageBtn) manageBtn.style.display = this.user.isAdmin ? '' : 'none';
+  if (manageBtn) manageBtn.style.display = (this.user.isAdmin || this._hasPerm('manage_roles')) ? '' : 'none';
 
   this.socket.emit('get-role-assignment-data', {}, (res) => {
     if (res.error) { this._showToast(res.error, 'error'); return; }
@@ -3076,7 +3092,8 @@ _renderRacConfig() {
     'pin_message', 'archive_messages', 'kick_user', 'mute_user', 'ban_user',
     'rename_channel', 'rename_sub_channel', 'set_channel_topic', 'manage_sub_channels',
     'create_channel', 'upload_files', 'use_voice', 'manage_webhooks', 'mention_everyone', 'view_history',
-    'manage_emojis', 'manage_soundboard', 'promote_user', 'transfer_admin'
+    'manage_emojis', 'manage_soundboard', 'promote_user', 'transfer_admin',
+    'manage_roles', 'manage_server', 'delete_channel'
   ];
   // Perms that only admin can grant
   const adminOnlyPerms = ['transfer_admin'];
@@ -3094,7 +3111,8 @@ _renderRacConfig() {
     mention_everyone: 'Mention Everyone', view_history: 'View History',
     manage_emojis: 'Manage Custom Emojis',
     manage_soundboard: 'Manage Soundboard',
-    promote_user: 'Promote Users', transfer_admin: 'Transfer Admin'
+    promote_user: 'Promote Users', transfer_admin: 'Transfer Admin',
+    manage_roles: 'Manage Roles', manage_server: 'Manage Server', delete_channel: 'Delete Channels'
   };
 
   // If a role preset is selected, get its permissions

--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -192,6 +192,15 @@ _openChannelCtxMenu(code, btnEl) {
   menu.querySelectorAll('.admin-only').forEach(el => {
     el.style.display = canManageChannels ? '' : 'none';
   });
+  // Delete Channel requires explicit delete_channel permission (not just create_channel)
+  const deleteBtn = menu.querySelector('[data-action="delete"]');
+  if (deleteBtn) {
+    deleteBtn.style.display = (isAdmin || this._hasPerm('delete_channel')) ? '' : 'none';
+    const deleteSep = deleteBtn.previousElementSibling;
+    if (deleteSep && deleteSep.classList.contains('channel-ctx-sep')) {
+      deleteSep.style.display = deleteBtn.style.display;
+    }
+  }
   menu.querySelectorAll('.mod-only').forEach(el => {
     el.style.display = isMod ? '' : 'none';
   });

--- a/src/socketHandlers.js
+++ b/src/socketHandlers.js
@@ -2489,7 +2489,7 @@ function setupSocketHandlers(io, db) {
 
     socket.on('delete-channel', (data) => {
       if (!data || typeof data !== 'object') return;
-      if (!socket.user.isAdmin) {
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'delete_channel')) {
         return socket.emit('error-msg', 'Only admins can delete channels');
       }
 
@@ -3278,14 +3278,14 @@ function setupSocketHandlers(io, db) {
     // ═══════════════ WHITELIST MANAGEMENT ═══════════════════
 
     socket.on('get-whitelist', () => {
-      if (!socket.user.isAdmin) return;
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_server')) return;
       const rows = db.prepare('SELECT id, username, created_at FROM whitelist ORDER BY username').all();
       rows.forEach(r => { r.created_at = utcStamp(r.created_at); });
       socket.emit('whitelist-list', rows);
     });
 
     socket.on('whitelist-add', (data) => {
-      if (!socket.user.isAdmin) return;
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_server')) return;
       if (!data || typeof data !== 'object') return;
       const username = typeof data.username === 'string' ? data.username.trim() : '';
       if (!username || username.length < 3 || username.length > 20) {
@@ -3308,7 +3308,7 @@ function setupSocketHandlers(io, db) {
     });
 
     socket.on('whitelist-remove', (data) => {
-      if (!socket.user.isAdmin) return;
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_server')) return;
       if (!data || typeof data !== 'object') return;
       const username = typeof data.username === 'string' ? data.username.trim() : '';
       if (!username) return;
@@ -3322,7 +3322,7 @@ function setupSocketHandlers(io, db) {
     });
 
     socket.on('whitelist-toggle', (data) => {
-      if (!socket.user.isAdmin) return;
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_server')) return;
       if (!data || typeof data !== 'object') return;
       const enabled = data.enabled === true ? 'true' : 'false';
       db.prepare("INSERT OR REPLACE INTO server_settings (key, value) VALUES ('whitelist_enabled', ?)").run(enabled);
@@ -3405,7 +3405,7 @@ function setupSocketHandlers(io, db) {
 
     socket.on('update-server-setting', (data) => {
       if (!data || typeof data !== 'object') return;
-      if (!socket.user.isAdmin) {
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_server')) {
         return socket.emit('error-msg', 'Only admins can change server settings');
       }
 
@@ -3461,7 +3461,8 @@ function setupSocketHandlers(io, db) {
             'pin_message', 'kick_user', 'mute_user', 'ban_user',
             'rename_channel', 'rename_sub_channel', 'set_channel_topic', 'manage_sub_channels',
             'upload_files', 'use_voice', 'manage_webhooks', 'mention_everyone', 'view_history',
-            'promote_user', 'transfer_admin', 'archive_messages', 'create_channel', 'manage_emojis', 'manage_soundboard'
+            'promote_user', 'transfer_admin', 'archive_messages', 'create_channel', 'manage_emojis', 'manage_soundboard',
+            'manage_roles', 'manage_server', 'delete_channel'
           ];
           for (const [k, v] of Object.entries(obj)) {
             if (!validPerms.includes(k)) return;
@@ -3493,7 +3494,7 @@ function setupSocketHandlers(io, db) {
     // ═══════════════ SERVER-WIDE INVITE CODE ════════════════
 
     socket.on('generate-server-code', () => {
-      if (!socket.user.isAdmin) {
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_server')) {
         return socket.emit('error-msg', 'Only admins can manage server codes');
       }
       const code = generateChannelCode();
@@ -3503,7 +3504,7 @@ function setupSocketHandlers(io, db) {
     });
 
     socket.on('clear-server-code', () => {
-      if (!socket.user.isAdmin) {
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_server')) {
         return socket.emit('error-msg', 'Only admins can manage server codes');
       }
       db.prepare('INSERT OR REPLACE INTO server_settings (key, value) VALUES (?, ?)').run('server_code', '');
@@ -3514,7 +3515,7 @@ function setupSocketHandlers(io, db) {
     // ═══════════════ ADMIN: RUN CLEANUP NOW ═════════════════
 
     socket.on('run-cleanup-now', () => {
-      if (!socket.user.isAdmin) {
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_server')) {
         return socket.emit('error-msg', 'Only admins can run cleanup');
       }
       // Trigger the global cleanup function exposed on the server
@@ -4817,7 +4818,7 @@ function setupSocketHandlers(io, db) {
     socket.on('get-channel-member-roles', (data, callback) => {
       if (!data || typeof data !== 'object') return;
       const cb = typeof callback === 'function' ? callback : () => {};
-      if (!socket.user.isAdmin) return cb({ error: 'Only admins can view channel roles' });
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_roles')) return cb({ error: 'Only admins can view channel roles' });
 
       const code = typeof data.code === 'string' ? data.code.trim() : '';
       if (!code || !/^[a-f0-9]{8}$/i.test(code)) return cb({ error: 'Invalid channel' });
@@ -4876,7 +4877,7 @@ function setupSocketHandlers(io, db) {
     socket.on('create-role', (data, callback) => {
       if (!data || typeof data !== 'object') return;
       const cb = typeof callback === 'function' ? callback : () => {};
-      if (!socket.user.isAdmin) return cb({ error: 'Only admins can create roles' });
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_roles')) return cb({ error: 'Only admins can create roles' });
 
       const name = isString(data.name, 1, 30) ? data.name.trim() : '';
       if (!name) return cb({ error: 'Role name required (1-30 chars)' });
@@ -4900,7 +4901,8 @@ function setupSocketHandlers(io, db) {
           'delete_lower_messages', 'edit_own_messages', 'pin_message', 'set_channel_topic',
           'manage_sub_channels', 'rename_channel', 'rename_sub_channel',
           'upload_files', 'use_voice', 'manage_webhooks', 'mention_everyone', 'view_history',
-          'promote_user', 'transfer_admin', 'archive_messages', 'create_channel', 'manage_emojis', 'manage_soundboard'
+          'promote_user', 'transfer_admin', 'archive_messages', 'create_channel', 'manage_emojis', 'manage_soundboard',
+          'manage_roles', 'manage_server', 'delete_channel'
         ];
         const insertPerm = db.prepare('INSERT OR IGNORE INTO role_permissions (role_id, permission, allowed) VALUES (?, ?, 1)');
         perms.forEach(p => { if (validPerms.includes(p)) insertPerm.run(result.lastInsertRowid, p); });
@@ -4915,7 +4917,7 @@ function setupSocketHandlers(io, db) {
     socket.on('update-role', (data, callback) => {
       if (!data || typeof data !== 'object') return;
       const cb = typeof callback === 'function' ? callback : () => {};
-      if (!socket.user.isAdmin) return cb({ error: 'Only admins can edit roles' });
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_roles')) return cb({ error: 'Only admins can edit roles' });
 
       const roleId = isInt(data.roleId) ? data.roleId : null;
       if (!roleId) return;
@@ -4957,7 +4959,8 @@ function setupSocketHandlers(io, db) {
             'delete_lower_messages', 'edit_own_messages', 'pin_message', 'set_channel_topic',
             'manage_sub_channels', 'rename_channel', 'rename_sub_channel',
             'upload_files', 'use_voice', 'manage_webhooks', 'mention_everyone', 'view_history',
-            'promote_user', 'transfer_admin', 'archive_messages', 'create_channel', 'manage_emojis', 'manage_soundboard'
+            'promote_user', 'transfer_admin', 'archive_messages', 'create_channel', 'manage_emojis', 'manage_soundboard',
+            'manage_roles', 'manage_server', 'delete_channel'
           ];
           db.prepare('DELETE FROM role_permissions WHERE role_id = ?').run(roleId);
           const insertPerm = db.prepare('INSERT INTO role_permissions (role_id, permission, allowed) VALUES (?, ?, 1)');
@@ -4984,7 +4987,7 @@ function setupSocketHandlers(io, db) {
     socket.on('delete-role', (data, callback) => {
       if (!data || typeof data !== 'object') return;
       const cb = typeof callback === 'function' ? callback : () => {};
-      if (!socket.user.isAdmin) return cb({ error: 'Only admins can delete roles' });
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_roles')) return cb({ error: 'Only admins can delete roles' });
 
       const roleId = isInt(data.roleId) ? data.roleId : null;
       if (!roleId) return;
@@ -5004,7 +5007,7 @@ function setupSocketHandlers(io, db) {
     socket.on('get-role-assignment-data', (data, callback) => {
       if (!data || typeof data !== 'object') return;
       const cb = typeof callback === 'function' ? callback : () => {};
-      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'promote_user')) {
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'promote_user') && !userHasPermission(socket.user.id, 'manage_roles')) {
         return cb({ error: 'You lack permission to manage roles' });
       }
 
@@ -5307,7 +5310,7 @@ function setupSocketHandlers(io, db) {
     socket.on('get-role-channel-access', (data, callback) => {
       if (!data || typeof data !== 'object') return;
       const cb = typeof callback === 'function' ? callback : () => {};
-      if (!socket.user.isAdmin) return cb({ error: 'Only admins can view role channel access' });
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_roles')) return cb({ error: 'Only admins can view role channel access' });
 
       const roleId = isInt(data.roleId) ? data.roleId : null;
       if (!roleId) return cb({ error: 'Invalid role ID' });
@@ -5321,7 +5324,7 @@ function setupSocketHandlers(io, db) {
     socket.on('update-role-channel-access', (data, callback) => {
       if (!data || typeof data !== 'object') return;
       const cb = typeof callback === 'function' ? callback : () => {};
-      if (!socket.user.isAdmin) return cb({ error: 'Only admins can edit role channel access' });
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_roles')) return cb({ error: 'Only admins can edit role channel access' });
 
       const roleId = isInt(data.roleId) ? data.roleId : null;
       if (!roleId) return cb({ error: 'Invalid role ID' });
@@ -5356,7 +5359,7 @@ function setupSocketHandlers(io, db) {
     socket.on('reapply-role-access', (data, callback) => {
       if (!data || typeof data !== 'object') return;
       const cb = typeof callback === 'function' ? callback : () => {};
-      if (!socket.user.isAdmin) return cb({ error: 'Only admins can reapply access' });
+      if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_roles')) return cb({ error: 'Only admins can reapply access' });
 
       const roleId = isInt(data.roleId) ? data.roleId : null;
       if (!roleId) return cb({ error: 'Invalid role ID' });


### PR DESCRIPTION
My server operates with multiple users who will functionally administrate, so we desired a little more permission management. I broke it down into 3 permission groups:

1. Manage roles
-  Allows users to edit existing roles, and grant roles to other users that they have channel access to. Admin is still monolithic for granting server-wide permissions
2. Manage server
- Allows users to edit branding, whitelist, persistent invite, cleanup, upload limit, and tunneling.
3. Delete channel
- Allows users to delete channels.

There's a lot of eggs in the manage server basket, so we could target breaking that down into subsections as well.