### PR TITLE
Remove server kill command from start.sh. (Linux start script)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -106,13 +106,6 @@ if [ -f "$HAVEN_DATA/.env" ]; then
     fi
 fi
 
-# ── Kill existing server on configured port ────────────────
-if command -v lsof &> /dev/null && lsof -ti:${HAVEN_PORT} &> /dev/null; then
-    echo "  [!] Killing existing process on port ${HAVEN_PORT}..."
-    lsof -ti:${HAVEN_PORT} | xargs kill -9 2>/dev/null || true
-    sleep 1
-fi
-
 echo "  [*] Data directory: $HAVEN_DATA"
 echo "  [*] Starting Haven server..."
 echo ""


### PR DESCRIPTION
Removed potentially dangerous command especially when port is configured to 443.

When helping Raidenphantom start his server it kept killing all the https websites he was connected to (since we were bound to 443), including the moviethingy haven voice chat which kicked him out of the server entirely until reloaded.

This command is mostly useless since express just errors if there's something already bound on whatever port we have set in the .env. AFAIK, this is bad practice anyways as it could kill server's where people are hosting multiple things. this one command could kill something essential on servers not containerizing.