### PR TITLE
[fix] :emoji autocomplete menu dying under specific circumstances

### DIFF
--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -1951,7 +1951,19 @@ _checkEmojiTrigger(inputEl) {
 },
 
 _showEmojiDropdown(query) {
-  const dd = document.getElementById('emoji-dropdown');
+  // #emoji-dropdown is a single shared node re-parented next to the active
+  // input (#5296). Opening the suggestions inside an inline message-edit box
+  // parks it in that message; saving/cancelling the edit wipes the message's
+  // HTML and deletes the node, so every later `:emoji` throws on the null
+  // element and autocomplete dies until a refresh. The node holds no state
+  // (its contents are rebuilt below), so recreate it if it's missing.
+  let dd = document.getElementById('emoji-dropdown');
+  if (!dd) {
+    dd = document.createElement('div');
+    dd.id = 'emoji-dropdown';
+    dd.className = 'emoji-dropdown';
+    dd.style.display = 'none';
+  }
   // Re-parent so the absolute-positioned dropdown anchors above the active
   // input (works for thread input + DM PiP input + main input). (#5296)
   const host = (this._emojiAcInput && this._emojiAcInput.parentElement) || null;


### PR DESCRIPTION
Steps to reproduce:
1. Edit an existing message, and type :emoji_name to open the emoji autosuggest menu. You do not have to select an emoji.
2. Cancel or save the edit,  either one triggers it.
3. Back in the main chatbox, typing :emoji_name to open the emoji menu throws a `dd is null` exception and the menu will not open anywhere.

Workaround before this fix: refresh the page.

The #emoji-dropdown autocomplete box is a single shared node that #5296 re-parents next to whichever input is active. Opening the suggestions inside an inline message-edit box parks that node inside the message; saving or cancelling the edit runs contentEl.innerHTML = originalHtml, which deletes it. From then on document.getElementById('emoji-dropdown') returns null, and _showEmojiDropdown threw on dd.parentElement — silently killing :emoji autocomplete everywhere (including the main composer) until a full page refresh.

The node holds no state (its contents are rebuilt on every open), so guard the lookup and recreate it when missing. Robust to any teardown path, not just the edit box.