### PR TITLE
feat: rich social embed cards (Bluesky / X) with size + collapse controls

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -1311,13 +1311,17 @@
             <span class="density-icon">🚫</span>
             <span class="density-label" data-i18n="settings.embed_display.off">Off</span>
           </button>
-          <button type="button" class="density-btn active" data-embed-size="normal" title="Normal — compact preview card">
+          <button type="button" class="density-btn" data-embed-size="small" title="Small — compact card with small media">
             <span class="density-icon">🔗</span>
-            <span class="density-label" data-i18n="settings.embed_display.normal">Normal</span>
+            <span class="density-label" data-i18n="settings.embed_display.small">Small</span>
           </button>
-          <button type="button" class="density-btn" data-embed-size="large" title="Large — wider card with bigger thumbnail">
+          <button type="button" class="density-btn active" data-embed-size="medium" title="Medium — balanced card with medium media">
+            <span class="density-icon">🖼️</span>
+            <span class="density-label" data-i18n="settings.embed_display.medium">Medium</span>
+          </button>
+          <button type="button" class="density-btn" data-embed-size="full" title="Full — large media, author, and post stats">
             <span class="density-icon">📰</span>
-            <span class="density-label" data-i18n="settings.embed_display.large">Large</span>
+            <span class="density-label" data-i18n="settings.embed_display.full">Full</span>
           </button>
         </div>
       </div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6426,19 +6426,30 @@ details.sound-section:not([open]) .sound-section-label::before {
   object-fit: contain;
 }
 
-/* Embed / link preview size modes */
-.embed-size-off .link-preview,
-.embed-size-off .link-preview-yt { display: none !important; }
+/* Embed / link preview size modes (shared by Settings picker + per-embed ⤢) */
+.embed-size-off .link-preview { display: none !important; }
 
-.embed-size-large .link-preview {
-  max-width: 600px;
-}
-.embed-size-large .link-preview-image {
-  width: 120px;
-  height: 120px;
-}
-.embed-size-large .link-preview-title { font-size: 14px; }
-.embed-size-large .link-preview-desc  { -webkit-line-clamp: 3; }
+.embed-size-full .link-preview--rich .lp-image,
+.embed-size-full .link-preview--rich .lp-video { max-height: 520px; }
+.embed-size-full .link-preview--rich .lp-text { -webkit-line-clamp: 14; }
+.embed-size-full .link-preview--yt .link-preview-yt { max-width: 480px; }
+
+.embed-size-medium .link-preview--rich .lp-media,
+.embed-size-medium .link-preview--rich .lp-video,
+.embed-size-medium .link-preview--rich .link-preview-gallery { max-width: 340px; }
+.embed-size-medium .link-preview--rich .lp-image,
+.embed-size-medium .link-preview--rich .lp-video { max-height: 300px; }
+.embed-size-medium .link-preview--rich .lp-text { -webkit-line-clamp: 8; }
+.embed-size-medium .link-preview--yt .link-preview-yt { max-width: 380px; }
+
+.embed-size-small .link-preview { max-width: 360px; }
+.embed-size-small .link-preview--rich .lp-media,
+.embed-size-small .link-preview--rich .lp-video,
+.embed-size-small .link-preview--rich .link-preview-gallery { max-width: 220px; }
+.embed-size-small .link-preview--rich .lp-image,
+.embed-size-small .link-preview--rich .lp-video { max-height: 160px; }
+.embed-size-small .link-preview--rich .lp-text { -webkit-line-clamp: 4; }
+.embed-size-small .link-preview--yt .link-preview-yt { max-width: 280px; }
 
 /* Image lightbox overlay */
 .image-lightbox {
@@ -12700,6 +12711,164 @@ ul.chat-list { list-style-type: disc; }
   width: 100%;
   height: 100%;
   border: 0;
+}
+
+/* ── Rich embed card (Bluesky / X / generic) — mobile-parity layout ───── */
+.link-preview--rich {
+  flex-direction: column;
+  gap: 6px;
+  align-items: stretch;
+  max-width: 480px;
+  padding: 8px 10px;
+  border-left-color: var(--lp-accent, var(--accent));
+}
+.lp-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.lp-site {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--lp-accent, var(--accent));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lp-size,
+.lp-collapse {
+  flex: 0 0 auto;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.lp-size:hover,
+.lp-collapse:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text-secondary);
+}
+.lp-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.link-preview.lp-collapsed .lp-content { display: none; }
+.lp-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  text-decoration: none;
+  color: inherit;
+}
+.lp-author {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.lp-avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex: 0 0 auto;
+}
+.lp-author-name {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lp-handle {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.lp-text {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 14;
+  overflow: hidden;
+}
+.lp-media {
+  position: relative;
+  display: block;
+  line-height: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  max-width: 100%;
+}
+.lp-image,
+.lp-video {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 520px;
+  border-radius: 8px;
+  background: #000;
+  object-fit: contain;
+}
+.lp-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 52px;
+  height: 52px;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.lp-play::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 54%;
+  transform: translate(-50%, -50%);
+  border-style: solid;
+  border-width: 9px 0 9px 15px;
+  border-color: transparent transparent transparent #fff;
+}
+.lp-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.lp-stats span { white-space: nowrap; }
+/* YouTube card reuses the shared chrome; neutralise the legacy inner styling */
+.link-preview--yt {
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+}
+.link-preview--yt .link-preview-yt {
+  margin-top: 0;
+  border: 0;
+  border-radius: 6px;
+  max-width: 480px;
+  width: 100%;
 }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•

--- a/public/js/modules/app-media.js
+++ b/public/js/modules/app-media.js
@@ -2448,28 +2448,33 @@ _applyImageMode(mode) {
 _setupEmbedSizePicker() {
   const picker = document.getElementById('embed-size-picker');
   if (!picker) return;
-
-  const saved = localStorage.getItem('haven-embed-size') || 'normal';
-  this._applyEmbedSize(saved);
-  picker.querySelectorAll('[data-embed-size]').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.embedSize === saved);
-  });
-
+  this._applyEmbedSize(this._embedSize());
   picker.addEventListener('click', (e) => {
     const btn = e.target.closest('[data-embed-size]');
-    if (!btn) return;
-    const mode = btn.dataset.embedSize;
-    this._applyEmbedSize(mode);
-    localStorage.setItem('haven-embed-size', mode);
-    picker.querySelectorAll('[data-embed-size]').forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
+    if (btn) this._applyEmbedSize(btn.dataset.embedSize);
   });
 },
 
+// Embed size is the single source of truth shared by the Settings picker and
+// the per-embed ⤢ toggle (see app-messages.js). Legacy values are migrated.
+_normalizeEmbedSize(mode) {
+  mode = ({ normal: 'medium', large: 'full' })[mode] || mode;
+  return ['full', 'medium', 'small', 'off'].includes(mode) ? mode : 'medium';
+},
+
+_embedSize() {
+  return this._normalizeEmbedSize(localStorage.getItem('haven-embed-size'));
+},
+
 _applyEmbedSize(mode) {
-  document.body.classList.remove('embed-size-off', 'embed-size-large');
-  if (mode === 'off') document.body.classList.add('embed-size-off');
-  if (mode === 'large') document.body.classList.add('embed-size-large');
+  mode = this._normalizeEmbedSize(mode);
+  localStorage.setItem('haven-embed-size', mode);
+  document.body.classList.remove('embed-size-off', 'embed-size-small', 'embed-size-medium', 'embed-size-full');
+  document.body.classList.add(`embed-size-${mode}`);
+  const label = `⤢ ${mode.charAt(0).toUpperCase() + mode.slice(1)}`;
+  document.querySelectorAll('.lp-size').forEach(b => { b.textContent = label; });
+  const picker = document.getElementById('embed-size-picker');
+  if (picker) picker.querySelectorAll('[data-embed-size]').forEach(b => b.classList.toggle('active', b.dataset.embedSize === mode));
 },
 
 // ── Role Display Picker ──

--- a/public/js/modules/app-messages.js
+++ b/public/js/modules/app-messages.js
@@ -1387,6 +1387,8 @@ _fetchLinkPreviews(containerEl) {
   // - this._linkPreviewInflight: url -> Promise<data>  (dedupe concurrent fetches)
   if (!this._linkPreviewCache) this._linkPreviewCache = new Map();
   if (!this._linkPreviewInflight) this._linkPreviewInflight = new Map();
+  if (!this._collapsedEmbeds) this._collapsedEmbeds = new Set();
+  if (!/\bembed-size-/.test(document.body.className)) this._applyEmbedSize(this._embedSize());
   const PREVIEW_CLIENT_TTL = 10 * 60 * 1000;
 
   const links = containerEl.querySelectorAll('.message-content a[href]');
@@ -1400,16 +1402,21 @@ _fetchLinkPreviews(containerEl) {
     if (/^https:\/\/media\d*\.giphy\.com\//i.test(url)) return;
     if (url.startsWith(window.location.origin)) return;
 
-    // ── Inline YouTube embed ────────────────────────────
+    // ── Inline YouTube embed (wrapped in the shared embed chrome) ──
     const ytVideoId = this._extractYouTubeVideoId(url);
     if (ytVideoId) {
       const msgContent = link.closest('.message-content');
       if (!msgContent) return;
-      if (msgContent.querySelector(`.link-preview-yt[data-url="${CSS.escape(url)}"]`)) return;
+      if (msgContent.querySelector(`.link-preview[data-url="${CSS.escape(url)}"]`)) return;
+      const ytCollapsed = this._collapsedEmbeds.has(url);
       const wrapper = document.createElement('div');
-      wrapper.className = 'link-preview-yt';
+      wrapper.className = 'link-preview link-preview--yt' + (ytCollapsed ? ' lp-collapsed' : '');
       wrapper.dataset.url = url;
-      wrapper.innerHTML = `<iframe src="https://www.youtube.com/embed/${this._escapeHtml(ytVideoId)}?rel=0" width="100%" height="270" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>`;
+      wrapper.style.setProperty('--lp-accent', '#ff0000');
+      wrapper.innerHTML =
+        this._embedHeaderHtml('YouTube', ytCollapsed) +
+        `<div class="lp-content"><div class="link-preview-yt"><iframe src="https://www.youtube.com/embed/${this._escapeHtml(ytVideoId)}?rel=0" width="100%" height="270" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div></div>`;
+      this._wireEmbedControls(wrapper, url);
       msgContent.appendChild(wrapper);
       if (this._coupledToBottom) this._scrollToBottom(true);
       return; // skip generic link preview for YouTube
@@ -1444,57 +1451,77 @@ _fetchLinkPreviews(containerEl) {
 
     dataPromise
       .then(data => {
-        if (!data || (!data.title && !data.description)) return;
+        if (!data || (!data.title && !data.description && !data.text)) return;
         const msgContent = link.closest('.message-content');
         if (!msgContent) return;
 
         // Don't add duplicate previews
         if (msgContent.querySelector(`.link-preview[data-url="${CSS.escape(url)}"]`)) return;
 
-        // ── Inline video embed (og:video MP4/WebM) ──
-        if (data.video && (data.videoType || /\.(mp4|webm|ogg)(\?[^#]*)?$/i.test(data.video))) {
-          const videoCard = document.createElement('div');
-          videoCard.className = 'link-preview link-preview--video';
-          videoCard.dataset.url = url;
-          let vInner = '<video controls preload="metadata" playsinline style="max-width:100%;max-height:400px;border-radius:8px;display:block"';
-          if (data.image) vInner += ` poster="${this._escapeHtml(data.image)}"`;
-          vInner += `><source src="${this._escapeHtml(data.video)}" type="${this._escapeHtml(data.videoType || 'video/mp4')}"></video>`;
-          vInner += '<div class="link-preview-text">';
-          if (data.siteName) vInner += `<span class="link-preview-site">${this._escapeHtml(data.siteName)}</span>`;
-          if (data.title) vInner += `<a class="link-preview-title" href="${this._escapeHtml(url)}" target="_blank" rel="noopener noreferrer nofollow">${this._escapeHtml(data.title)}</a>`;
-          vInner += '</div>';
-          videoCard.innerHTML = vInner;
-          const wasAtBottom = this._coupledToBottom;
-          msgContent.appendChild(videoCard);
-          if (wasAtBottom) this._scrollToBottom(true);
-          return;
-        }
-
-        const card = document.createElement('a');
+        // Unified rich embed card — social posts (Bluesky / X) gain an author
+        // row, avatar and engagement stats; everything else renders the same
+        // chrome (accent header, size toggle, collapse) with title/text/media.
+        const collapsed = this._collapsedEmbeds.has(url);
+        const accent = (typeof data.accentColor === 'string' && /^#[0-9a-fA-F]{3,8}$/.test(data.accentColor)) ? data.accentColor : null;
+        const isSocial = !!(data.author || data.handle);
         const hasGallery = Array.isArray(data.images) && data.images.length >= 2;
-        card.className = hasGallery ? 'link-preview link-preview--gallery' : 'link-preview';
-        card.href = url;
-        card.target = '_blank';
-        card.rel = 'noopener noreferrer nofollow';
-        card.dataset.url = url;
+        const isInlineVideo = data.video && (data.videoType || /\.(mp4|webm|ogg)(\?[^#]*)?$/i.test(data.video));
 
-        let inner = '';
+        const card = document.createElement('div');
+        card.className = 'link-preview link-preview--rich'
+          + (isSocial ? ' link-preview--social' : '')
+          + (hasGallery ? ' link-preview--gallery' : '')
+          + (collapsed ? ' lp-collapsed' : '');
+        card.dataset.url = url;
+        if (accent) card.style.setProperty('--lp-accent', accent);
+
+        // Author row (social) or title (generic) + post text
+        let meta = '';
+        if (isSocial) {
+          meta += '<div class="lp-author">';
+          if (data.avatar) meta += `<img class="lp-avatar" src="${this._escapeHtml(data.avatar)}" alt="" loading="lazy">`;
+          if (data.author) meta += `<span class="lp-author-name">${this._escapeHtml(data.author)}</span>`;
+          if (data.handle) meta += `<span class="lp-handle">${this._escapeHtml(data.handle)}</span>`;
+          meta += '</div>';
+        } else if (data.title) {
+          meta += `<span class="link-preview-title">${this._escapeHtml(data.title)}</span>`;
+        }
+        const textContent = data.text || data.description;
+        if (textContent) meta += `<span class="lp-text">${this._escapeHtml(textContent)}</span>`;
+
+        // Media — gallery grid, inline player, or image (with play badge if a
+        // non-inline video is linked, e.g. a Bluesky video post).
+        let media = '';
         if (hasGallery) {
           const count = Math.min(data.images.length, 4);
-          inner += `<div class="link-preview-gallery" data-count="${count}">`;
+          media += `<div class="link-preview-gallery" data-count="${count}">`;
           data.images.slice(0, 4).forEach(imgUrl => {
-            inner += `<img class="link-preview-gallery-img" src="${this._escapeHtml(imgUrl)}" alt="">`;
+            media += `<img class="link-preview-gallery-img" src="${this._escapeHtml(imgUrl)}" alt="" loading="lazy">`;
           });
-          inner += '</div>';
+          media += '</div>';
+        } else if (isInlineVideo) {
+          media += `<video class="lp-video" controls preload="metadata" playsinline${data.image ? ` poster="${this._escapeHtml(data.image)}"` : ''}><source src="${this._escapeHtml(data.video)}" type="${this._escapeHtml(data.videoType || 'video/mp4')}"></video>`;
         } else if (data.image) {
-          inner += `<img class="link-preview-image" src="${this._escapeHtml(data.image)}" alt="">`;
+          media += `<a class="lp-media" href="${this._escapeHtml(url)}" target="_blank" rel="noopener noreferrer nofollow"><img class="lp-image" src="${this._escapeHtml(data.image)}" alt="" loading="lazy">${data.video ? '<span class="lp-play"></span>' : ''}</a>`;
         }
-        inner += '<div class="link-preview-text">';
-        if (data.siteName) inner += `<span class="link-preview-site">${this._escapeHtml(data.siteName)}</span>`;
-        if (data.title) inner += `<span class="link-preview-title">${this._escapeHtml(data.title)}</span>`;
-        if (data.description) inner += `<span class="link-preview-desc">${this._escapeHtml(data.description).slice(0, 200)}</span>`;
-        inner += '</div>';
-        card.innerHTML = inner;
+
+        // Engagement stats (Bluesky / X) — skip any the source didn't provide.
+        let stats = '';
+        if (data.stats) {
+          const parts = [['💬', data.stats.replies], ['🔁', data.stats.reposts], ['❤️', data.stats.likes], ['👁', data.stats.views]]
+            .map(([icon, v]) => { const c = this._cnt(v); return c == null ? null : `<span>${icon} ${c}</span>`; })
+            .filter(Boolean);
+          if (parts.length) stats = `<div class="lp-stats">${parts.join('')}</div>`;
+        }
+
+        card.innerHTML =
+          this._embedHeaderHtml(data.siteName, collapsed) +
+          '<div class="lp-content">' +
+            (meta ? `<a class="lp-meta" href="${this._escapeHtml(url)}" target="_blank" rel="noopener noreferrer nofollow">${meta}</a>` : '') +
+            media +
+            stats +
+          '</div>';
+        this._wireEmbedControls(card, url);
 
         const wasAtBottom = this._coupledToBottom;
         msgContent.appendChild(card);
@@ -1505,6 +1532,51 @@ _fetchLinkPreviews(containerEl) {
       })
       .catch(() => {});
   });
+},
+
+// ── Shared embed chrome (size toggle + per-message collapse) ──────────
+// Mirrors the Haven mobile app's embed controls. The global Full/Medium/Small/Off
+// size preference is the shared one driven by the Settings picker (_embedSize /
+// _applyEmbedSize live in app-media.js); the per-card ⤢ button is a quick cycle
+// through Full→Medium→Small (Off stays Settings-only so the button can't hide
+// itself), and the ▾/▸ caret collapses a single embed for this session.
+
+/** Header row markup: site name (accent), size cycle button, collapse caret. */
+_embedHeaderHtml(siteName, collapsed) {
+  const size = this._embedSize();
+  const label = size.charAt(0).toUpperCase() + size.slice(1);
+  return '<div class="lp-header">'
+    + `<span class="lp-site">${this._escapeHtml(siteName || 'Link')}</span>`
+    + `<button type="button" class="lp-size" title="Embed size (Settings ▸ Link Previews for Off)">⤢ ${label}</button>`
+    + `<button type="button" class="lp-collapse" title="Collapse">${collapsed ? '▸' : '▾'}</button>`
+    + '</div>';
+},
+
+/** Wire the size + collapse buttons on a freshly-built embed card. */
+_wireEmbedControls(card, url) {
+  const sizeBtn = card.querySelector('.lp-size');
+  if (sizeBtn) sizeBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    const order = ['full', 'medium', 'small'];
+    this._applyEmbedSize(order[(order.indexOf(this._embedSize()) + 1) % order.length]);
+  });
+  const colBtn = card.querySelector('.lp-collapse');
+  if (colBtn) colBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    const isCol = card.classList.toggle('lp-collapsed');
+    isCol ? this._collapsedEmbeds.add(url) : this._collapsedEmbeds.delete(url);
+    colBtn.textContent = isCol ? '▸' : '▾';
+  });
+},
+
+/** Compact engagement count (1.2K / 3.4M); null for missing/negative values. */
+_cnt(n) {
+  if (n == null || n < 0) return null;
+  if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, '') + 'M';
+  if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, '') + 'K';
+  return String(n);
 },
 
 /**

--- a/server.js
+++ b/server.js
@@ -2317,32 +2317,47 @@ app.get('/api/link-preview', async (req, res) => {
   try {
     let data = null;
 
-    // ── Site-specific oEmbed handlers ────────────────────
+    // ── Site-specific handlers ───────────────────────────
     // Native twitter.com / x.com — their HTML requires JS rendering so the generic
-    // scraper gets blank OG tags. The oEmbed API returns structured data directly.
-    // NOTE: fxtwitter / vxtwitter / fixupx are proxy sites that deliberately serve
-    // their own OG-enriched HTML — they must NOT be routed here; they fall through
-    // to the generic OG scraper below which picks up their tags directly.
-    const twitterMatch = url.match(/^https?:\/\/(?:(?:www\.|mobile\.)?(?:twitter|x)\.com)\/\w+\/status\/\d+/i);
+    // scraper gets blank OG tags. The fxtwitter public JSON API returns structured
+    // post data (author, avatar, text, media, engagement counts) with no auth, so
+    // the client can render a rich social card matching the mobile app's embeds.
+    // NOTE: fxtwitter / vxtwitter / fixupx proxy URLs are NOT matched here; they
+    // serve their own OG-enriched HTML and fall through to the generic scraper.
+    const twitterMatch = url.match(/^https?:\/\/(?:(?:www\.|mobile\.)?(?:twitter|x)\.com)\/([A-Za-z0-9_]{1,20})\/status(?:es)?\/(\d+)/i);
     if (twitterMatch) {
       try {
-        const oembed = await fetch(
-          `https://publish.twitter.com/oembed?url=${encodeURIComponent(url)}&omit_script=true`,
+        const fxApi = await fetch(
+          `https://api.fxtwitter.com/${twitterMatch[1]}/status/${twitterMatch[2]}`,
           { signal: AbortSignal.timeout(6000), headers: { 'User-Agent': PREVIEW_UA } }
         );
-        if (oembed.ok) {
-          const oj = await oembed.json();
-          // Strip HTML tags from the embedded HTML to extract text
-          const text = (oj.html || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-          data = {
-            title: oj.author_name ? `${oj.author_name} on ${oj.provider_name || 'X'}` : (oj.provider_name || 'X'),
-            description: text.slice(0, 280) || null,
-            image: null, // Twitter oEmbed doesn't return images, OG scrape below may add one
-            siteName: oj.provider_name || 'X',
-            url: oj.url || url
-          };
+        if (fxApi.ok) {
+          const tw = (await fxApi.json())?.tweet;
+          if (tw) {
+            const a = tw.author || {};
+            const photos = (tw.media?.photos || []).map(p => p.url).filter(Boolean);
+            const vid = tw.media?.videos?.[0] || null;
+            const text = tw.text || '';
+            data = {
+              kind: 'twitter',
+              siteName: 'X / Twitter',
+              accentColor: '#1d9bf0',
+              author: a.name || null,
+              handle: a.screen_name ? `@${a.screen_name}` : null,
+              avatar: a.avatar_url || null,
+              title: a.name ? `${a.name} on X` : 'X / Twitter',
+              text: text || null,
+              description: text.slice(0, 280) || null,
+              image: vid?.thumbnail_url || photos[0] || null,
+              images: photos.length >= 2 ? photos.slice(0, 4) : undefined,
+              video: vid?.url || null,
+              videoType: vid?.url ? 'video/mp4' : undefined,
+              stats: { replies: tw.replies ?? -1, reposts: tw.retweets ?? -1, likes: tw.likes ?? -1, views: tw.views ?? -1 },
+              url
+            };
+          }
         }
-      } catch { /* fall through to generic scrape */ }
+      } catch { /* fall through to fxtwitter OG scrape / generic */ }
     }
 
     // ── fxtwitter / vxtwitter / fixupx fallback for native Twitter/X links ──
@@ -2484,12 +2499,21 @@ app.get('/api/link-preview', async (req, res) => {
               } else if (mType.startsWith('app.bsky.embed.external')) {
                 image = media.external?.thumb || null;
               }
+              const text = post.record?.text || '';
               data = {
+                kind: 'bsky',
+                siteName: 'Bluesky',
+                accentColor: '#0085ff',
+                author: name,
+                handle: author.handle ? `@${author.handle}` : null,
+                avatar: author.avatar || null,
                 title: `${name} on Bluesky`,
-                description: (post.record?.text || '').slice(0, 280) || null,
+                text: text || null,
+                description: text.slice(0, 280) || null,
                 image,
                 images,
-                siteName: 'Bluesky',
+                video: mType.startsWith('app.bsky.embed.video') ? url : null,
+                stats: { replies: post.replyCount ?? -1, reposts: post.repostCount ?? -1, likes: post.likeCount ?? -1, views: -1 },
                 url
               };
             }


### PR DESCRIPTION
## What

Renders link previews as **rich embed cards** for Bluesky and X/Twitter — a per-site accent stripe, author avatar + name/@handle, post text, sized media (with a play badge for videos), and engagement stats (replies / reposts / likes / views) — bringing the desktop/web client in line with the Haven mobile app's embeds. Generic links and YouTube use the same chrome.

## Why

`/api/link-preview` already returned structured data for X, Reddit, Pixiv and Bluesky, but everything was flattened to `{ title, description, image }` and drawn as a plain card. The richer data (author, avatar, engagement counts) was fetched and then discarded, so a Bluesky/X link looked far plainer than the same post in the mobile app. This was a recurring request from server members who'd seen the mobile embeds.

## How

**Server (`server.js`)** — `/api/link-preview` now also returns `kind`, `author`, `handle`, `avatar`, `text`, `accentColor` and `stats`:
- **X/Twitter** switches from the bare `publish.twitter.com` oEmbed to the **fxtwitter public JSON API**, which provides the author avatar, post text, media and engagement counts (no auth).
- **Bluesky** is enriched from the post data it was already hydrating via the public AT Protocol app view (still no auth).
- The existing `title` / `description` / `image` / `images` fields are **unchanged**, so older clients and any other callers are unaffected.

**Client (`public/js/modules/app-messages.js`)** — the single `_fetchLinkPreviews` renderer (used by chat, DMs and the DM PiP) builds the unified card: accent header, author row, post text, gallery / inline video / image-with-play-overlay, and the stat row. All interpolated values are escaped; the accent color is regex-validated before it touches `style`.

**Embed size + collapse** — consolidated into **one** preference shared by the Settings ▸ Link Previews picker and a new per-embed **⤢** toggle:
- Modes are now **Off / Small / Medium / Full** (legacy `normal → medium`, `large → full` are migrated automatically).
- The per-embed **⤢** quick-cycles Full → Medium → Small; **Off** stays in Settings so the toggle can't hide itself.
- A per-embed **▾/▸** caret collapses a single preview for the session.

YouTube keeps its inline iframe, now wrapped in the same header/size/collapse chrome.

## Testing

- `node --check` passes on `server.js`, `app-messages.js`, `app-media.js`.
- The Bluesky and fxtwitter handlers were verified against the live public APIs (correct author, avatar, text, media and counts; multi-image posts populate `images[]`). No credentials required.
- Rendered the card markup in a headless browser across Full / Medium / Small / collapsed states.
