### PR TITLE
fix(#5248): search DMs locally over the decrypted message cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **#5248: Searching inside a DM previously short-circuited with "search is not available in DMs because messages are end-to-end encrypted" — which made the feature look broken even though the messages were sitting decrypted in front of the user.** The server still can't run `LIKE` against ciphertext rows, but the client already has the decrypted DM messages cached in `_lastRenderedMessages` (the same cache used to render them). Search input now detects when the active channel is a DM and routes the query to a new `_searchDmCacheLocally` helper that scans the cached plaintext and renders results in the existing `search-results-panel` UI with a small `DM (local)` tag in the header so the user understands the scope is "messages already loaded — scroll up to load more". Click-to-jump still works via the existing `_jumpToMessage` path. Server-side DM short-circuit is left in place as defense in depth.
+
+---
+
 ## [3.10.11] — 2026-04-28
 
 ### Fixed

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -1306,7 +1306,14 @@ _setupUI() {
     const q = e.target.value.trim();
     if (q.length >= 2 && this.currentChannel) {
       searchTimeout = setTimeout(() => {
-        this.socket.emit('search-messages', { code: this.currentChannel, query: q });
+        // E2E DMs can't be searched on the server — the message column holds
+        // ciphertext. Run the search locally over the decrypted cache (#5248).
+        const ch = (this.channels || []).find(c => c.code === this.currentChannel);
+        if (ch && ch.is_dm) {
+          this._searchDmCacheLocally(q);
+        } else {
+          this.socket.emit('search-messages', { code: this.currentChannel, query: q });
+        }
       }, 400);
     } else {
       document.getElementById('search-results-panel').style.display = 'none';

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -91,6 +91,56 @@ _bumpPinIndicator(delta) {
   this._updatePinIndicator(Math.max(0, cur + (delta | 0)));
 },
 
+// Local-only search over the decrypted DM message cache (#5248). The server
+// can't search E2E DMs because the `content` column on the row is ciphertext;
+// the historical behavior was to short-circuit and tell the user "search is
+// not available in DMs" — which made the search box look broken. This walks
+// `_lastRenderedMessages` (the per-channel decrypted cache populated by
+// `_renderMessages`) and renders the same `search-results-panel` UI, with a
+// small "DM (local)" tag so the user understands the scope is "what's already
+// loaded in this view".
+_searchDmCacheLocally(query) {
+  const msgs = Array.isArray(this._lastRenderedMessages) ? this._lastRenderedMessages : [];
+  const q = query.toLowerCase();
+  const results = msgs
+    .filter(m => typeof m.content === 'string' && m.content.toLowerCase().includes(q))
+    .map(m => ({
+      id: m.id,
+      content: m.content,
+      created_at: m.created_at,
+      username: m.username || m.display_name || '[Unknown]',
+      user_id: m.user_id
+    }))
+    .slice(-50)
+    .reverse();
+  const panel = document.getElementById('search-results-panel');
+  const list = document.getElementById('search-results-list');
+  const count = document.getElementById('search-results-count');
+  if (!panel || !list || !count) return;
+  let header = t(results.length === 1 ? 'header.search_results_one' : 'header.search_results_other', { count: results.length, query: this._escapeHtml(query) });
+  header += ` <span class="search-filter-tag" title="DMs are end-to-end encrypted; this search runs locally over messages already loaded in this view. Scroll up to load more history if you don't see what you're looking for.">DM (local)</span>`;
+  count.innerHTML = header;
+  list.innerHTML = results.length === 0
+    ? `<p class="muted-text" style="padding:12px">${t('header.search_no_results')}</p>`
+    : results.map(r => `
+      <div class="search-result-item" data-msg-id="${r.id}">
+        <span class="search-result-author" style="color:${this._getUserColor(r.username)}">${this._escapeHtml(this._getNickname(r.user_id, r.username))}</span>
+        <span class="search-result-time">${this._formatTime(r.created_at)}</span>
+        <div class="search-result-content">${this._highlightSearch(this._escapeHtml(r.content), query)}</div>
+      </div>
+    `).join('');
+  panel.style.display = 'block';
+  list.querySelectorAll('.search-result-item').forEach(item => {
+    item.addEventListener('click', () => {
+      const msgId = parseInt(item.dataset.msgId, 10);
+      panel.style.display = 'none';
+      document.getElementById('search-container').style.display = 'none';
+      document.getElementById('search-input').value = '';
+      this._jumpToMessage(msgId);
+    });
+  });
+},
+
 _isImageUrl(str) {
   if (!str) return false;
   const trimmed = str.trim();


### PR DESCRIPTION
Closes #5248

## Summary

Searching inside a DM short-circuits with \"search is not available in DMs because messages are end-to-end encrypted\" — which makes the search box look broken to the user even though the messages they want to find are sitting decrypted right in front of them. The server can't `LIKE`-match ciphertext rows (and shouldn't try), but the client already has the decrypted DM messages cached in `_lastRenderedMessages` for rendering. So the search just needs to run there.

## What changed

**\`public/js/modules/app-ui.js\`**
- The 400 ms search-input debounce now branches on the active channel's \`is_dm\` flag. DM channels go to a new \`_searchDmCacheLocally(q)\` helper; everything else still emits \`search-messages\` to the server.

**\`public/js/modules/app-utilities.js\`** — new \`_searchDmCacheLocally(query)\`:
- Walks \`_lastRenderedMessages\`, lowercases content + query, returns up to 50 matches in newest-first order.
- Renders into the existing \`search-results-panel\` markup so result rows look identical to the server-side path: author color, formatted time, \`_highlightSearch\` highlight, click-to-jump via \`_jumpToMessage\`.
- Adds a small \`DM (local)\` chip in the header with a tooltip explaining that scope is \"messages already loaded — scroll up to load more history if you don't see what you're looking for.\"

**\`src/socketHandlers/messages.js\`** — left alone on purpose. The \`is_dm\` short-circuit that emits \`{ results: [], isDM: true }\` stays as defense in depth: a stale client that still calls \`search-messages\` for a DM gets the same friendly empty result it always did.

## What didn't change

- No locale strings — the existing \`search-filter-tag\` class is reused for the \`DM (local)\` chip.
- No new socket events; no server-side changes at all.

## Known scope limit (deliberate, not a regression)

Local search only sees what's already loaded in this view (typically the most recent 50–100 messages — same as what's been rendered). If the user wants to find an old message, they need to scroll up to pull more history first. The chip's tooltip says so. A future PR can add a \"search older history\" affordance that pulls + decrypts more pages on demand.

## Test plan

- [x] \`node --check\` passes on both edited modules
- [ ] Open a DM with messages → type a substring of a known recent message → result row appears with the right author, time, highlight, and click-to-jump
- [ ] Type a substring that isn't in the loaded view → empty results panel, \"DM (local)\" chip still shown
- [ ] Open a non-DM channel → search still goes to the server (unchanged path)
- [ ] In a DM, send a new message containing a unique token, search the token → it appears (because incoming messages are appended to the cache)