### PR TITLE
feat(#5280): burn-after-read DMs (Signal-style click-to-reveal)

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -498,6 +498,8 @@
                   <line x1="2"  y1="20" x2="22" y2="20"/>
                 </svg>
               </button>
+              <span class="input-actions-divider" id="burn-divider" style="display:none"></span>
+              <button id="burn-btn" class="btn-burn" data-i18n-title="app.input_bar.burn_btn" title="Burn after read (DM only)" style="display:none">🔥</button>
             </div>
             <div id="emoji-picker" class="emoji-picker" style="display:none"></div>
             <div id="gif-picker" class="gif-picker" style="display:none">

--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -26,6 +26,18 @@ async switchChannel(code) {
   // Clear scramble cache so the effect picks up the new channel name
   const headerEl = document.getElementById('channel-header-name');
   if (headerEl) { delete headerEl.dataset.originalText; headerEl._scrambling = false; }
+  // (#5280) Burn-after-read 🔥 button is DM-only — toggle visibility on
+  // every channel switch and reset the per-message arming so a stale
+  // toggle from another DM doesn't accidentally arm the next message
+  // here in a non-DM channel.
+  const _burnBtn = document.getElementById('burn-btn');
+  const _burnDiv = document.getElementById('burn-divider');
+  if (_burnBtn) {
+    _burnBtn.style.display = isDm ? 'inline-flex' : 'none';
+    _burnBtn.classList.remove('active');
+  }
+  if (_burnDiv) _burnDiv.style.display = isDm ? 'inline-block' : 'none';
+  this._burnArmed = false;
   const displayCode = channel ? (channel.display_code || code) : code;
   const isMaskedCode = (displayCode === '••••••••');
   document.getElementById('channel-code-display').textContent = isDm ? '' : displayCode;

--- a/public/js/modules/app-messages.js
+++ b/public/js/modules/app-messages.js
@@ -93,6 +93,17 @@ async _sendMessage() {
   if (this.replyingTo) {
     payload.replyTo = this.replyingTo.id;
   }
+  // (#5280) Burn-after-read arming — DM-only; cleared in switchChannel
+  // when the user moves to a non-DM channel so a stale flag can't leak.
+  if (this._burnArmed) {
+    payload.burnSeconds = 30;
+    this._burnArmed = false;
+    const _burnBtn = document.getElementById('burn-btn');
+    if (_burnBtn) {
+      _burnBtn.classList.remove('active');
+      _burnBtn.title = 'Burn after read (DM only)';
+    }
+  }
 
   // Clear UI immediately (before any async E2E work)
   input.value = '';
@@ -290,6 +301,8 @@ _renderMessages(messages, lastReadMessageId) {
   this._setupVideos(container);
   // Decrypt E2E images (async — renders as images load)
   this._decryptE2EImages(container);
+  // Wire burn-after-read placeholders + countdowns (#5280)
+  this._wireBurnMessages?.(container);
   // Mark as read (last message ID)
   if (messages.length > 0) {
     this._markRead(messages[messages.length - 1].id);
@@ -527,6 +540,7 @@ _appendMessage(message, forceScroll = false) {
   this._fetchLinkPreviews(msgEl);
   this._setupVideos(msgEl);
   this._decryptE2EImages(msgEl);
+  this._wireBurnMessages?.(msgEl);
   if (wasAtBottom) {
     this._scrollToBottom(true);
   }
@@ -727,6 +741,14 @@ _createMessageEl(msg, prevMsg) {
   if (msg.pinned) el.dataset.pinned = '1';
   if (msg.is_archived) el.dataset.archived = '1';
   if (msg._e2e) el.dataset.e2e = '1';
+  // (#5280) burn-after-read marker — `_wireBurnMessages` (called from
+  // every render path) reads these attrs to set up the click-to-reveal
+  // placeholder + countdown timer.
+  if (msg.burn_seconds && msg.burn_seconds > 0) {
+    el.classList.add('message-burn-pending');
+    el.dataset.burnSeconds = String(msg.burn_seconds);
+    if (msg.burning_started_at) el.dataset.burnStartedAt = msg.burning_started_at;
+  }
   if (msg.poll && msg.poll.anonymous) el.dataset.pollAnonymous = '1';
   el.innerHTML = `
     <div class="message-row">

--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -1438,6 +1438,23 @@ _setupSocketListeners() {
     }
   });
 
+  // ── Burn-after-read DM events (#5280) ──────────────
+  this.socket.on('message-burning', (data) => {
+    if (!data || !data.messageId) return;
+    const el = document.querySelector(`#messages [data-msg-id="${data.messageId}"], #dm-pip-messages [data-msg-id="${data.messageId}"]`);
+    if (!el) return;
+    el.dataset.burnStartedAt = data.burningStartedAt || new Date().toISOString();
+    el.dataset.burnSeconds = String(data.burnSeconds || 0);
+    this._startBurnCountdown?.(el, data.burnSeconds, el.dataset.burnStartedAt);
+  });
+
+  this.socket.on('message-burned', (data) => {
+    if (!data || !data.messageId) return;
+    document.querySelectorAll(`[data-msg-id="${data.messageId}"]`).forEach(el => {
+      this._replaceBurnedMessage?.(el);
+    });
+  });
+
   // ── Search results ─────────────────────────────────
   this.socket.on('search-results', (data) => {
     const panel = document.getElementById('search-results-panel');

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -2230,6 +2230,21 @@ _setupUI() {
   document.getElementById('poll-btn').addEventListener('click', () => {
     this._openPollModal();
   });
+
+  // (#5280) Burn-after-read toggle (DM-only, default 30 s).
+  // Single click arms the next message; click-and-long-press could later
+  // pop a duration picker but 30 s is a reasonable default. Visual state
+  // mirrors the existing input-action active class.
+  const _burnBtn = document.getElementById('burn-btn');
+  if (_burnBtn) {
+    _burnBtn.addEventListener('click', () => {
+      this._burnArmed = !this._burnArmed;
+      _burnBtn.classList.toggle('active', !!this._burnArmed);
+      _burnBtn.title = this._burnArmed
+        ? 'Burn after read armed — next message will self-destruct 30s after viewing'
+        : 'Burn after read (DM only)';
+    });
+  }
   document.getElementById('poll-cancel-btn').addEventListener('click', () => {
     document.getElementById('poll-modal').style.display = 'none';
   });

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -91,6 +91,73 @@ _bumpPinIndicator(delta) {
   this._updatePinIndicator(Math.max(0, cur + (delta | 0)));
 },
 
+// (#5280) Burn-after-read DMs. Walks any message rows in `root` whose
+// `data-burn-seconds` is set and either replaces the content with a
+// click-to-reveal placeholder (not yet started) or wires the countdown
+// (already started — `data-burn-started-at` is set). When the user
+// clicks reveal, emits `mark-burning` so the server stamps the start
+// time and broadcasts `message-burning` to keep the timer in sync
+// across both participants. The actual destructive delete fires from
+// the server's periodic sweep — this is just the UI layer.
+_wireBurnMessages(root) {
+  if (!root) root = document.getElementById('messages');
+  if (!root) return;
+  const rows = root.querySelectorAll('.message-burn-pending:not([data-burn-wired])');
+  rows.forEach(el => {
+    el.dataset.burnWired = '1';
+    const burnSeconds = parseInt(el.dataset.burnSeconds) || 0;
+    const startedAt = el.dataset.burnStartedAt || '';
+    const messageId = parseInt(el.dataset.msgId) || 0;
+    if (!burnSeconds || !messageId) return;
+    if (startedAt) {
+      this._startBurnCountdown(el, burnSeconds, startedAt);
+      return;
+    }
+    const content = el.querySelector('.message-content');
+    if (!content) return;
+    const real = content.innerHTML;
+    el.dataset.burnRealContent = real;
+    content.innerHTML = `<button type="button" class="burn-reveal-btn">🔥 ${this._escapeHtml(t('messages.burn_reveal') || 'Tap to view')} <span class="muted-text">(${burnSeconds}s after viewing)</span></button>`;
+    const btn = content.querySelector('.burn-reveal-btn');
+    btn.addEventListener('click', () => {
+      content.innerHTML = el.dataset.burnRealContent || '';
+      this.socket.emit('mark-burning', { code: this.currentChannel, messageId });
+      this._startBurnCountdown(el, burnSeconds, new Date().toISOString());
+    }, { once: true });
+  });
+},
+
+_startBurnCountdown(el, burnSeconds, startedAtIso) {
+  const started = Date.parse(startedAtIso);
+  if (!Number.isFinite(started)) return;
+  if (el._burnTimer) clearInterval(el._burnTimer);
+  const tick = () => {
+    const left = Math.max(0, Math.ceil((started + burnSeconds * 1000 - Date.now()) / 1000));
+    let pill = el.querySelector('.burn-countdown-pill');
+    if (!pill) {
+      pill = document.createElement('span');
+      pill.className = 'burn-countdown-pill';
+      pill.style.cssText = 'margin-left:6px;font-size:0.75em;opacity:0.7';
+      const head = el.querySelector('.message-content');
+      if (head) head.prepend(pill);
+    }
+    pill.textContent = `🔥 ${left}s`;
+    if (left <= 0) { clearInterval(el._burnTimer); el._burnTimer = null; }
+  };
+  tick();
+  el._burnTimer = setInterval(tick, 1000);
+},
+
+_replaceBurnedMessage(el) {
+  if (!el) return;
+  if (el._burnTimer) { clearInterval(el._burnTimer); el._burnTimer = null; }
+  const content = el.querySelector('.message-content');
+  if (!content) return;
+  content.innerHTML = `<span class="muted-text" style="font-style:italic">🔥 ${this._escapeHtml(t('messages.burn_done') || 'Message burned')}</span>`;
+  el.classList.remove('message-burn-pending');
+  el.classList.add('message-burned');
+},
+
 _isImageUrl(str) {
   if (!str) return false;
   const trimmed = str.trim();

--- a/src/database.js
+++ b/src/database.js
@@ -169,6 +169,18 @@ function initDatabase() {
     db.exec("ALTER TABLE messages ADD COLUMN edited_at DATETIME DEFAULT NULL");
   }
 
+  // ── Migration: burn-after-read columns on messages (#5280) ──
+  // burn_seconds: 0 = no burn (default); >0 = delete N seconds after first
+  // recipient view. burning_started_at is NULL until the first viewer sends
+  // a `mark-burning` event; once set, the periodic sweep below deletes the
+  // row when (started_at + burn_seconds) < now.
+  try {
+    db.prepare("SELECT burn_seconds FROM messages LIMIT 0").get();
+  } catch {
+    db.exec("ALTER TABLE messages ADD COLUMN burn_seconds INTEGER DEFAULT 0");
+    db.exec("ALTER TABLE messages ADD COLUMN burning_started_at DATETIME DEFAULT NULL");
+  }
+
   // ── Migration: high_scores table ────────────────────────
   db.exec(`
     CREATE TABLE IF NOT EXISTS high_scores (

--- a/src/socketHandlers/messages.js
+++ b/src/socketHandlers/messages.js
@@ -31,7 +31,7 @@ module.exports = function register(socket, ctx) {
     let messages;
     if (before) {
       messages = db.prepare(`
-        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data,
+        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data, m.burn_seconds, m.burning_started_at,
                COALESCE(m.webhook_username, u.display_name, u.username, '[Deleted User]') as username, u.id as user_id, u.avatar, COALESCE(u.avatar_shape, 'circle') as avatar_shape
         FROM messages m LEFT JOIN users u ON m.user_id = u.id
         WHERE m.channel_id = ? AND m.id < ? AND m.thread_id IS NULL
@@ -39,7 +39,7 @@ module.exports = function register(socket, ctx) {
       `).all(channel.id, before, limit);
     } else if (after) {
       messages = db.prepare(`
-        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data,
+        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data, m.burn_seconds, m.burning_started_at,
                COALESCE(m.webhook_username, u.display_name, u.username, '[Deleted User]') as username, u.id as user_id, u.avatar, COALESCE(u.avatar_shape, 'circle') as avatar_shape
         FROM messages m LEFT JOIN users u ON m.user_id = u.id
         WHERE m.channel_id = ? AND m.id > ? AND m.thread_id IS NULL
@@ -48,20 +48,20 @@ module.exports = function register(socket, ctx) {
     } else if (around) {
       const half = Math.floor(limit / 2);
       const beforeMsgs = db.prepare(`
-        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data,
+        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data, m.burn_seconds, m.burning_started_at,
                COALESCE(m.webhook_username, u.display_name, u.username, '[Deleted User]') as username, u.id as user_id, u.avatar, COALESCE(u.avatar_shape, 'circle') as avatar_shape
         FROM messages m LEFT JOIN users u ON m.user_id = u.id
         WHERE m.channel_id = ? AND m.id < ? AND m.thread_id IS NULL
         ORDER BY m.created_at DESC, m.id DESC LIMIT ?
       `).all(channel.id, around, half);
       const targetMsg = db.prepare(`
-        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data,
+        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data, m.burn_seconds, m.burning_started_at,
                COALESCE(m.webhook_username, u.display_name, u.username, '[Deleted User]') as username, u.id as user_id, u.avatar, COALESCE(u.avatar_shape, 'circle') as avatar_shape
         FROM messages m LEFT JOIN users u ON m.user_id = u.id
         WHERE m.channel_id = ? AND m.id = ?
       `).all(channel.id, around);
       const afterMsgs = db.prepare(`
-        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data,
+        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data, m.burn_seconds, m.burning_started_at,
                COALESCE(m.webhook_username, u.display_name, u.username, '[Deleted User]') as username, u.id as user_id, u.avatar, COALESCE(u.avatar_shape, 'circle') as avatar_shape
         FROM messages m LEFT JOIN users u ON m.user_id = u.id
         WHERE m.channel_id = ? AND m.id > ? AND m.thread_id IS NULL
@@ -71,7 +71,7 @@ module.exports = function register(socket, ctx) {
       messages = [...beforeMsgs.reverse(), ...targetMsg, ...afterMsgs];
     } else {
       messages = db.prepare(`
-        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data,
+        SELECT m.id, m.content, m.created_at, m.reply_to, m.edited_at, m.is_webhook, m.webhook_username, m.webhook_avatar, m.imported_from, m.is_archived, m.poll_data, m.burn_seconds, m.burning_started_at,
                COALESCE(m.webhook_username, u.display_name, u.username, '[Deleted User]') as username, u.id as user_id, u.avatar, COALESCE(u.avatar_shape, 'circle') as avatar_shape
         FROM messages m LEFT JOIN users u ON m.user_id = u.id
         WHERE m.channel_id = ? AND m.thread_id IS NULL
@@ -449,10 +449,18 @@ module.exports = function register(socket, ctx) {
       if (!replyMsg || replyMsg.channel_id !== channel.id) replyTo = null;
     }
 
+    // (#5280) burn-after-read for DMs — capped at 5 minutes; only honored
+    // for is_dm channels (the issue scopes burn to direct messages only).
+    let burnSeconds = 0;
+    if (channel.is_dm) {
+      const reqBurn = parseInt(data && data.burnSeconds);
+      if (Number.isFinite(reqBurn) && reqBurn >= 1 && reqBurn <= 300) burnSeconds = reqBurn;
+    }
+
     try {
       const result = db.prepare(
-        'INSERT INTO messages (channel_id, user_id, content, reply_to) VALUES (?, ?, ?, ?)'
-      ).run(channel.id, socket.user.id, safeContent, replyTo);
+        'INSERT INTO messages (channel_id, user_id, content, reply_to, burn_seconds) VALUES (?, ?, ?, ?, ?)'
+      ).run(channel.id, socket.user.id, safeContent, replyTo, burnSeconds);
 
       const message = {
         id: result.lastInsertRowid,
@@ -466,7 +474,8 @@ module.exports = function register(socket, ctx) {
         replyContext: null,
         reactions: [],
         edited_at: null,
-        thread: null
+        thread: null,
+        burn_seconds: burnSeconds || undefined
       };
 
       if (replyTo) {
@@ -492,6 +501,65 @@ module.exports = function register(socket, ctx) {
       socket.emit('error-msg', 'Failed to send message — please try again');
     }
   });
+
+  // ── Burn-after-read mark + sweep (#5280) ────────────────────
+  // The recipient (or sender, but typically recipient) emits `mark-burning`
+  // the first time the message is revealed. Server stamps
+  // `burning_started_at` once and fans out `message-burning` so every
+  // viewer can run a synced countdown. Subsequent emits for the same
+  // message are no-ops. The actual delete fires from the periodic sweep
+  // below, which also handles the "server restarted mid-timer" case
+  // (sweep on next get-messages catches expired burns regardless).
+  socket.on('mark-burning', (data) => {
+    if (!data || typeof data !== 'object') return;
+    const messageId = parseInt(data.messageId);
+    const code = typeof data.code === 'string' ? data.code.trim() : '';
+    if (!Number.isFinite(messageId) || !code) return;
+    const channel = db.prepare('SELECT id, is_dm FROM channels WHERE code = ?').get(code);
+    if (!channel || !channel.is_dm) return;
+    const member = db.prepare('SELECT 1 FROM channel_members WHERE channel_id = ? AND user_id = ?').get(channel.id, socket.user.id);
+    if (!member) return;
+    const msg = db.prepare('SELECT id, channel_id, burn_seconds, burning_started_at FROM messages WHERE id = ?').get(messageId);
+    if (!msg || msg.channel_id !== channel.id) return;
+    if (!msg.burn_seconds || msg.burn_seconds <= 0) return;
+    if (msg.burning_started_at) return; // already burning — synced countdown is already live
+    const startedAt = new Date().toISOString();
+    db.prepare('UPDATE messages SET burning_started_at = ? WHERE id = ?').run(startedAt, messageId);
+    io.to(`channel:${code}`).emit('message-burning', {
+      channelCode: code,
+      messageId,
+      burnSeconds: msg.burn_seconds,
+      burningStartedAt: startedAt
+    });
+  });
+
+  // Periodic sweep: every 10 seconds, delete any burning message whose
+  // timer is up. Emits `message-burned` so clients can replace the row
+  // with a "[message burned]" placeholder. Uses datetime() arithmetic
+  // so SQLite handles the timezone math.
+  if (!global.__havenBurnSweep) {
+    global.__havenBurnSweep = setInterval(() => {
+      try {
+        const expired = db.prepare(`
+          SELECT m.id, m.channel_id, c.code AS channel_code
+          FROM messages m
+          JOIN channels c ON c.id = m.channel_id
+          WHERE m.burn_seconds > 0
+            AND m.burning_started_at IS NOT NULL
+            AND datetime(m.burning_started_at, '+' || m.burn_seconds || ' seconds') <= datetime('now')
+        `).all();
+        for (const row of expired) {
+          db.prepare('DELETE FROM messages WHERE id = ?').run(row.id);
+          io.to(`channel:${row.channel_code}`).emit('message-burned', {
+            channelCode: row.channel_code,
+            messageId: row.id
+          });
+        }
+      } catch (err) {
+        console.error('[burn-sweep] error:', err.message);
+      }
+    }, 10000);
+  }
 
   // ── Typing indicator ────────────────────────────────────
   socket.on('typing', (data) => {


### PR DESCRIPTION
Refs #5280

## Summary

Adds Signal-style burn-after-read for DMs. Sender arms 🔥 in the composer, recipient sees \"Tap to view,\" the message destroys itself N seconds after reveal — and both participants see the same synced countdown. Capped at 300 s and DM-only by design.

## What changed

### Server

**\`src/database.js\`**
- \`ALTER TABLE messages ADD COLUMN burn_seconds INTEGER DEFAULT 0\`
- \`ALTER TABLE messages ADD COLUMN burning_started_at DATETIME DEFAULT NULL\`

Added via the standard try/catch + ALTER migration so existing databases pick it up on next boot.

**\`src/socketHandlers/messages.js\`**
- \`send-message\` accepts an optional \`burnSeconds\` field (1–300, DM channels only). Server-cleartext metadata so the destroyer can run without decrypting E2E content.
- New \`mark-burning\` socket handler: when a recipient reveals a burn-flagged message, the server stamps \`burning_started_at\` once (idempotent — repeat emits are no-ops) and emits \`message-burning\` to both participants with the canonical start time so countdowns stay synced.
- \`get-messages\` SELECTs now include \`burn_seconds\` + \`burning_started_at\` in every variant via a single \`replace_all\` on the shared SELECT prefix.
- **10 s periodic sweep** finds expired burns (\`burning_started_at + burn_seconds <= now()\`), \`DELETE\`s the row, and emits \`message-burned\` so clients can replace the rendered row with a placeholder. Set up once via \`global.__havenBurnSweep\` so socket re-registrations don't stack timers.

### Client

**\`public/app.html\`** — new 🔥 \`#burn-btn\` in the message-input action row, hidden by default.

**\`public/js/modules/app-channels.js\`** (\`switchChannel\`) — show/hide the button on channel switch (DM-only); reset \`this._burnArmed\` so a stale arming can't leak across DMs.

**\`public/js/modules/app-ui.js\`** — click handler toggles \`this._burnArmed\` and mirrors active state + tooltip on the button.

**\`public/js/modules/app-messages.js\`**
- \`_sendMessage\`: when armed, set \`payload.burnSeconds = 30\` and clear the flag immediately (single-message arming, like reply-to).
- Renderer: every message-row gets \`data-burn-seconds\` and an optional \`data-burn-started-at\` if the row arrives already-burning, plus a \`.message-burn-pending\` class.
- Every render path that wires \`_decryptE2EImages\` now also calls \`_wireBurnMessages\`.

**\`public/js/modules/app-utilities.js\`** — new \`_wireBurnMessages\`:
- Walks pending burn rows. Already-started → starts a synced countdown. Not-yet-started → swaps the message body for a click-to-reveal placeholder.
- On reveal, restores the original content, emits \`mark-burning\`, and starts an optimistic local timer (replaced by the server-authoritative start when \`message-burning\` echoes back).
- \`_replaceBurnedMessage\` swaps the row to a \"🔥 Message burned\" placeholder when \`message-burned\` fires.

**\`public/js/modules/app-socket.js\`** — handlers for \`message-burning\` and \`message-burned\` route to those helpers; lookups cover both \`#messages\` and \`#dm-pip-messages\` so the PiP overlay participates.

## E2E DM compatibility

\`burnSeconds\` is server-cleartext metadata, not part of the encrypted ciphertext. The server needs it in plain to schedule deletion. The actual message body remains end-to-end encrypted.

## What's not in this PR (intentional follow-up)

- **Per-DM \"auto-burn everything\" toggle** — the second half of the issue's ask. Today every burn message is per-message armed; a follow-up can persist a per-DM \`auto_burn_seconds\` preference that pre-arms outgoing messages.
- **Configurable timer**. Currently hardcoded 30 s default. Server accepts 1–300; client UI just needs a long-press / dropdown to pick.

## Test plan

- [x] \`node --check\` passes on all 7 edited JS files
- [ ] Fresh DB → new columns exist; existing DB → migration runs once on next boot
- [ ] In a DM: arm 🔥, send \"hello\" → recipient sees \"🔥 Tap to view (30s after viewing)\" placeholder
- [ ] Recipient clicks → message body appears, both sides see countdown ticking
- [ ] After ~30 s → row swaps to \"🔥 Message burned\" on both sides; server row is deleted
- [ ] Channel switch → 🔥 button hides on non-DM channels, arming flag clears
- [ ] burnSeconds=400 from a stale client → server clamps and stores 0 (no burn)
- [ ] burnSeconds set on a non-DM channel → server ignores (only honored when \`channel.is_dm\`)
- [ ] Server restart with messages mid-burn → next sweep cleans them up correctly