### PR TITLE
fix(#5310, #5308): encrypt all DM uploads — non-image filetypes + PiP paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **#5310 + #5308: DM uploads were only encrypted for images going through the explicit "queue → preview → send" path.** Drag-and-drop, the 📎 button, paste in the main composer (for non-image files), and any paste into the DM PiP all routed through `_uploadGeneralFile`, which had no E2E branch — so non-image files in DMs (and any file pasted into the PiP) hit the server filesystem in plaintext, defeating the DM's E2E guarantee. `_uploadGeneralFile` now first calls `_maybeUploadEncryptedDmFile`: if the channel is an E2E DM with a known partner key, the file's bytes go through `e2e.encryptBytes` → opaque blob upload → and the metadata (mime / size / url / name) is wrapped in a new `e2e-file:{json}` marker that's encrypted as a normal text message. `_formatContent` renders that marker as a 🔒 download row, and a new `_decryptE2EFiles` (called next to `_decryptE2EImages` in every render path) wires the click → fetch → `e2e.decryptBytes` → save-as flow. Server-side static `/uploads` handler is unchanged — encrypted blobs are already opaque.
+
+---
+
 ## [3.10.11] — 2026-04-28
 
 ### Fixed

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2070,33 +2070,93 @@ _uploadGeneralFile(file, targetCode) {
     return;
   }
 
-  const formData = new FormData();
-  formData.append('file', file);
+  // E2E DM path (#5310, #5308): if this channel is an E2E DM, encrypt the
+  // file bytes before upload and send the metadata as an encrypted text
+  // message. Without this, drag-drop / 📎 / paste / PiP-paste of any non-image
+  // file (and any image pasted into the PiP) lands plaintext on the server
+  // filesystem, defeating the DM's E2E guarantee.
+  this._maybeUploadEncryptedDmFile(file, code, _ugCh).then(handled => {
+    if (handled) return;
 
-  this._uploadWithProgress('/api/upload-file', formData)
-  .then(data => {
-    if (data.error) {
-      this._showToast(data.error, 'error');
-      return;
+    const formData = new FormData();
+    formData.append('file', file);
+    this._uploadWithProgress('/api/upload-file', formData)
+    .then(data => {
+      if (data.error) {
+        this._showToast(data.error, 'error');
+        return;
+      }
+      // Send as a message with file attachment format
+      const sizeStr = this._formatFileSize(data.fileSize);
+      let content;
+      if (data.isImage) {
+        content = data.url; // images render inline already
+      } else {
+        // Use a special file attachment format: [file:name](url|size)
+        content = `[file:${data.originalName}](${data.url}|${sizeStr})`;
+      }
+      this.socket.emit('send-message', {
+        code,
+        content,
+        replyTo: (code === this.currentChannel && this.replyingTo) ? this.replyingTo.id : null
+      });
+      this.notifications.play('sent');
+      if (code === this.currentChannel) this._clearReply();
+    })
+    .catch(err => this._showToast(err.message || t('settings.admin.upload_failed'), 'error'));
+  });
+},
+
+/**
+ * If `code` is an E2E DM and the partner key is available, encrypt `file`,
+ * upload as an opaque blob, then send the metadata as an encrypted
+ * `e2e-file:{json}` text message. Returns true if handled, false otherwise
+ * (so the caller can fall back to the plaintext upload path). (#5310, #5308)
+ */
+async _maybeUploadEncryptedDmFile(file, code, ch) {
+  if (!ch || !ch.is_dm || !ch.dm_target) return false;
+  let partner = this._getE2EPartnerFor ? this._getE2EPartnerFor(code) : this._getE2EPartner();
+  if (!partner && this.e2e && this.e2e.ready) {
+    const jwk = await this.e2e.requestPartnerKey(this.socket, ch.dm_target.id);
+    if (jwk) {
+      this._dmPublicKeys[ch.dm_target.id] = jwk;
+      partner = this._getE2EPartnerFor ? this._getE2EPartnerFor(code) : this._getE2EPartner();
     }
-    // Send as a message with file attachment format
-    const sizeStr = this._formatFileSize(data.fileSize);
-    let content;
-    if (data.isImage) {
-      content = data.url; // images render inline already
-    } else {
-      // Use a special file attachment format: [file:name](url|size)
-      content = `[file:${data.originalName}](${data.url}|${sizeStr})`;
+  }
+  if (!partner) return false;
+  try {
+    const arrayBuffer = await file.arrayBuffer();
+    const encrypted = await this.e2e.encryptBytes(arrayBuffer, partner.userId, partner.publicKeyJwk);
+    const blob = new Blob([encrypted], { type: 'application/octet-stream' });
+    const formData = new FormData();
+    formData.append('file', blob, 'e2e-file.enc');
+    const data = await this._uploadWithProgress('/api/upload-file', formData);
+    if (!data || !data.url) {
+      this._showToast(t('toasts.encrypted_image_failed') || 'Encrypted upload failed', 'error');
+      return true;
     }
+    const meta = JSON.stringify({
+      mime: file.type || 'application/octet-stream',
+      size: file.size,
+      url: data.url,
+      name: file.name || 'file'
+    });
+    const marker = `e2e-file:${meta}`;
+    const encryptedText = await this.e2e.encrypt(marker, partner.userId, partner.publicKeyJwk);
     this.socket.emit('send-message', {
       code,
-      content,
+      content: encryptedText,
+      encrypted: true,
       replyTo: (code === this.currentChannel && this.replyingTo) ? this.replyingTo.id : null
     });
     this.notifications.play('sent');
     if (code === this.currentChannel) this._clearReply();
-  })
-  .catch(err => this._showToast(err.message || t('settings.admin.upload_failed'), 'error'));
+    return true;
+  } catch (err) {
+    console.warn('[E2E] File encryption failed:', err);
+    this._showToast(t('toasts.encrypted_image_failed') || 'Encrypted upload failed', 'error');
+    return true;
+  }
 },
 
 _formatFileSize(bytes) {

--- a/public/js/modules/app-messages.js
+++ b/public/js/modules/app-messages.js
@@ -290,6 +290,8 @@ _renderMessages(messages, lastReadMessageId) {
   this._setupVideos(container);
   // Decrypt E2E images (async — renders as images load)
   this._decryptE2EImages(container);
+  // Wire up decryption-on-click for E2E file attachments (#5310, #5308)
+  this._decryptE2EFiles(container);
   // Mark as read (last message ID)
   if (messages.length > 0) {
     this._markRead(messages[messages.length - 1].id);
@@ -426,6 +428,7 @@ _prependMessages(messages) {
     this._fetchLinkPreviews(el);
     this._setupVideos(el);
     this._decryptE2EImages(el);
+    this._decryptE2EFiles(el);
   }
 },
 
@@ -479,6 +482,7 @@ _appendMessages(messages) {
   this._fetchLinkPreviews(container);
   this._setupVideos(container);
   this._decryptE2EImages(container);
+  this._decryptE2EFiles(container);
 
   // Mark as read so the server-side read position advances
   if (messages.length > 0) {
@@ -527,6 +531,7 @@ _appendMessage(message, forceScroll = false) {
   this._fetchLinkPreviews(msgEl);
   this._setupVideos(msgEl);
   this._decryptE2EImages(msgEl);
+  this._decryptE2EFiles(msgEl);
   if (wasAtBottom) {
     this._scrollToBottom(true);
   }

--- a/public/js/modules/app-platform.js
+++ b/public/js/modules/app-platform.js
@@ -1104,6 +1104,63 @@ async _decryptMessages(messages, channelCode = null) {
 },
 
 /**
+ * Wire up download buttons on e2e-file-pending attachments inside `root`.
+ * Click → fetch encrypted blob → decrypt with the DM partner key →
+ * trigger a save-as via an object URL. Marks the row `e2e-file-failed` if the
+ * partner key isn't available so the user understands why download is blocked
+ * instead of getting a silent no-op. (#5310, #5308)
+ */
+_decryptE2EFiles(root) {
+  if (!root) root = document.getElementById('messages');
+  if (!root) return;
+  const rows = root.querySelectorAll('.e2e-file-pending');
+  if (!rows.length) return;
+  const inPip = !!(root.id === 'dm-pip-messages' || (root.closest && root.closest('#dm-pip-messages')));
+  const partner = inPip && this._activeDMPip
+    ? this._getE2EPartnerFor(this._activeDMPip)
+    : this._getE2EPartner();
+  rows.forEach(row => {
+    row.classList.remove('e2e-file-pending');
+    const url = row.dataset.e2eUrl;
+    const mime = row.dataset.e2eMime || 'application/octet-stream';
+    const name = row.dataset.e2eName || 'file';
+    const btn = row.querySelector('.e2e-file-download');
+    if (!url || !url.startsWith('/uploads/') || !partner) {
+      row.classList.add('e2e-file-failed');
+      if (btn) btn.disabled = true;
+      return;
+    }
+    if (!btn) return;
+    btn.addEventListener('click', async (e) => {
+      e.preventDefault();
+      if (btn.disabled) return;
+      btn.disabled = true;
+      row.classList.add('e2e-file-loading');
+      try {
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error(resp.status);
+        const buf = await resp.arrayBuffer();
+        const plain = await this.e2e.decryptBytes(new Uint8Array(buf), partner.userId, partner.publicKeyJwk);
+        const blob = new Blob([plain], { type: mime });
+        const objectUrl = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = objectUrl;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+      } catch (err) {
+        row.classList.add('e2e-file-failed');
+      } finally {
+        row.classList.remove('e2e-file-loading');
+        btn.disabled = false;
+      }
+    });
+  });
+},
+
+/**
  * Find all e2e-img-pending images in a DOM element (or the messages container),
  * fetch their encrypted data, decrypt, and display as blob URLs.
  */

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -157,6 +157,31 @@ _formatContent(str) {
     return `<img data-e2e-src="${url}" data-e2e-mime="${mime}" class="chat-image e2e-img-pending" alt="Encrypted image" title="🔒 End-to-end encrypted image">`;
   }
 
+  // E2E encrypted file: e2e-file:{"mime":...,"size":N,"url":"/uploads/...","name":"..."}
+  // (#5310, #5308) — non-image DM uploads, plus paste-into-PiP, are encrypted
+  // before upload and the metadata is wrapped in this marker.
+  if (str.startsWith('e2e-file:')) {
+    try {
+      const meta = JSON.parse(str.slice(9));
+      if (meta && typeof meta.url === 'string' && meta.url.startsWith('/uploads/')) {
+        const name = this._escapeHtml(typeof meta.name === 'string' ? meta.name : 'file');
+        const url = this._escapeHtml(meta.url);
+        const mime = this._escapeHtml(typeof meta.mime === 'string' ? meta.mime : 'application/octet-stream');
+        const size = Number(meta.size) || 0;
+        const sizeStr = this._escapeHtml(this._formatFileSize ? this._formatFileSize(size) : (size + ' B'));
+        return `<div class="file-attachment e2e-file-pending" data-e2e-url="${url}" data-e2e-mime="${mime}" data-e2e-name="${name}" title="🔒 End-to-end encrypted file — click to download">
+          <button type="button" class="file-download-link e2e-file-download">
+            <span class="file-icon">🔒</span>
+            <span class="file-name">${name}</span>
+            <span class="file-size">(${sizeStr})</span>
+            <span class="file-download-arrow">⬇</span>
+          </button>
+        </div>`;
+      }
+    } catch {}
+    return `<span class="muted-text">[Encrypted file — unable to parse]</span>`;
+  }
+
   // Decode legacy HTML entities from old server-side sanitization.
   // The server no longer entity-encodes, but older messages in the DB
   // may still contain entities like &#39; &amp; &lt; etc.


### PR DESCRIPTION
Closes #5310
Closes #5308

## Summary

DM uploads were only being encrypted on the \"queue → preview → send\" path that \`_uploadImage\` runs (image-only). Everything else routed through \`_uploadGeneralFile\`, which had no E2E branch — so:

- **#5310** Drag-and-drop / 📎 button / paste of any **non-image** file in a DM landed plaintext on the server filesystem.
- **#5308** Pasting into the DM PiP also went through \`_uploadGeneralFile\` (regardless of file type), so PiP-pasted images were also plaintext on disk.

This PR closes both with one shared fix because they're literally the same code path.

## What changed

**\`public/js/modules/app-admin.js\`**
- \`_uploadGeneralFile\` now calls a new \`_maybeUploadEncryptedDmFile\` first. When the target channel is an E2E DM and the partner key is available (auto-fetched if missing, mirroring \`_uploadImage\`), the file bytes are encrypted with \`e2e.encryptBytes\`, uploaded as an opaque blob, and the metadata is wrapped in a new \`e2e-file:{\"mime\",\"size\",\"url\",\"name\"}\` text marker that's then encrypted as a normal message via \`e2e.encrypt\`. Falls through to the existing plaintext path for non-DM channels (so regular channels work unchanged).

**\`public/js/modules/app-utilities.js\`**
- \`_formatContent\` detects \`e2e-file:\` markers, JSON-parses the payload (with bounds-check on \`url\`), and renders a 🔒 download row with \`class=\"e2e-file-pending\"\`. Filename / mime / url go onto data-attrs; size is formatted via the existing \`_formatFileSize\`.

**\`public/js/modules/app-platform.js\`**
- New \`_decryptE2EFiles(root)\` is the file counterpart to \`_decryptE2EImages\`. Walks \`.e2e-file-pending\` rows, picks the right DM partner (PiP-scoped via \`_getE2EPartnerFor\` + \`_activeDMPip\`), and wires up click → \`fetch\` → \`e2e.decryptBytes\` → \`Blob\` → invisible \`<a download>\` flow. Object URL is revoked after 60 s. Rows whose partner key isn't available go to \`e2e-file-failed\` with a disabled button instead of silently no-op'ing.

**\`public/js/modules/app-messages.js\`**
- Every render site that already called \`_decryptE2EImages\` now also calls \`_decryptE2EFiles\` (4 sites: \`_renderMessages\`, \`_renderDecryptedMessages\` per-element loop, \`_renderPiPMessages\`, \`_appendIncomingMessage\`).

## What didn't change

- **No server changes.** Encrypted blobs hit the existing \`/api/upload-file\` endpoint which already serves them opaquely from \`/uploads\` via the existing static handler. The server has no idea — and shouldn't — that the file is encrypted vs plaintext.
- **DM-attachment cleanup on delete still works** because the delete path added in 95b219b / ad9ab4d already accepts client-supplied URLs extracted from the decrypted message — \`_getMessageAttachments\` only needs the \`/uploads/...\` substring, which the new marker contains.
- **No locale strings, no CSS additions** — reuses \`.file-attachment\` / \`.file-icon\` / \`.file-name\` / \`.file-size\` / \`.file-download-link\` / \`.file-download-arrow\` / \`.muted-text\`. The new \`.e2e-file-pending\` / \`.e2e-file-loading\` / \`.e2e-file-failed\` classes are state markers; they pick up theme via the existing \`.file-attachment\` rules.

## Test plan

- [x] \`node --check\` passes on all four edited modules
- [ ] In a DM (E2E):
  - [ ] Drag-drop a PDF → row appears with 🔒 + filename → recipient clicks Download → file decrypts and saves → server's \`/uploads/<hash>.enc\` is opaque on disk (verify with \`file\` / hex inspector)
  - [ ] Click 📎 → pick a .zip → same outcome
  - [ ] Paste an image into the DM PiP → 🔒 download row → decrypts and saves correctly
  - [ ] Paste a non-image file (e.g. PDF copied from another tab) into the main composer → same
  - [ ] Cancel-during-decrypt: click Download, navigate away → no crash; navigating back, button re-enables (idempotent click handler)
- [ ] In a non-DM channel:
  - [ ] Drag-drop a PDF → existing \`[file:name](url|size)\` plaintext path still works
  - [ ] Click 📎 → image → existing inline-image path still works
- [ ] Delete an E2E DM message that contains an \`e2e-file:\` marker → server cleans the \`.enc\` blob (already covered by 95b219b's URL-list-from-client logic)