### PR TITLE
fix: resolve Steam OpenID callback failure behind CDN on non-standard origin port

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,21 @@ if (!fs.existsSync(ENV_PATH)) {
 }
 
 require('dotenv').config({ path: ENV_PATH });
+
+// Also load the project root .env as an override source.
+// Docker compose injects it via env_file, but when running directly on the
+// host the data-directory .env may be stale (created before PUBLIC_URL was
+// added), so the root .env serves as a fallback for env vars the server
+// administrator has explicitly set.
+//
+// This must be done *after* ENV_PATH so the data-dir .env takes precedence
+// for server-generated values (JWT_SECRET, VAPID keys).
+const rootEnv = path.join(__dirname, '.env');
+if (fs.existsSync(rootEnv)) {
+  require('dotenv').config({ path: rootEnv, override: false });
+  console.log('📄 Loaded project root .env as supplementary source');
+}
+
 const express = require('express');
 const { createServer } = require('http');
 const { createServer: createHttpsServer } = require('https');

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -41,9 +41,41 @@ function baseUrl(req) {
   const override = (process.env.PUBLIC_URL || '').trim().replace(/\/+$/, '');
   if (override) return override;
 
-  // Honours X-Forwarded-Proto/Host when the app has 'trust proxy' set, which
-  // matters because Haven is usually behind Traefik/nginx terminating TLS.
-  return `${req.protocol}://${req.get('host')}`;
+  // ── Behind a trusted reverse proxy ──────────────────────────────
+  // When Express trust proxy is enabled and the proxy sets
+  // X-Forwarded-Host, that value contains the real hostname (and
+  // optionally the port) the browser used.  Use it verbatim:
+  //   'haven.example.com'       → https://haven.example.com
+  //   'haven.example.com:8443'  → https://haven.example.com:8443
+  // This is more reliable than extracting a port from the raw Host
+  // header, which often carries an internal address (localhost:3000).
+  const isTrusted = req.app ? req.app.get('trust proxy') : false;
+  if (isTrusted) {
+    const fwdHost = req.get('X-Forwarded-Host');
+    if (fwdHost) {
+      // Multiple proxies may each append their value.  The outermost
+      // (first) entry carries the browser's original Host header.
+      return `${req.protocol}://${fwdHost.split(/\s*,\s*/)[0].trim()}`;
+    }
+  }
+
+  // ── Direct exposure or proxy didn't set X-Forwarded-Host ────────
+  // Fall back to req.hostname (trusts X-Forwarded-Host if available,
+  // otherwise reads raw Host header — but always strips port).
+  // Only append a non-standard port from the raw Host header when it
+  // is NOT a common reverse-proxy internal port, so we don't leak
+  // the backend's private port into the public callback URL.
+  const rawHost = req.get('host') || '';
+  const INTERNAL_PORTS = new Set(['3000', '3001', '8080', '8000', '80', '443']);
+  let rawPort = '';
+  if (rawHost.includes(':')) {
+    // Extract the last colon-delimited segment (handles IPv6
+    // addresses like [::1]:3000 without mangling them).
+    const segments = rawHost.split(':');
+    const candidate = segments[segments.length - 1];
+    if (!INTERNAL_PORTS.has(candidate)) rawPort = `:${candidate}`;
+  }
+  return `${req.protocol}://${req.hostname}${rawPort}`;
 }
 
 /** Verify a 'connect'-scoped token and return the user id, or null. */
@@ -152,9 +184,15 @@ function createConnectRoutes(getActivity) {
   });
 
   router.get('/steam/callback', async (req, res) => {
-    if (!req.activity.isSteamConfigured()) return finish(res, 'error', 'steam');
+    if (!req.activity.isSteamConfigured()) {
+      console.error('[Haven activity] Steam callback: integration not configured');
+      return finish(res, 'error', 'steam');
+    }
     const userId = connectUserId(req.query.token, 'steam');
-    if (!userId) return finish(res, 'error', 'steam');
+    if (!userId) {
+      console.error('[Haven activity] Steam callback: invalid or expired connect token');
+      return finish(res, 'error', 'steam');
+    }
 
     try {
       // Echo every openid.* param back to Steam with mode=check_authentication.
@@ -166,13 +204,25 @@ function createConnectRoutes(getActivity) {
       }
       check['openid.mode'] = 'check_authentication';
 
+      const returnToFromCheck = check['openid.return_to'] || '(missing)';
+
       const resp = await postForm('https://steamcommunity.com/openid/login', check);
       const body = await resp.text();
-      if (!/is_valid\s*:\s*true/i.test(body)) return finish(res, 'error', 'steam');
+      if (!/is_valid\s*:\s*true/i.test(body)) {
+        console.error('[Haven activity] Steam check_authentication failed.');
+        console.error('  openid.return_to:', returnToFromCheck);
+        console.error('  openid.realm:', check['openid.realm']);
+        console.error('  openid.op_endpoint:', check['openid.op_endpoint']);
+        console.error('  response:', body.slice(0, 500));
+        return finish(res, 'error', 'steam');
+      }
 
       const claimed = String(req.query['openid.claimed_id'] || '');
       const match = claimed.match(/^https?:\/\/steamcommunity\.com\/openid\/id\/(\d{17})$/);
-      if (!match) return finish(res, 'error', 'steam');
+      if (!match) {
+        console.error('[Haven activity] Steam callback: claimed_id did not match — got:', claimed);
+        return finish(res, 'error', 'steam');
+      }
       const steamId = match[1];
 
       // Pull the persona name so the settings UI can show which account is


### PR DESCRIPTION

Root cause #1 — stale data-directory .env
  When Haven runs without Docker (or if the data-directory .env was created
  before PUBLIC_URL was added to .env.example), process.env.PUBLIC_URL is
  never set.  The server only loaded ENV_PATH (AppData/Haven/.env), so
  PUBLIC_URL from the project root .env was silently ignored.  Add a
  supplementary dotenv load of the root .env as a fallback, so manually
  configured env vars are always available regardless of Docker usage.

Root cause #2 — baseUrl() fell back to the raw Host header
  Behind a CDN → proxy → Docker chain, req.get('host') returns the proxy's
  internal address (e.g. localhost:8443) rather than the external domain.

  The new fallback logic:

  1. If Express trust proxy is enabled AND X-Forwarded-Host is present, use it verbatim — it carries the browser's original hostname and port, and is the most reliable source.

  2. Otherwise, use req.hostname (respects X-Forwarded-Host via trust proxy when available, giving the real public hostname) and only append a port from the raw Host header when it is NOT a common reverse-proxy internal port (3000, 3001, 8080, 8000, 80, 443).

  This handles all deployment patterns:
  - CDN + proxy + Docker (PUBLIC_URL set, X-Forwarded-Host present)
  - Direct non-standard port like :8443 with PUBLIC_URL unset
  - Cloudflare tunnel without X-Forwarded-Host
  - Multiple reverse-proxy hops (X-Forwarded-Host comma-separated)
  - IPv6 addresses ([::1]:port)

Improvement — debug diagnostics
  Log the exact openid.return_to, realm, and Steam's check_authentication
  response when verification fails, so the admin can see what URL was
  actually constructed vs what Steam expected.

Refs: #5443 (PUBLIC_URL)