### PR TITLE
fix(#5307): route channel/role/user/account delete through themed confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **#5307: Delete confirmations were inconsistent — channel delete used the browser's native double-`confirm()` "web info box" while role / DM / message deletes used the themed modal.** All user-data delete actions (channel, role, user, account) now route through the themed `_showConfirmModal`. The two chained channel-delete prompts are merged into one modal that surfaces both the warning copy and the "absolutely sure?" finality copy at once. The themed modal also picks a smarter default button label — when `danger: true` and the caller doesn't pass a `confirmLabel`, the OK button now reads "Delete" instead of "Confirm".
+
+---
+
 ## [3.10.11] — 2026-04-28
 
 ### Fixed

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -3114,8 +3114,13 @@ _renderRoleDetail() {
     });
   });
 
-  document.getElementById('delete-role-btn').addEventListener('click', () => {
-    if (!confirm(t('settings.admin.roles_delete_confirm', { name: role.name }))) return;
+  document.getElementById('delete-role-btn').addEventListener('click', async () => {
+    const ok = await this._showConfirmModal(
+      t('settings.admin.roles_delete_confirm', { name: role.name }),
+      '',
+      { danger: true }
+    );
+    if (!ok) return;
     this.socket.emit('delete-role', { roleId: role.id }, (res) => {
       if (res.error) { this._showToast(res.error, 'error'); return; }
       this._showToast(t('settings.admin.roles_deleted'), 'success');
@@ -3462,8 +3467,13 @@ _renderChannelRolesRoleDetail() {
     });
   });
 
-  document.getElementById('cr-delete-role-btn').addEventListener('click', () => {
-    if (!confirm(t('settings.admin.roles_delete_confirm', { name: role.name }))) return;
+  document.getElementById('cr-delete-role-btn').addEventListener('click', async () => {
+    const ok = await this._showConfirmModal(
+      t('settings.admin.roles_delete_confirm', { name: role.name }),
+      '',
+      { danger: true }
+    );
+    if (!ok) return;
     this.socket.emit('delete-role', { roleId: role.id }, (res) => {
       if (res.error) { this._showToast(res.error, 'error'); return; }
       this._showToast(t('settings.admin.roles_deleted'), 'success');

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -250,13 +250,17 @@ _setupUI() {
   // ── Channel context menu ("..." on hover) ──────────
   this._initChannelContextMenu();
   this._initDmContextMenu();
-  // Delete channel with TWO confirmations (from ctx menu)
-  document.querySelector('[data-action="delete"]')?.addEventListener('click', () => {
+  // Delete channel — themed confirm (issue #5307: was using two chained native confirm() calls)
+  document.querySelector('[data-action="delete"]')?.addEventListener('click', async () => {
     const code = this._ctxMenuChannel;
     if (!code) return;
     this._closeChannelCtxMenu();
-    if (!confirm('⚠️ ' + t('confirm.delete_channel'))) return;
-    if (!confirm('⚠️ ' + t('confirm.delete_channel_sure'))) return;
+    const ok = await this._showConfirmModal(
+      '⚠️ ' + t('confirm.delete_channel'),
+      t('confirm.delete_channel_sure'),
+      { danger: true }
+    );
+    if (!ok) return;
     this.socket.emit('delete-channel', { code });
   });
   // Mark channel as read
@@ -2422,9 +2426,9 @@ _setupUI() {
     if (e.target === e.currentTarget) e.currentTarget.style.display = 'none';
   });
 
-  document.getElementById('confirm-admin-action-btn').addEventListener('click', () => {
+  document.getElementById('confirm-admin-action-btn').addEventListener('click', async () => {
     if (!this.adminActionTarget) return;
-    const { action, userId } = this.adminActionTarget;
+    const { action, userId, username } = this.adminActionTarget;
     const reason = document.getElementById('admin-action-reason').value.trim();
     const duration = parseInt(document.getElementById('admin-action-duration').value) || 10;
     const scrubMessages = document.getElementById('admin-scrub-checkbox').checked;
@@ -2441,7 +2445,8 @@ _setupUI() {
     } else if (action === 'mute') {
       this.socket.emit('mute-user', { userId, reason, duration });
     } else if (action === 'delete-user') {
-      if (!confirm(t('confirm.delete_user', { username: this.adminActionTarget.username }))) return;
+      const ok = await this._showConfirmModal(t('confirm.delete_user', { username }), '', { danger: true });
+      if (!ok) return;
       this.socket.emit('delete-user', { userId, reason, scrubMessages });
     }
 
@@ -2979,13 +2984,14 @@ _setupUI() {
     overlay.querySelector('.self-delete-cancel').addEventListener('click', () => overlay.remove());
     overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
 
-    overlay.querySelector('.self-delete-confirm').addEventListener('click', () => {
+    overlay.querySelector('.self-delete-confirm').addEventListener('click', async () => {
       const pw = document.getElementById('self-delete-pw').value;
       const scrub = document.getElementById('self-delete-scrub').checked;
       const status = overlay.querySelector('.self-delete-status');
 
       if (!pw) { status.textContent = t('settings.delete_account_section.password_required'); return; }
-      if (!confirm(t('confirm.delete_account'))) return;
+      const ok = await this._showConfirmModal(t('confirm.delete_account'), '', { danger: true });
+      if (!ok) return;
 
       status.textContent = t('settings.delete_account_section.deleting');
       overlay.querySelector('.self-delete-confirm').disabled = true;

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -2839,7 +2839,7 @@ _showConfirmModal(title, message, opts = {}) {
         ${message ? `<p class="muted-text" style="margin:0 0 12px;white-space:pre-line">${this._escapeHtml(message)}</p>` : ''}
         <div class="modal-actions" style="margin-top:12px">
           <button class="btn-sm" id="confirm-modal-cancel">${this._escapeHtml(cancelLabel || t('modals.common.cancel'))}</button>
-          <button class="${okClass}" id="confirm-modal-ok">${this._escapeHtml(confirmLabel || t('modals.common.confirm'))}</button>
+          <button class="${okClass}" id="confirm-modal-ok">${this._escapeHtml(confirmLabel || (danger ? (t('messages.delete') || 'Delete') : t('modals.common.confirm')))}</button>
         </div>
       </div>
     `;


### PR DESCRIPTION
Closes #5307

## Summary

#5307 flagged that channel-delete uses the browser's native `confirm()` "web info box" while role / DM / message deletes use the themed modal — and even where the themed modal is in use, the OK button defaults to "Confirm" which reads oddly on a destructive prompt. This PR walks the remaining user-data delete actions onto the same `_showConfirmModal` everything else uses, and gives the modal a smarter default button label.

## What changed

**`public/js/modules/app-ui.js`**
- **Channel delete (ctx menu).** Was calling `confirm()` twice in a row (`confirm.delete_channel` then `confirm.delete_channel_sure`) — that's the "web info box" the issue calls out. Replaced with a single `_showConfirmModal` whose title carries the warning and whose body carries the "absolutely sure" finality copy. Handler now `async`.
- **Admin moderation `delete-user`.** Was calling `confirm()` mid-handler. Now routes through `_showConfirmModal`. Username is destructured up-front so the outer modal cleanup at the bottom of the handler still runs after the inner modal resolves.
- **Self-delete account.** Same migration.

**`public/js/modules/app-admin.js`**
- **Role delete from main role detail view** and **role delete from the create-role / channel-roles modal.** Both replaced with `_showConfirmModal`.

**`public/js/modules/app-utilities.js`**
- **`_showConfirmModal` smart default.** When `danger: true` and no `confirmLabel` is supplied, the OK button now defaults to `t('messages.delete')` (\"Delete\") instead of `t('modals.common.confirm')` (\"Confirm\"). Existing call sites all pass an explicit label, so this is a no-op for them and only improves any future caller that forgets.

No locale string changes — every existing copy key is reused.

## Out of scope

These call sites still use native `confirm()` and can move in a small follow-up — they're not user-data destructive in the same way:

- `app-channels.js:1350` — webhook delete
- `app-media.js:1423` — bot delete
- `app-ui.js:3189` — backup-file delete

Happy to do that here if you'd prefer one PR.

## Test plan

- [x] `node --check` passes on all three edited modules
- [ ] Right-click a channel → Delete → themed modal appears with warning + "absolutely sure" body and a red **Delete** button → confirm → channel deleted
- [ ] Right-click a channel → Delete → cancel → no socket emit
- [ ] Admin moderation modal → choose "delete-user" → themed confirm appears → both confirm and cancel paths leave the outer admin-action modal closed
- [ ] Settings → Delete Account → themed confirm appears with red **Delete** button
- [ ] Admin → Roles → select role → Delete → themed modal with role name in title
- [ ] Channel-roles modal → role row → Delete → same