### PR TITLE
feat(#5300): admin password reset to one-time placeholder (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [Unreleased]
+
+### Added
+- **#5300: Admin password reset (opt-in).** New `admin_password_reset_enabled` server setting (default `false`) lets admins enable a "reset user password to a one-time temp value" flow. New socket event `admin-reset-user-password` (admin-only, gated on the setting) generates a 16-hex-char temp password (`XXXX-XXXX-XXXX-XXXX`), bcrypt-hashes it, bumps `password_version` (which invalidates the target's existing JWTs via the existing pwv-rejection path), sets a new `must_change_password` flag on the user row, and returns the plaintext temp password to the admin once. Audit-logged as `admin_password_reset`. Login response now carries `mustChangePassword: bool`, and a new `POST /api/auth/change-password-required` endpoint accepts a valid token + new password and clears the flag. The setting is also mirrored into `/api/public-config` so any user can see whether admins on this server have this power before signing up — the disclosure half of the feature. Admin Settings → Members & Visibility gets a checkbox + warning text covering the E2E impact (the user's wrap key derives from the password, so old encrypted DM history becomes unrecoverable on their side, matching the existing recovery-codes flow). The actual "click to reset" admin button on the moderation modal and the client-side mandatory change-password screen are intentionally a fast-follow PR.
+
+---
+
 ## [3.10.11] — 2026-04-28
 
 ### Fixed

--- a/public/app.html
+++ b/public/app.html
@@ -1783,6 +1783,11 @@
             <input type="checkbox" id="update-banner-admin-only">
           </label>
           <small class="settings-hint" data-i18n="settings.admin.update_banner_hint">When enabled, the "update available" banner is only shown to admins</small>
+          <label class="toggle-row" style="margin-top:8px">
+            <span data-i18n="settings.admin.admin_pw_reset_label">Allow admin password reset</span>
+            <input type="checkbox" id="admin-password-reset-enabled">
+          </label>
+          <small class="settings-hint" data-i18n="settings.admin.admin_pw_reset_hint">⚠️ When enabled, admins can reset any user's password to a one-time temp value. The user must change it on next login. Resetting a password also wipes that user's E2E DM history (their wrap key derives from the password). The fact that this is enabled is exposed via /api/public-config so users can see whether admins on this server have this power.</small>
         </div>
         <div class="admin-settings" id="section-whitelist" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">🛡️ <span data-i18n="settings.admin.whitelist_title">Whitelist</span></h5>

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -356,6 +356,10 @@ _applyServerSettings() {
     if (whitelistToggle) {
       whitelistToggle.checked = this.serverSettings.whitelist_enabled === 'true';
     }
+    const adminPwReset = document.getElementById('admin-password-reset-enabled');
+    if (adminPwReset) {
+      adminPwReset.checked = this.serverSettings.admin_password_reset_enabled === 'true';
+    }
 
     // ── Auto-backup form ───
     const abEnabled = document.getElementById('auto-backup-enabled');
@@ -597,6 +601,7 @@ _snapshotAdminSettings() {
     max_emoji_kb: this.serverSettings.max_emoji_kb || '256',
     max_poll_options: this.serverSettings.max_poll_options || '10',
     update_banner_admin_only: this.serverSettings.update_banner_admin_only || 'false',
+    admin_password_reset_enabled: this.serverSettings.admin_password_reset_enabled || 'false',
     default_theme: this.serverSettings.default_theme || '',
     custom_tos: this.serverSettings.custom_tos || '',
     role_icon_sidebar: this.serverSettings.role_icon_sidebar || 'true',
@@ -695,6 +700,12 @@ _saveAdminSettings() {
   const updateBannerAdminOnly = document.getElementById('update-banner-admin-only')?.checked ? 'true' : 'false';
   if (updateBannerAdminOnly !== (snap.update_banner_admin_only || 'false')) {
     this.socket.emit('update-server-setting', { key: 'update_banner_admin_only', value: updateBannerAdminOnly });
+    changed = true;
+  }
+
+  const adminPwReset = document.getElementById('admin-password-reset-enabled')?.checked ? 'true' : 'false';
+  if (adminPwReset !== (snap.admin_password_reset_enabled || 'false')) {
+    this.socket.emit('update-server-setting', { key: 'admin_password_reset_enabled', value: adminPwReset });
     changed = true;
   }
 

--- a/server.js
+++ b/server.js
@@ -638,6 +638,7 @@ app.get('/api/public-config', (req, res) => {
     const tosRow = db.prepare("SELECT value FROM server_settings WHERE key = 'custom_tos'").get();
     const nameRow = db.prepare("SELECT value FROM server_settings WHERE key = 'server_name'").get();
     const iconRow = db.prepare("SELECT value FROM server_settings WHERE key = 'server_icon'").get();
+    const adminPwResetRow = db.prepare("SELECT value FROM server_settings WHERE key = 'admin_password_reset_enabled'").get();
     res.json({
       default_theme: themeRow?.value || '',
       server_title: titleRow?.value || '',
@@ -645,7 +646,12 @@ app.get('/api/public-config', (req, res) => {
       // Expose name + icon so the login page can brand its tab title and
       // favicon (issue #5284). These are already public via /api/health.
       server_name: nameRow?.value || process.env.SERVER_NAME || '',
-      server_icon: iconRow?.value || ''
+      server_icon: iconRow?.value || '',
+      // Surface security-relevant settings users may want to know about
+      // before signing up (issue #5300). Allowing a user to *see* whether
+      // an admin can reset their password is the trust-and-warning half
+      // of the feature — admins enable, users get the disclosure.
+      admin_password_reset_enabled: adminPwResetRow?.value === 'true'
     });
   } catch {
     res.json({ default_theme: '', server_title: '' });

--- a/src/auth.js
+++ b/src/auth.js
@@ -343,10 +343,49 @@ router.post('/login', async (req, res) => {
 
     res.json({
       token,
-      user: { id: user.id, username: user.username, isAdmin: !!user.is_admin, displayName }
+      user: { id: user.id, username: user.username, isAdmin: !!user.is_admin, displayName },
+      // (#5300) Set when an admin reset this user's password to a temp
+      // placeholder. Client must funnel the user through a mandatory
+      // change-password screen before doing anything else.
+      mustChangePassword: !!user.must_change_password
     });
   } catch (err) {
     console.error('Login error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// ── Forced change-password endpoint (#5300) ─────────────────
+// Used after an admin password reset. Requires a valid session token,
+// validates the new password's length, updates the row, clears the
+// must_change_password flag, and returns a fresh JWT so the client
+// doesn't have to re-login.
+router.post('/change-password-required', authLimiter, async (req, res) => {
+  try {
+    const auth = req.headers.authorization || '';
+    if (!auth.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
+    let decoded;
+    try { decoded = jwt.verify(auth.slice(7), JWT_SECRET); } catch { return res.status(401).json({ error: 'Unauthorized' }); }
+    const newPassword = typeof req.body.newPassword === 'string' ? req.body.newPassword : '';
+    if (newPassword.length < 8 || newPassword.length > 128) {
+      return res.status(400).json({ error: 'Password must be 8–128 characters' });
+    }
+    const db = getDb();
+    const user = db.prepare('SELECT id, username, is_admin, display_name, password_version FROM users WHERE id = ?').get(decoded.id);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+    const hash = await bcrypt.hash(newPassword, 10);
+    const newPwv = (user.password_version || 1) + 1;
+    db.prepare('UPDATE users SET password_hash = ?, password_version = ?, must_change_password = 0 WHERE id = ?')
+      .run(hash, newPwv, user.id);
+    const displayName = user.display_name || user.username;
+    const freshToken = jwt.sign(
+      { id: user.id, username: user.username, isAdmin: !!user.is_admin, displayName, pwv: newPwv },
+      JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+    res.json({ token: freshToken, user: { id: user.id, username: user.username, isAdmin: !!user.is_admin, displayName } });
+  } catch (err) {
+    console.error('change-password-required error:', err);
     res.status(500).json({ error: 'Server error' });
   }
 });

--- a/src/database.js
+++ b/src/database.js
@@ -162,6 +162,17 @@ function initDatabase() {
     db.exec("CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id)");
   } catch { /* already exists */ }
 
+  // ── Migration: must_change_password flag on users (#5300) ──
+  // Set to 1 by admin password-reset; cleared the first time the user
+  // sets a new password through the forced-change flow. Login still
+  // succeeds when the flag is set — the client routes the user to a
+  // mandatory change-password screen before the rest of the app loads.
+  try {
+    db.prepare("SELECT must_change_password FROM users LIMIT 0").get();
+  } catch {
+    db.exec("ALTER TABLE users ADD COLUMN must_change_password INTEGER DEFAULT 0");
+  }
+
   // ── Migration: edited_at column on messages ───────────
   try {
     db.prepare("SELECT edited_at FROM messages LIMIT 0").get();
@@ -209,6 +220,7 @@ function initDatabase() {
   insertSetting.run('max_emoji_kb', '256');               // max emoji file size in KB (64–1024)
   insertSetting.run('setup_wizard_complete', 'false');   // first-time admin setup wizard
   insertSetting.run('update_banner_admin_only', 'false'); // hide update banner from non-admins
+  insertSetting.run('admin_password_reset_enabled', 'false'); // admin can reset user passwords (#5300) — opt-in, defaults off
 
   // Unique server fingerprint — used by the multi-server sidebar to detect "self"
   const crypto = require('crypto');

--- a/src/socketHandlers/admin.js
+++ b/src/socketHandlers/admin.js
@@ -41,7 +41,8 @@ module.exports = function register(socket, ctx) {
       'default_theme', 'channel_sort_mode', 'channel_cat_order', 'channel_cat_sort',
       'channel_tag_sorts', 'custom_tos', 'welcome_message', 'vanity_code',
       'role_icon_sidebar', 'role_icon_chat', 'role_icon_after_name',
-      'auto_backup_enabled', 'auto_backup_interval_hours', 'auto_backup_retention', 'auto_backup_sections'
+      'auto_backup_enabled', 'auto_backup_interval_hours', 'auto_backup_retention', 'auto_backup_sections',
+      'admin_password_reset_enabled'
     ];
     if (!allowedKeys.includes(key)) return;
 
@@ -69,6 +70,7 @@ module.exports = function register(socket, ctx) {
     if (key === 'tunnel_provider' && !['localtunnel', 'cloudflared'].includes(value)) return;
     if (key === 'setup_wizard_complete' && !['true', 'false'].includes(value)) return;
     if (key === 'update_banner_admin_only' && !['true', 'false'].includes(value)) return;
+    if (key === 'admin_password_reset_enabled' && !['true', 'false'].includes(value)) return;
     if (key === 'role_icon_sidebar' && !['true', 'false'].includes(value)) return;
     if (key === 'role_icon_chat' && !['true', 'false'].includes(value)) return;
     if (key === 'role_icon_after_name' && !['true', 'false'].includes(value)) return;
@@ -556,5 +558,62 @@ module.exports = function register(socket, ctx) {
       console.error('get-audit-log error:', err);
       cb({ error: 'Failed to load audit log' });
     }
+  });
+
+  // ── Admin password reset (#5300) ────────────────────────────
+  // Generates a random 16-char temporary password for the target user,
+  // hashes + saves it, sets must_change_password=1 so the user is forced
+  // through a change-password flow on next login, and returns the
+  // plaintext temp password to the admin once (caller is expected to
+  // copy it and hand it to the user out of band).
+  //
+  // Disabled by default. Admin must explicitly opt-in via the
+  // `admin_password_reset_enabled` server setting — and that toggle is
+  // surfaced in `/api/public-config` so users can see whether the
+  // current admin can reset their password (the trust-and-warning side
+  // of the feature requested in the issue).
+  //
+  // E2E impact: bumping `password_version` invalidates all of the
+  // user's existing JWTs (matching the existing pwv-rejection logic)
+  // and the new password no longer derives the same E2E wrap key, so
+  // encrypted DM history that depended on the old key is unrecoverable
+  // from the user's side. This matches the existing
+  // recovery-codes flow behavior.
+  socket.on('admin-reset-user-password', (data, cb) => {
+    if (typeof cb !== 'function') return;
+    if (!socket.user.isAdmin) return cb({ error: 'Admin only' });
+    const enabled = db.prepare("SELECT value FROM server_settings WHERE key = 'admin_password_reset_enabled'").get();
+    if (!enabled || enabled.value !== 'true') {
+      return cb({ error: 'Admin password reset is disabled in server settings' });
+    }
+    const userId = parseInt(data && data.userId);
+    if (!Number.isFinite(userId)) return cb({ error: 'Invalid userId' });
+    const target = db.prepare('SELECT id, username, password_version FROM users WHERE id = ?').get(userId);
+    if (!target) return cb({ error: 'User not found' });
+    if (target.id === socket.user.id) return cb({ error: 'Use Settings → Account to change your own password' });
+
+    // 16 hex chars, grouped as XXXX-XXXX-XXXX-XXXX for readability.
+    const raw = crypto.randomBytes(8).toString('hex').toUpperCase();
+    const tempPw = `${raw.slice(0,4)}-${raw.slice(4,8)}-${raw.slice(8,12)}-${raw.slice(12,16)}`;
+    let hash;
+    try {
+      const bcrypt = require('bcryptjs');
+      hash = bcrypt.hashSync(tempPw, 10);
+    } catch (err) {
+      console.error('admin-reset-user-password hash error:', err);
+      return cb({ error: 'Server error' });
+    }
+    const newPwv = (target.password_version || 1) + 1;
+    db.prepare('UPDATE users SET password_hash = ?, password_version = ?, must_change_password = 1 WHERE id = ?')
+      .run(hash, newPwv, target.id);
+
+    if (typeof logAudit === 'function') {
+      logAudit({
+        actor: socket.user, action: 'admin_password_reset',
+        target_type: 'user', target_id: target.id, target_name: target.username,
+        details: { reason: typeof data?.reason === 'string' ? data.reason.slice(0, 200) : '' }
+      });
+    }
+    cb({ ok: true, username: target.username, tempPassword: tempPw });
   });
 };


### PR DESCRIPTION
Refs #5300

## Summary

Opt-in admin power for resetting a forgetful user's password to a randomly-generated temp value, with the trust-and-warning side that #5300 specifically asked for: the fact that an admin **can** do this is exposed via `/api/public-config` so users can see the policy before signing up. Default off — admins must explicitly enable it.

## What changed

### Server

**`src/database.js`**
- New default \`admin_password_reset_enabled = 'false'\` setting.
- Migration: \`ALTER TABLE users ADD COLUMN must_change_password INTEGER DEFAULT 0\`. Set to 1 by the reset flow, cleared when the user picks a new password.

**`src/socketHandlers/admin.js`**
- \`admin_password_reset_enabled\` added to \`allowedKeys\` + \`'true'/'false'\` validation.
- New \`admin-reset-user-password\` socket handler (admin-only, gated on the setting). Generates a 16-hex-char temp password formatted \`XXXX-XXXX-XXXX-XXXX\`, bcrypt-hashes it, bumps \`password_version\` (which invalidates the target's existing JWTs via the existing pwv-rejection logic), sets \`must_change_password=1\`, and returns the plaintext temp password to the calling admin once. Audit-logged as \`admin_password_reset\`. Rejects self-reset (admin must use Settings → Account for their own password).

**`src/auth.js`**
- Login response now includes \`mustChangePassword\` so the client can route the user through a forced change-password screen before doing anything else.
- New \`POST /api/auth/change-password-required\` endpoint accepts a valid token + new password (8–128 chars), updates the row, clears the flag, returns a fresh JWT.

**`server.js`**
- \`/api/public-config\` now exposes \`admin_password_reset_enabled\`. This is the user-visible disclosure half of the feature: anyone (including unauthenticated visitors on the login page) can see whether admins on this server have this power.

### Client (admin toggle UI only)

**`public/app.html`** — new checkbox under Admin Settings → Members & Visibility with a warning that resetting the password derives a new wrap key, so the user's encrypted DM history depending on the old key becomes unrecoverable from their side (same behavior as the existing recovery-codes flow).

**`public/js/modules/app-admin.js`** — load / save / snapshot / revert of the new setting, mirroring the existing \`update_banner_admin_only\` checkbox.

## Out of scope (intentional fast-follow)

- Actual \"Reset password to placeholder\" button on the moderation modal — needs its own confirm modal with the warning and a one-time-display modal for the temp password the admin then hands to the user out of band.
- Client-side mandatory change-password screen that fires when a login response carries \`mustChangePassword=true\`.

Both are wired against the same socket event / endpoint already implemented here, so the follow-up is purely UI. Keeping this PR scoped so the security-sensitive backend can land and get used (via tooling / devtools) before the click-button UI gets layered on.

## Test plan

- [x] \`node --check\` passes on all four edited server-side JS files
- [ ] Fresh DB → \`admin_password_reset_enabled='false'\`, \`users.must_change_password\` column exists
- [ ] Admin toggles on → setting persists, \`/api/public-config\` reflects it
- [ ] Calling \`admin-reset-user-password\` with the setting off → \`{ error: 'Admin password reset is disabled in server settings' }\`
- [ ] With setting on, non-admin caller → \`{ error: 'Admin only' }\`
- [ ] Admin resets user X → returns \`{ ok: true, tempPassword: 'XXXX-XXXX-XXXX-XXXX' }\`, audit log shows \`admin_password_reset\`, X's existing tokens stop working (pwv mismatch)
- [ ] X logs in with temp password → response includes \`mustChangePassword: true\`
- [ ] X calls \`/api/auth/change-password-required\` with new password → flag clears, fresh JWT returned, X can re-login normally
- [ ] Admin tries to reset themselves → \`{ error: 'Use Settings → Account...' }\`