### PR TITLE
fix(#5309): render SVG attachments inline (with hardened serving headers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **#5309: SVG files sent in DMs (and elsewhere) showed as a filename row instead of rendering.** `_isImageUrl` and the E2E `e2e-img:` matcher both excluded SVG, so the message renderer fell through to plain-text and the user only saw the URL. Both now accept `.svg` (and `image/svg+xml` for E2E). The static `/uploads` middleware also gives `.svg` proper CORS / CORP headers so cross-origin `<img>` loads work, while keeping `Content-Disposition: attachment` for direct navigation and adding a strict `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox` so the SVG can't reference external resources or run scripts even in a future browser that loosens `<img>` secure-static-mode.
+
+---
+
 ## [3.10.11] — 2026-04-28
 
 ### Fixed

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -95,8 +95,8 @@ _isImageUrl(str) {
   if (!str) return false;
   const trimmed = str.trim();
   if (trimmed.startsWith('e2e-img:')) return true;
-  if (/^\/uploads\/[\w\-]+\.(jpg|jpeg|png|gif|webp)$/i.test(trimmed)) return true;
-  if (/^https?:\/\/.+\.(jpg|jpeg|png|gif|webp)(\?[^"'<>]*)?$/i.test(trimmed)) return true;
+  if (/^\/uploads\/[\w\-]+\.(jpg|jpeg|png|gif|webp|svg)$/i.test(trimmed)) return true;
+  if (/^https?:\/\/.+\.(jpg|jpeg|png|gif|webp|svg)(\?[^"'<>]*)?$/i.test(trimmed)) return true;
   // GIPHY GIF URLs (may not have file extensions)
   if (/^https:\/\/media\d*\.giphy\.com\/.+/i.test(trimmed)) return true;
   return false;
@@ -150,7 +150,7 @@ _isEmojiOnly(str) {
 
 _formatContent(str) {
   // E2E encrypted image: e2e-img:<mime>:<url>
-  const e2eImgMatch = str.match(/^e2e-img:(image\/(?:jpeg|png|gif|webp)):(\/uploads\/[\w\-.]+)$/i);
+  const e2eImgMatch = str.match(/^e2e-img:(image\/(?:jpeg|png|gif|webp|svg\+xml)):(\/uploads\/[\w\-.]+)$/i);
   if (e2eImgMatch) {
     const mime = this._escapeHtml(e2eImgMatch[1]);
     const url = this._escapeHtml(e2eImgMatch[2]);

--- a/server.js
+++ b/server.js
@@ -169,6 +169,18 @@ app.use('/uploads', express.static(UPLOADS_DIR, {
       res.setHeader('Access-Control-Allow-Origin', '*');
       res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
       res.setHeader('Vary', 'Origin');
+    } else if (ext === '.svg') {
+      // SVG (issue #5309): renderable inline via <img> tag (browsers run SVG in
+      // "secure static mode" — no scripts, no XHR), but direct navigation still
+      // gets attachment-disposition so opening the raw URL in a new tab can't
+      // execute the file. CSP doubles up on that — even if a future browser
+      // change allowed any external loads inside <img>-rendered SVG, this
+      // header forbids everything except inline styles (needed for fill/stroke).
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+      res.setHeader('Vary', 'Origin');
+      res.setHeader('Content-Disposition', 'attachment');
+      res.setHeader('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; sandbox");
     } else {
       res.setHeader('Content-Disposition', 'attachment');
     }


### PR DESCRIPTION
Closes #5309

## Summary

Sending an SVG file in a DM showed only the filename / raw URL — never the actual image. The renderer's `_isImageUrl` check and the E2E `e2e-img:` regex both whitelisted only jpeg/png/gif/webp, so SVGs fell through to plain-text.

The fix is in two pieces:

1. **Client renders SVG like any other image** — `_isImageUrl` and the E2E matcher both pick up \`.svg\` / \`image/svg+xml\` now, so DMs and channels render uploaded SVGs through the existing chat-image pipeline.
2. **Server hardens the way SVGs are served** so allowing them inline doesn't expand the existing attack surface.

## What changed

**\`public/js/modules/app-utilities.js\`**
- \`_isImageUrl\`: added \`.svg\` to both the \`/uploads/...\` and \`https?://...\` extension regexes.
- \`_formatContent\` E2E image matcher: added \`image/svg+xml\` to the \`e2e-img:<mime>:<url>\` allowlist so encrypted SVGs in DMs decrypt and render the same as encrypted raster images.

**\`server.js\` (\`/uploads\` static middleware)**
- New explicit branch for \`.svg\`:
  - Sets \`Access-Control-Allow-Origin: *\`, \`Cross-Origin-Resource-Policy: cross-origin\`, \`Vary: Origin\` so cross-origin \`<img>\` loads behave the same as raster images.
  - Keeps \`Content-Disposition: attachment\` — direct navigation to \`/uploads/whatever.svg\` still downloads. That's the original concern (\"prevents HTML/SVG execution in browser\") and \`<img>\` rendering ignores Content-Disposition, so this preserves the original safety while still allowing inline render.
  - Adds \`Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox\`. Browsers already render \`<img>\`-loaded SVG in secure static mode (no scripts, no XHR), but this CSP also blocks the one remaining concern — \`<image href=\"http://attacker/...\">\` tracking pixels and external font/stylesheet loads inside the SVG. \`style-src 'unsafe-inline'\` is needed for normal SVG fill/stroke styling.

## What didn't change

- The image-upload \`fileFilter\` (jpeg/png/gif/webp only) is **not** loosened — SVGs still go through the general \`fileUpload\` route, which is how they were already arriving when this issue was filed.
- No locale strings, no CSS additions.

## Test plan

- [x] \`node --check\` passes on \`server.js\` and \`public/js/modules/app-utilities.js\`
- [ ] Upload an SVG in a normal channel → renders as image, not as filename
- [ ] Upload an SVG in a DM (E2E) → recipient sees rendered SVG, not filename
- [ ] Open \`/uploads/\<svg-file\>.svg\` directly in the browser → still downloads (Content-Disposition: attachment respected)
- [ ] Crafted SVG with \`<script>alert(1)</script>\` → does not execute when rendered inline
- [ ] Crafted SVG with \`<image href=\"https://example.com/track.gif\">\` → external request blocked by CSP