### PR TITLE
feat(#5282): orphan-DM watchdog in auto-cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ---
 
+## [Unreleased]
+
+### Added
+- **#5282: Orphan-DM watchdog.** When one or both participants of a DM delete their account (or get force-removed), the `channel_members` rows vanish via `ON DELETE CASCADE` but the DM channel itself was left lingering with stale messages forever. The auto-cleanup routine now sweeps `is_dm=1` channels with member count below 2, moves their `/uploads/...` attachments into `deleted-attachments/`, and `DELETE`s the channel. Runs unconditionally — `cleanup_enabled` only gates message-age expiry.
+
+---
+
 ## [3.10.11] — 2026-04-28
 
 ### Fixed

--- a/server.js
+++ b/server.js
@@ -3116,6 +3116,57 @@ function runAutoCleanup() {
       }
     }
 
+    // 3. (#5282) Orphan-DM sweep — delete any DM channel that has dropped
+    // below 2 members (one or both participants deleted their account or
+    // were force-removed). channel_members.user_id has ON DELETE CASCADE
+    // so the row vanishes when the user does, but the DM channel itself
+    // is left lingering with stale messages forever; this is the
+    // "orphaned conversation" issue called out in #5282. Runs regardless
+    // of cleanup_enabled so the data isn't retained indefinitely.
+    try {
+      const orphanRows = db.prepare(`
+        SELECT c.id, c.code, COUNT(cm.user_id) as member_count
+        FROM channels c
+        LEFT JOIN channel_members cm ON cm.channel_id = c.id
+        WHERE c.is_dm = 1
+        GROUP BY c.id
+        HAVING member_count < 2
+      `).all();
+      let orphansDeleted = 0;
+      for (const ch of orphanRows) {
+        try {
+          // Move any /uploads/<file> referenced in this DM's messages to
+          // deleted-attachments first so file cleanup doesn't lose track.
+          const msgs = db.prepare('SELECT content FROM messages WHERE channel_id = ?').all(ch.id);
+          const uploadRe = /\/uploads\/((?!deleted-attachments)[\w\-.]+)/g;
+          const seen = new Set();
+          for (const m of msgs) {
+            if (typeof m.content !== 'string') continue;
+            let mm;
+            while ((mm = uploadRe.exec(m.content)) !== null) seen.add(mm[1]);
+          }
+          if (seen.size) {
+            const deletedDir = path.join(UPLOADS_DIR, 'deleted-attachments');
+            require('fs').mkdirSync(deletedDir, { recursive: true });
+            for (const fn of seen) {
+              const src = path.join(UPLOADS_DIR, fn);
+              if (!require('fs').existsSync(src)) continue;
+              try { require('fs').renameSync(src, path.join(deletedDir, fn)); } catch {}
+            }
+          }
+          // Delete the channel — cascades to messages + read_positions +
+          // channel_members + reactions etc. via the existing FKs.
+          db.prepare('DELETE FROM channels WHERE id = ?').run(ch.id);
+          orphansDeleted++;
+        } catch (e) {
+          console.error('[orphan-DM] failed to clean', ch.code, e.message);
+        }
+      }
+      if (orphansDeleted > 0) {
+        console.log(`🗑️  Auto-cleanup: removed ${orphansDeleted} orphan DM channel(s)`);
+      }
+    } catch (e) { /* sweep is best-effort */ }
+
     if (totalDeleted > 0) {
       console.log(`🗑️  Auto-cleanup: deleted ${totalDeleted} old messages`);
     }


### PR DESCRIPTION
Refs #5282

## Summary

When one or both participants of a DM delete their account (or get force-removed), the `channel_members` rows vanish via the existing `ON DELETE CASCADE` but the DM channel itself was left lingering with stale messages forever — the \"orphaned conversation\" problem flagged in #5282 (\"if a user deletes their account (or is banned) the data will be retained forever\"). This PR adds a watchdog pass to the existing auto-cleanup routine that finds and deletes those orphans.

## What changed

**\`server.js\`** — adds a third pass at the end of \`runCleanup()\`:

1. Selects every \`is_dm=1\` channel whose member count is below 2.
2. For each, walks message contents, extracts \`/uploads/<file>\` references, and renames them into \`deleted-attachments/\` so the existing file-cleanup later can age-expire them.
3. \`DELETE\`s the channel — cascades through messages, read_positions, channel_members, reactions, etc. via the existing FKs.

Runs **regardless of \`cleanup_enabled\`**. \`cleanup_enabled\` gates whether older messages get age-expired; orphan DMs shouldn't be retained indefinitely just because an admin hasn't opted into broader cleanup.

## What's not in this PR (intentional follow-ups)

The issue lists more asks; each deserves its own focused PR:

- **Per-DM cleanup banner** showing \"messages older than N days are auto-purged\" when cleanup is on.
- **Role-based upload override** + temporary one-shot grants. Needs a new permission + grant table.
- **Per-message pin-immunity to purge.** Today \`is_archived=1\` and \`channels.cleanup_exempt=1\` cover the common cases; explicit per-message exemption would need a new boolean column.
- **DM-specific filesize cap.** The existing \`max_upload_mb\` already enforces an upload cap that DMs respect; if you want it tighter for DMs specifically, that's a separate \`dm_max_upload_mb\` setting.

I can do any/all of those as follow-ups — flagged each in the commit body. Keeping this PR scoped to the actual data-retention bug.

## Test plan

- [x] \`node --check server.js\` passes
- [ ] Create a DM between A and B → admin deletes account A → next \`runCleanup\` cycle removes the DM channel + its messages; B's sidebar no longer lists the orphan
- [ ] Same flow but the DM had attachments → files are moved into `deleted-attachments/` and not lost mid-cleanup
- [ ] Active DM (both members present) → no false-positive deletion across cycles
- [ ] cleanup_enabled='false' → orphan sweep still runs (the orphan case is independent of opt-in age-expiry)