### PR TITLE
fix: don't move shared stickers to deleted-attachments on message/DM delete

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,7 +70,7 @@ const { initFcm } = require('./src/fcm');
 
 const app = express();
 
-const UPLOAD_PATH_RE = /\/uploads\/((?!deleted-attachments\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
+const UPLOAD_PATH_RE = /\/uploads\/((?!(?:deleted-attachments|stickers)\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
 
 function isSafeUploadRelPath(relPath) {
   if (typeof relPath !== 'string' || !relPath) return false;

--- a/src/socketHandlers/channels.js
+++ b/src/socketHandlers/channels.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const { UPLOADS_DIR, DELETED_ATTACHMENTS_DIR } = require('../paths');
 
-const UPLOAD_PATH_RE = /\/uploads\/((?!deleted-attachments\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
-const UPLOAD_PATH_EXACT_RE = /^\/uploads\/((?!deleted-attachments\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)$/;
+const UPLOAD_PATH_RE = /\/uploads\/((?!(?:deleted-attachments|stickers)\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
+const UPLOAD_PATH_EXACT_RE = /^\/uploads\/((?!(?:deleted-attachments|stickers)\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)$/;
 
 function isSafeUploadRelPath(relPath) {
   if (typeof relPath !== 'string' || !relPath) return false;

--- a/src/socketHandlers/messages.js
+++ b/src/socketHandlers/messages.js
@@ -10,8 +10,8 @@ module.exports = function register(socket, ctx) {
           touchVoiceActivity, floodCheck, UPLOADS_DIR, DELETED_ATTACHMENTS_DIR } = ctx;
   const { slowModeTracker } = state;
 
-  const UPLOAD_PATH_RE = /\/uploads\/((?!deleted-attachments\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
-  const UPLOAD_PATH_EXACT_RE = /^\/uploads\/((?!deleted-attachments\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)$/;
+  const UPLOAD_PATH_RE = /\/uploads\/((?!(?:deleted-attachments|stickers)\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
+  const UPLOAD_PATH_EXACT_RE = /^\/uploads\/((?!(?:deleted-attachments|stickers)\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)$/;
 
   function isSafeUploadRelPath(relPath) {
     if (typeof relPath !== 'string' || !relPath) return false;


### PR DESCRIPTION
Fixes #5411

## What

Deleting a DM (or channel/message) that contains a sticker no longer moves the shared sticker file out of `/uploads/stickers/`.

## Root cause

Stickers are shared library assets stored under `/uploads/stickers/` and sent as standalone `/uploads/stickers/<file>` URLs in message content (same mechanism as GIFs, per the note in `database.js`). The deletion cleanup scans message content with `UPLOAD_PATH_RE` and moves every matched `/uploads/` file into `deleted-attachments/`. That regex already excluded `deleted-attachments/` (via negative lookahead) but **not** `stickers/` — so a sticker referenced in a deleted DM was treated as a per-message attachment and its shared file was relocated, breaking that sticker for everyone on the server.

This matches the reporter's repro: send a sticker in a DM, delete the DM, and the sticker file ends up in `deleted-attachments/`.

## Fix

Add `stickers/` to the existing negative lookahead in all five definitions of `UPLOAD_PATH_RE` / `UPLOAD_PATH_EXACT_RE`:

- `server.js`
- `src/socketHandlers/messages.js` (×2)
- `src/socketHandlers/channels.js` (×2)

`(?!deleted-attachments\/)` → `(?!(?:deleted-attachments|stickers)\/)`

So sticker URLs are never matched by the attachment-move logic.

## Why this is safe

- Stickers live in the `stickers/` **subdirectory**. The top-level orphan auto-cleanup (`readdirSync(uploadsDir)`) only deletes top-level files — a subdirectory entry would throw on `unlinkSync` and is swallowed — so stickers were never subject to it and remain protected.
- The exempt/pinned/archived "protect" passes use the same regex; sticker subdir paths there never matched a top-level filename anyway, so behavior is unchanged.
- Stickers are the only shared asset emitted as a raw `/uploads/` URL in message content (custom emojis render as `:name:`, not URLs), so this fully covers the class.

## Testing

- `node --check` passes on all three changed files.
- Regex unit check: `/uploads/stickers/happy.png` and nested `/uploads/stickers/pack/wave.webp` no longer match; normal attachments (`/uploads/report.pdf`, timestamped names) still match; `/uploads/deleted-attachments/...` still excluded; a mixed-content message scan returns only the real attachment.