### PR TITLE
feat: add Bluesky link previews to /api/link-preview

### DIFF
--- a/server.js
+++ b/server.js
@@ -2358,6 +2358,59 @@ app.get('/api/link-preview', async (req, res) => {
       } catch { /* fall through to generic scrape */ }
     }
 
+    // ── Bluesky — HTML is client-rendered (blank OG tags); the public AT Protocol
+    // app view returns structured post data with no auth. Resolve the handle to a
+    // DID when needed, then hydrate the post and pull author / text / media. ──
+    if (!data && /^https?:\/\/bsky\.app\/profile\/[^/]+\/post\/[A-Za-z0-9]+/i.test(url)) {
+      try {
+        const m = url.match(/^https?:\/\/bsky\.app\/profile\/([^/?#]+)\/post\/([A-Za-z0-9]+)/i);
+        let did = m[1];
+        if (!did.startsWith('did:')) {
+          const rh = await fetch(
+            `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(did)}`,
+            { signal: AbortSignal.timeout(6000), headers: { 'User-Agent': PREVIEW_UA } }
+          );
+          if (rh.ok) did = (await rh.json()).did || did;
+        }
+        if (did.startsWith('did:')) {
+          const atUri = `at://${did}/app.bsky.feed.post/${m[2]}`;
+          const pResp = await fetch(
+            `https://public.api.bsky.app/xrpc/app.bsky.feed.getPosts?uris=${encodeURIComponent(atUri)}`,
+            { signal: AbortSignal.timeout(6000), headers: { 'User-Agent': PREVIEW_UA } }
+          );
+          if (pResp.ok) {
+            const post = (await pResp.json())?.posts?.[0];
+            if (post) {
+              const author = post.author || {};
+              const name = author.displayName || author.handle || 'Bluesky';
+              const embed = post.embed || {};
+              // recordWithMedia nests the real media one level down under .media
+              const media = (embed.$type || '').startsWith('app.bsky.embed.recordWithMedia') ? (embed.media || {}) : embed;
+              const mType = media.$type || '';
+              let image = null, images;
+              if (mType.startsWith('app.bsky.embed.images')) {
+                const imgs = (media.images || []).map(i => i.fullsize).filter(Boolean);
+                if (imgs.length >= 2) images = imgs.slice(0, 4);
+                image = imgs[0] || null;
+              } else if (mType.startsWith('app.bsky.embed.video')) {
+                image = media.thumbnail || null;
+              } else if (mType.startsWith('app.bsky.embed.external')) {
+                image = media.external?.thumb || null;
+              }
+              data = {
+                title: `${name} on Bluesky`,
+                description: (post.record?.text || '').slice(0, 280) || null,
+                image,
+                images,
+                siteName: 'Bluesky',
+                url
+              };
+            }
+          }
+        }
+      } catch { /* Bluesky app view failed — continue to generic scrape */ }
+    }
+
     // ── Generic OG scrape (manual redirect following with SSRF checks) ──
     if (!data) {
       let currentUrl = url;


### PR DESCRIPTION
## What

Adds a **Bluesky** handler to `/api/link-preview`, so `bsky.app` post links render a rich preview card instead of a bare URL.

## Why

The server already produces rich previews for X/Twitter, YouTube, Reddit and Pixiv, but Bluesky links fall through to the generic OG scraper — and `bsky.app` renders posts client-side, so the scraper only sees an empty shell. Users on the desktop/web client (and the Android app's generic fallback) just see the raw link. This was a recurring request from server members.

## How

Slots into the existing site-specific handler chain (right after Pixiv, before the generic scrape), following the same pattern as the Twitter oEmbed / Reddit JSON handlers:

- Matches `bsky.app/profile/<handle-or-did>/post/<rkey>`
- Resolves the handle to a DID via `com.atproto.identity.resolveHandle` (skipped when the URL already contains a `did:`)
- Hydrates the post via `app.bsky.feed.getPosts` on the **public** AT Protocol app view — **no auth or API key**
- Returns the same preview shape as the other handlers: `title` (`<author> on Bluesky`), `description` (post text, capped at 280), `image`, optional `images[]` for multi-image posts (mirrors the Reddit gallery handling), `siteName`, `url`
- Handles `images`, `video` (thumbnail), `external` (card thumb), and `recordWithMedia` (quote-with-media) embeds
- Same `AbortSignal.timeout(6000)` + `PREVIEW_UA` + `try/catch → fall through to generic scrape` as its neighbours

## Testing

- `node --check server.js` passes
- Verified the handler logic against the live public app view: a handle-based URL resolves the DID, hydrates the post, and returns the correct author, text, and `feed_fullsize` image; multi-image posts populate `images[]`. No credentials required.