### PR TITLE
fix(#5311): show unread indicator on collapsed sub-channel tag rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **#5311: Collapsed sub-channel tag rows didn't show an unread indicator.** Categories and parent channels already bubble a count badge when collapsed and a "look inside" dot when expanded, but the per-parent tag groupings (e.g. an `Off-topic` tag inside a `Lounge` parent channel) were missing both. `_updateNestedIndicators` now walks `.sub-tag-label` rows and applies the same rules: count bubble when the tag is collapsed and any sub-channel under it has unreads, dot when the tag is expanded with unreads inside. The tag toggle handler also re-runs the indicator pass so the badge appears/disappears immediately on collapse/expand.
+
+---
+
 ## [3.10.11] — 2026-04-28
 
 ### Fixed

--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -1780,6 +1780,7 @@ _renderChannels() {
             list.querySelectorAll(`.sub-channel-item[data-parent-code="${ch.code}"][data-sub-tag="${CSS.escape(tagName)}"]`).forEach(el => {
               el.style.display = nowCollapsed ? 'none' : '';
             });
+            this._updateNestedIndicators();
           });
           if (isSubCollapsed || catCollapsed) tagLabel.style.display = 'none';
           list.appendChild(tagLabel);
@@ -2437,6 +2438,40 @@ _updateNestedIndicators() {
     const subTotal = subs.reduce((sum, s) => sum + (this.unreadCounts[s.code] || 0), 0);
     setDot(parentEl, subTotal > 0);
   }
+
+  // Tag labels (sub-channel category groups inside a parent channel) — issue #5311.
+  // When the tag row is collapsed, append a count bubble like the one used for
+  // collapsed parent channels. When expanded, fall back to the same dot pattern
+  // as parents/categories so the indication stays consistent.
+  document.querySelectorAll('.sub-tag-label').forEach(tagEl => {
+    const parentCode = tagEl.dataset.parentCode;
+    const tagName = tagEl.dataset.tagName;
+    if (!parentCode || !tagName) return;
+    const parentChannel = this.channels.find(c => c.code === parentCode);
+    if (!parentChannel) return;
+    const subs = subChannelMap[parentChannel.id] || [];
+    const total = subs.reduce((sum, s) => {
+      const subTag = s.category || 'Untagged';
+      if (subTag !== tagName) return sum;
+      return sum + (this.unreadCounts[s.code] || 0);
+    }, 0);
+    const tagKey = `haven_subtag_collapsed_${parentCode}_${tagName}`;
+    const isCollapsed = localStorage.getItem(tagKey) === 'true';
+    let bubble = tagEl.querySelector(':scope > .channel-badge-bubble');
+    if (isCollapsed && total > 0) {
+      if (!bubble) {
+        bubble = document.createElement('span');
+        bubble.className = 'channel-badge channel-badge-bubble';
+        bubble.style.marginLeft = 'auto';
+        tagEl.appendChild(bubble);
+      }
+      bubble.textContent = total > 99 ? '99+' : total;
+      setDot(tagEl, false);
+    } else {
+      if (bubble) bubble.remove();
+      setDot(tagEl, !isCollapsed && total > 0);
+    }
+  });
 },
 
 _updateTabTitle() {


### PR DESCRIPTION
Closes #5311

## Summary

When a sub-channel **tag** group (the small uppercase label that groups sub-channels by their `category` inside a parent channel) is collapsed, no unread indicator appears even if a contained sub-channel has unread messages — so the user sees nothing in the sidebar and has to remember to expand the tag manually. Parent channels and top-level categories already bubble a count badge for this exact case (and a small dot when expanded with nested unreads), so this PR brings tag rows up to parity.

## What changed

**\`public/js/modules/app-channels.js\`**

\`_updateNestedIndicators\` now also walks every \`.sub-tag-label\` row and applies the same rules already used for parents and categories:

- **Tag collapsed + any sub-channel under that tag has unreads** → count bubble (max \"99+\") on the tag row. Reuses the existing \`channel-badge channel-badge-bubble\` classes so it picks up the theme without any CSS additions.
- **Tag expanded + unreads inside** → small accent-color \"look inside\" dot, mirroring the expanded-parent / expanded-category indicator added in 5d4ef37.
- **Otherwise** → both removed.

The tag toggle click handler (\`tagLabel.addEventListener('click', …)\`) also calls \`this._updateNestedIndicators()\` after flipping the collapse state so the indicator swaps over immediately on click, instead of waiting for the next \`channels-list\` snapshot or other unrelated re-render to refresh it.

## What didn't change

- No CSS additions — both \`.channel-badge-bubble\` and \`.channel-badge-nested-dot\` already exist and are themed.
- No locale strings — the dot's existing \`channels.nested_unread\` tooltip is reused on tag rows.
- The pre-existing inline parent-collapsed bubble logic at the render path is left alone — it covers a different state (entire sub-channel section collapsed via the parent's \`▾\`) and \`_updateNestedIndicators\` already runs after channel renders, so there's no double-bubble.

## Test plan

- [x] \`node --check public/js/modules/app-channels.js\` passes
- [ ] Server with a parent channel that has at least 2 sub-channels under different tag categories
- [ ] Send a message in a sub-channel under tag \`A\` → tag \`A\` row gets a small dot when expanded
- [ ] Click tag \`A\` arrow to collapse → dot becomes count bubble (\"1\")
- [ ] Send another message → bubble updates to \"2\"
- [ ] Open the sub-channel via PiP / mark-read → bubble disappears, dot returns when expanded
- [ ] Sanity: existing parent-channel-collapsed bubble + category-collapsed bubble + nested-unread dot all still work as before