### PR TITLE
feat: add PUBLIC_URL env var for OAuth/OpenID callback URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,13 @@ ADMIN_USERNAME=admin
 # Set to true to skip SSL even if certificates exist.
 # FORCE_HTTP=false
 
+# Public-facing URL for OAuth/OpenID callbacks.
+# Set this when the server cannot determine its own external address —
+# for example Docker port mapping (8080→3000), reverse proxies that strip
+# the port, or Cloudflare Tunnels. Must include the scheme (https://).
+# Example: PUBLIC_URL=https://haven.example.com:8443
+# PUBLIC_URL=
+
 # Optional: Override the data directory location
 # HAVEN_DATA_DIR=
 

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -33,6 +33,14 @@ const { verifyToken } = require('./auth');
 const SPOTIFY_SCOPES = 'user-read-currently-playing user-read-playback-state';
 
 function baseUrl(req) {
+  // PUBLIC_URL is the canonical answer when the server can't guess its own
+  // external address — e.g. Docker port mapping (8080→3000), reverse proxy
+  // that strips the port from the Host header, or Cloudflare Tunnels.
+  // Set it in .env and both Steam and Spotify callbacks will use exactly that.
+  // Example: PUBLIC_URL=https://haven.example.com:8443
+  const override = (process.env.PUBLIC_URL || '').trim().replace(/\/+$/, '');
+  if (override) return override;
+
   // Honours X-Forwarded-Proto/Host when the app has 'trust proxy' set, which
   // matters because Haven is usually behind Traefik/nginx terminating TLS.
   return `${req.protocol}://${req.get('host')}`;


### PR DESCRIPTION
When Haven runs behind Docker port mapping (8080->3000), a reverse proxy that strips the port from the Host header, or a Cloudflare Tunnel, the server can't reliably guess its own public-facing URL. This causes Steam and Spotify callback URLs to be wrong.

Add PUBLIC_URL environment variable. When set, baseUrl() uses it explicitly instead of trying to derive from req.protocol + Host. Covers all callback URL construction in connectRoutes.js (Steam OpenID return_to/realm and Spotify OAuth redirect_uri).