### PR TITLE
fix: auto-disconnect voice when channel is deleted

### DIFF
--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -587,7 +587,12 @@ _setupSocketListeners() {
   this.socket.on('channel-deleted', (data) => {
     this.channels = this.channels.filter(c => c.code !== data.code);
     this._renderChannels();
+    // Disconnect from voice if the user is in the deleted channel's voice
+    if (this.voice && this.voice.inVoice && this.voice.currentChannel === data.code) {
+      this._leaveVoice();
+    }
     if (this.currentChannel === data.code) {
+      this._renderVoiceUsers([]);
       this.currentChannel = null;
       this._showWelcome();
       this._showToast(t('toasts.channel_deleted'), 'error');

--- a/src/socketHandlers.js
+++ b/src/socketHandlers.js
@@ -886,7 +886,7 @@ function setupSocketHandlers(io, db) {
         db.prepare('DELETE FROM messages WHERE channel_id = ?').run(ch.id);
         db.prepare('DELETE FROM channel_members WHERE channel_id = ?').run(ch.id);
         db.prepare('DELETE FROM channels WHERE id = ?').run(ch.id);
-        io.to(`channel:${ch.code}`).emit('channel-deleted', { code: ch.code, reason: 'expired' });
+        io.to(`channel:${ch.code}`).to(`voice:${ch.code}`).emit('channel-deleted', { code: ch.code, reason: 'expired' });
         channelUsers.delete(ch.code);
         voiceUsers.delete(ch.code);
         activeMusic.delete(ch.code);
@@ -3420,7 +3420,7 @@ function setupSocketHandlers(io, db) {
       });
       deleteAll(channel.id);
 
-      io.to(`channel:${code}`).emit('channel-deleted', { code });
+      io.to(`channel:${code}`).to(`voice:${code}`).emit('channel-deleted', { code });
 
       channelUsers.delete(code);
       voiceUsers.delete(code);


### PR DESCRIPTION

When a temporary (or any) channel is deleted, users inside its voice
channel were left in a ghost voice state — the WebRTC session stayed
alive, the voice bar remained visible, and the right sidebar still
listed participants.

Root cause: the `channel-deleted` event was only broadcast to the
`channel:{code}` socket.io room. Voice participants who had navigated
away from the text channel (which leaves that room) never received it.

Fix:
- Server: emit to both `channel:{code}` AND `voice:{code}` so all
  voice participants receive the event regardless of which text channel
  they're currently viewing. Applies to both the delete-channel handler
  and the temporary-channel expiry loop.
- Client: on `channel-deleted`, call _leaveVoice() if the user's active
  voice channel matches the deleted one, and _renderVoiceUsers([]) to
  reset the right-sidebar voice panel.

Fixes #5223
