### PR TITLE
feat(#5255): PTT recorder — lone modifiers, mouse buttons, toggle/hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [Unreleased]
+
+### Added
+- **#5255: PTT recorder accepts lone modifiers, extra mouse buttons, and a toggle/hold mode.** Three asks from the issue, all in the keybind recorder under Settings → Shortcuts (Haven Desktop only). Lone modifiers (just Alt / Ctrl / Shift) now commit on keyup if no other key was pressed in the meantime — useful while gaming so PTT doesn't pull a hand off WASD. A new `mousedown` listener captures buttons 3+ (Mouse4 / Mouse5 thumb buttons); left/middle/right pass through unchanged. The PTT row now has a hold/toggle select that replaces the previously-hardcoded "(toggle)" label, saved via `havenDesktop.shortcuts.setConfig({ pttMode })` (default `hold`). The actual OS-level registration of bare modifiers / mouse buttons and the runtime honoring of `pttMode` are a separate PR in `ancsemi/Haven-Desktop`; older desktop builds get a clear "may need an update" toast when the new binding is rejected by Electron's `globalShortcut`.
+
+---
+
 ## [3.10.11] — 2026-04-28
 
 ### Fixed

--- a/public/app.html
+++ b/public/app.html
@@ -1594,7 +1594,13 @@
             </div>
           </div>
           <div class="shortcut-row" id="shortcut-row-ptt">
-            <span class="shortcut-label"><span data-i18n="settings.desktop_shortcuts_section.ptt">Push-to-Talk</span> <span class="muted-text" style="font-weight:400;font-size:0.85em" data-i18n="settings.desktop_shortcuts_section.ptt_toggle">(toggle)</span></span>
+            <span class="shortcut-label">
+              <span data-i18n="settings.desktop_shortcuts_section.ptt">Push-to-Talk</span>
+              <select id="ptt-mode-select" class="settings-select" style="font-weight:400;font-size:0.85em;margin-left:6px;padding:1px 4px" title="How the PTT key behaves">
+                <option value="hold" data-i18n="settings.desktop_shortcuts_section.ptt_hold">hold</option>
+                <option value="toggle" data-i18n="settings.desktop_shortcuts_section.ptt_toggle_mode">toggle</option>
+              </select>
+            </span>
             <span class="shortcut-key" id="shortcut-key-ptt" data-i18n="settings.desktop_shortcuts_section.not_set">Not set</span>
             <div class="shortcut-btns">
               <button class="btn-xs shortcut-record-btn" data-action="ptt" data-i18n="settings.desktop_shortcuts_section.change_btn">Change</button>
@@ -1602,7 +1608,7 @@
             </div>
           </div>
         </div>
-        <p class="settings-hint" id="shortcut-status" style="margin-top:8px"></p>
+        <p class="settings-hint" id="shortcut-status" style="margin-top:8px" data-i18n="settings.desktop_shortcuts_section.binding_hint">Lone modifiers (Alt / Ctrl / Shift) and extra mouse buttons (Mouse4 / Mouse5) can be bound here. Some bindings require a recent Haven Desktop build to register at the OS level.</p>
       </div>
 
       <!-- Desktop App Settings Section (only shown in Haven Desktop) -->

--- a/public/js/modules/app-platform.js
+++ b/public/js/modules/app-platform.js
@@ -350,38 +350,85 @@ async _setupDesktopShortcuts() {
       // doesn't swallow the keystroke before the BrowserView sees it
       window.havenDesktop.shortcuts.setConfig({ [action]: '' }).catch(() => {});
 
-      const onKeyDown = async (e) => {
+      // (#5255) Three things the previous recorder couldn't do:
+      // 1. Lone modifiers (just Alt / Ctrl / Shift) — useful while gaming so
+      //    you can transmit without lifting a hand off WASD.
+      // 2. Extra mouse buttons (Mouse4 / Mouse5) for thumb-button push-to-talk.
+      // 3. The PTT mode (toggle vs hold) lives on a sibling control wired up
+      //    elsewhere; the recorder itself just captures the keystroke / button.
+      //
+      // Bare-modifier capture works by deferring commit to keyup: keydown for
+      // a modifier alone arms a "pending lone modifier" that will commit if
+      // the user releases without ever pressing a non-modifier. Pressing a
+      // non-modifier in the meantime falls through to the original combo path
+      // and clears the pending state.
+      const MOD_KEYS = new Set(['Control', 'Meta', 'Alt', 'Shift']);
+      let pendingLoneMod = null;
+
+      const finish = async (accel) => {
+        document.removeEventListener('keydown', onKeyDown, true);
+        document.removeEventListener('keyup', onKeyUp, true);
+        document.removeEventListener('mousedown', onMouseDown, true);
+        recordBtn.classList.remove('recording');
+        recordBtn.textContent = 'Record';
+        keyEl.classList.remove('recording-label');
+        try {
+          await window.havenDesktop.shortcuts.setConfig({ [action]: accel });
+          config[action] = accel;
+          keyEl.textContent = formatAccel(accel);
+        } catch (err) {
+          await window.havenDesktop.shortcuts.setConfig({ [action]: config[action] || '' }).catch(() => {});
+          keyEl.textContent = formatAccel(config[action] || '');
+          this._showToast?.('Failed to register shortcut — it may already be in use, or the desktop app version doesn\'t support this binding type yet.', 'error');
+        }
+      };
+
+      const onKeyDown = (e) => {
         e.preventDefault();
         e.stopPropagation();
-        // Ignore lone modifiers
-        if (['Control', 'Meta', 'Alt', 'Shift'].includes(e.key)) return;
-
+        if (MOD_KEYS.has(e.key)) {
+          // Don't commit yet — wait for keyup to decide if this is a lone-mod
+          // press or the modifier half of a combo.
+          pendingLoneMod = e.key;
+          keyEl.textContent = `${e.key}…`;
+          return;
+        }
+        // Non-modifier pressed — kill the pending lone-mod and commit a combo.
+        pendingLoneMod = null;
         const parts = [];
         if (e.ctrlKey || e.metaKey) parts.push('CommandOrControl');
         if (e.altKey)  parts.push('Alt');
         if (e.shiftKey) parts.push('Shift');
         const mapped = keyMap[e.key] || (e.key.length === 1 ? e.key.toUpperCase() : e.key);
         parts.push(mapped);
-        const accel = parts.join('+');
+        finish(parts.join('+'));
+      };
 
-        document.removeEventListener('keydown', onKeyDown, true);
-        recordBtn.classList.remove('recording');
-        recordBtn.textContent = 'Record';
-        keyEl.classList.remove('recording-label');
+      const onKeyUp = (e) => {
+        // Only commit a lone modifier if the user released the SAME modifier
+        // they pressed and never pressed anything else in between.
+        if (!MOD_KEYS.has(e.key)) return;
+        if (pendingLoneMod !== e.key) return;
+        pendingLoneMod = null;
+        // Map "Control"/"Meta" → "CommandOrControl" to match Electron's
+        // accelerator format. "Alt" / "Shift" pass through.
+        const mapped = (e.key === 'Control' || e.key === 'Meta') ? 'CommandOrControl' : e.key;
+        finish(mapped);
+      };
 
-        try {
-          await window.havenDesktop.shortcuts.setConfig({ [action]: accel });
-          config[action] = accel;
-          keyEl.textContent = formatAccel(accel);
-        } catch (err) {
-          // Restore previous shortcut
-          await window.havenDesktop.shortcuts.setConfig({ [action]: config[action] || '' }).catch(() => {});
-          keyEl.textContent = formatAccel(config[action] || '');
-          this._showToast?.('Failed to register shortcut — it may already be in use.', 'error');
-        }
+      const onMouseDown = (e) => {
+        // 0/1/2 are left/middle/right — leave those alone so the user can still
+        // click around. 3+ are the extra mouse buttons (mouse4 / mouse5).
+        if (e.button < 3) return;
+        e.preventDefault();
+        e.stopPropagation();
+        pendingLoneMod = null;
+        finish(`Mouse${e.button + 1}`);
       };
 
       document.addEventListener('keydown', onKeyDown, true);
+      document.addEventListener('keyup', onKeyUp, true);
+      document.addEventListener('mousedown', onMouseDown, true);
     });
 
     clearBtn.addEventListener('click', async () => {
@@ -392,6 +439,22 @@ async _setupDesktopShortcuts() {
       } catch (err) {}
     });
   });
+
+  // (#5255) PTT mode select — toggle vs hold-to-transmit. Stored on the same
+  // shortcuts config object alongside the keybinds. Default to "hold" since
+  // that's what most voice apps use and what the issue reporter wanted.
+  const pttModeSel = document.getElementById('ptt-mode-select');
+  if (pttModeSel) {
+    pttModeSel.value = (config.pttMode === 'toggle') ? 'toggle' : 'hold';
+    pttModeSel.addEventListener('change', async () => {
+      try {
+        await window.havenDesktop.shortcuts.setConfig({ pttMode: pttModeSel.value });
+        config.pttMode = pttModeSel.value;
+      } catch (err) {
+        this._showToast?.('Failed to save PTT mode — desktop app may need an update.', 'error');
+      }
+    });
+  }
 },
 
 /* ── Desktop App Preferences (start on login, tray, SDR) ── */


### PR DESCRIPTION
Refs #5255

## Summary

Three asks from the issue, all in the keybind recorder used by Settings → Desktop Shortcuts (Haven Desktop only):

1. **Lone modifiers** (just Alt / Ctrl / Shift) — useful while gaming so PTT doesn't pull a hand off WASD.
2. **Extra mouse buttons** (Mouse4 / Mouse5 thumb buttons).
3. **PTT toggle vs hold mode** — replaces the previously-hardcoded \"(toggle)\" label that didn't match what the desktop app actually does.

This PR is the **client side**: capture + UI + persistence to the existing shortcuts config. The actual OS-level registration that has to honor lone modifiers and mouse buttons (and read \`pttMode\` to switch behavior) lives in \`ancsemi/Haven-Desktop\` and is a follow-up PR — Electron's stock \`globalShortcut\` doesn't accept either, so the desktop app needs to switch to a more capable hook (e.g. `uiohook-napi`).

## What changed

**\`public/js/modules/app-platform.js\`** — \`_setupDesktopShortcuts\`:

- **Bare-modifier capture.** The previous handler hard-rejected lone modifiers with `if (['Control','Meta','Alt','Shift'].includes(e.key)) return`. Replaced with a deferred-commit pattern: pressing a modifier alone arms `pendingLoneMod`, and releasing it without ever pressing anything else commits as a bare-modifier accelerator on keyup. Pressing a non-modifier in the meantime falls through to the original combo path and clears the pending state. \`Control\` / \`Meta\` map to Electron's \`CommandOrControl\` string; \`Alt\` and \`Shift\` pass through.
- **Mouse buttons.** New \`mousedown\` listener active during recording. Buttons 0/1/2 (left / middle / right) are intentionally left alone so the user can still click around the page. Buttons 3+ commit immediately as \`Mouse<N>\` (so Mouse4, Mouse5, etc.).
- **Failure UX.** When `setConfig` rejects the binding (older desktop build that doesn't understand `Alt` alone or `Mouse4`), the toast explicitly says the desktop app may need an update — instead of a generic \"in use\" message that misled users.
- **PTT mode select.** New `<select id=\"ptt-mode-select\">` is wired to a new `pttMode` key on the shortcuts config. Default `'hold'`. Persisted via the same `shortcuts.setConfig` IPC.

**\`public/app.html\`**

- The PTT row's hardcoded \"(toggle)\" label is replaced with a `<select>` (hold / toggle).
- Settings hint under the table now mentions that lone-modifier and extra-mouse-button bindings need a recent Haven Desktop build to register.

## What didn't change

- No server-side changes — this is all renderer / IPC.
- No locale strings beyond two new keys (`ptt_hold`, `ptt_toggle_mode`, `binding_hint`); the inline English defaults render until the locale files are updated.
- No CSS additions — reuses `.shortcut-key`, `.shortcut-row`, `.settings-select`, `.muted-text`.

## Test plan

- [x] `node --check` passes on `app-platform.js`
- [ ] In Haven Desktop: Settings → Shortcuts → PTT → Change → press Alt alone, release → \"Alt\" appears in the row (and `setConfig({ ptt: 'Alt' })` is called)
- [ ] Same flow with Ctrl+Shift+P → captures combo as before
- [ ] Same flow with thumb mouse button → \"Mouse4\" / \"Mouse5\" appears
- [ ] Left-click during recording → no commit; the click reaches the page as normal
- [ ] PTT mode select: change to \"toggle\" → `setConfig({ pttMode: 'toggle' })` fires; reload settings → select shows \"toggle\"
- [ ] On an older Haven Desktop build that rejects `Alt` alone → toast \"…desktop app version doesn't support this binding type yet\"
- [ ] In a regular browser (not Electron): the section is already display:none — no regressions