### PR TITLE
fix: disable CSP upgrade-insecure-requests when FORCE_HTTP=true

### DIFF
--- a/server.js
+++ b/server.js
@@ -114,6 +114,7 @@ app.use(helmet({
       baseUri: ["'self'"],
       formAction: ["'self'"],
       frameAncestors: ["'self'"],               // allow mobile app iframe, block third-party clickjacking
+      ...(process.env.FORCE_HTTP?.toLowerCase() === 'true' ? { upgradeInsecureRequests: null } : {}), // helmet 8.x auto-appends upgrade-insecure-requests; disable when FORCE_HTTP=true
     }
   },
   crossOriginEmbedderPolicy: false,  // needed for WebRTC


### PR DESCRIPTION
## Problem

When a Haven server runs with `FORCE_HTTP=true` (plain HTTP, no TLS), the Content-Security-Policy header includes `upgrade-insecure-requests`. This directive tells browsers and Electron clients to upgrade all `http://` subresource requests (CSS, JS, fonts, WebSocket) to `https://`.

Since the server has no TLS, those upgraded requests fail silently, resulting in a **broken UI** — the HTML loads but no stylesheets, JavaScript, or fonts load. This is the root cause of [issue #1](https://github.com/ancsemi/Haven-Desktop/issues/1) (blank/broken rendering in the desktop app) and affects any browser connecting to a plain-HTTP Haven server.

## Root Cause

Helmet 8.x automatically appends `upgrade-insecure-requests` to every CSP response, even when custom directives are provided via `contentSecurityPolicy.directives`. The server already correctly disables HSTS when `FORCE_HTTP=true` (line 121), but the CSP directive was missed.

## Fix

Spread `{ upgradeInsecureRequests: null }` into the CSP directives when `FORCE_HTTP=true`. Setting a directive to `null` tells Helmet to omit it entirely.

```js
...(process.env.FORCE_HTTP?.toLowerCase() === "true"
  ? { upgradeInsecureRequests: null }
  : {}),
```

## Verification

**Before fix** (FORCE_HTTP=true):
```
Content-Security-Policy: ...;upgrade-insecure-requests
```
→ Browser upgrades all http:// to https:// → CSS/JS/fonts fail → broken UI

**After fix** (FORCE_HTTP=true):
```
Content-Security-Policy: ...;base-uri "self";form-action "self";frame-ancestors "self"
```
→ No `upgrade-insecure-requests` → resources load over http:// normally

**HTTPS servers** (FORCE_HTTP not set or false): unchanged — `upgrade-insecure-requests` is still appended by Helmet, which is correct behavior for HTTPS.

## Testing

```bash
# Start server with FORCE_HTTP=true
FORCE_HTTP=true node server.js

# Check CSP header
curl -sI http://localhost:3000/ | grep "Content-Security-Policy"
# Should NOT contain "upgrade-insecure-requests"
```

One-line change, no dependencies affected, backwards compatible.