### PR TITLE
fix: Glitch effect overwrites server name after scramble animation

### DIFF
--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -615,7 +615,23 @@ _applyServerBranding() {
 
   // Sidebar brand text
   const brandText = document.querySelector('.brand-text');
-  if (brandText) brandText.textContent = name;
+  if (brandText) {
+    brandText.textContent = name;
+    // Keep glitch scramble system in sync. The scrambler captures each element's
+    // original text in a data-original-text attribute and restores it at the end of
+    // every animation. If the cache is stale (e.g. "HAVEN" from the HTML default) it
+    // will overwrite the real server name on every tick.
+    // We also abort any in-progress animation: the animation closure captures
+    // trueOriginal as a const at start time, so updating the attribute alone won't
+    // prevent that specific closure from writing the stale name when it finishes.
+    brandText.dataset.originalText = name;
+    if (brandText._scrambleInterval) {
+      clearInterval(brandText._scrambleInterval);
+      brandText._scrambleInterval = null;
+    }
+    brandText._scrambling = false;
+    brandText.classList.remove('scrambling');
+  }
 
   // Sidebar brand icon
   const logoSm = document.querySelector('.logo-sm');


### PR DESCRIPTION
## Problem

When the **Cyberpunk / Glitch** Effect Overlay is enabled, the server name displayed in the sidebar brand area resets back to `HAVEN` after every scramble animation cycle — even when the admin has set a custom server name.

## Root cause

The text scramble system (`_scrambleElement` in `theme.js`) works in two parts:

1. It caches each element's original text in `data-original-text` on first contact.
2. At the **end of every animation**, it restores `el.textContent = trueOriginal`, where `trueOriginal` is a `const` **captured at the start of that animation closure**.

The `.brand-text` element is hard-coded as `HAVEN` in `app.html`. The typical race condition on page load:

1. Page loads → `.brand-text` = `"HAVEN"`
2. Glitch effect restores from localStorage → first animation fires → `trueOriginal` is captured as `"HAVEN"` inside the closure
3. Server settings arrive asynchronously → `_applyServerBranding()` sets `textContent = "YourServerName"` — but never touches `dataset.originalText` or the running animation
4. The animation completes and executes `el.textContent = trueOriginal` = `"HAVEN"` — silently overwriting the real server name
5. Repeat on every tick

A naive fix that only updates `dataset.originalText` while guarding with `if (!brandText._scrambling)` doesn't solve it either: `trueOriginal` is already captured as a `const` inside the running closure, so updating the attribute mid-animation has no effect — the closure will still write `"HAVEN"` when it finishes.

## Fix

In `_applyServerBranding()` (`app-admin.js`), three things must happen atomically whenever the server name changes:

1. Update `textContent` to the real name (already done)
2. Update `dataset.originalText` so future animations use the correct restore value
3. **Abort the in-progress animation** — clear its interval and reset `_scrambling` so the stale `trueOriginal` closure never gets to execute its final restore

```js
brandText.dataset.originalText = name;
if (brandText._scrambleInterval) {
  clearInterval(brandText._scrambleInterval);
  brandText._scrambleInterval = null;
}
brandText._scrambling = false;
brandText.classList.remove('scrambling');
```

## Files changed

- `public/js/modules/app-admin.js` — `_applyServerBranding()`


Fix #5224
