### PR TITLE
[feat] Emoji menu shortcuts

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6985,6 +6985,9 @@ details.sound-section:not([open]) .sound-section-label::before {
   max-height: 240px;
   padding: 2px;
   position: relative; /* offsetParent for category sections, so tab clicks can scroll to them */
+  /* Reserve the sticky .emoji-cat-header strip (26px) so keyboard scrollIntoView
+     lands emoji below the header instead of tucked underneath it. */
+  scroll-padding-top: 26px;
 }
 
 .emoji-cat-grid {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -7026,6 +7026,13 @@ details.sound-section:not([open]) .sound-section-label::before {
   transform: scale(1.2);
 }
 
+/* Keyboard selection highlight (arrow-key navigation in the picker) */
+.emoji-item.kb-active {
+  background: var(--bg-tertiary);
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 /* ── Stickers ───────────────────────────────────────── */
 /* Inline rendered sticker in messages — larger than chat-image, no background. */
 .sticker-img {

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -1774,6 +1774,12 @@ _setupUI() {
       e.preventDefault();
       this._openQuickSwitcher();
     }
+    // Ctrl+E = toggle emoji picker (open/close)
+    if ((e.ctrlKey || e.metaKey) && e.key === 'e' && this.currentChannel) {
+      e.preventDefault();
+      this._emojiPickerContext = 'main';
+      this._toggleEmojiPicker();
+    }
     // Alt+ArrowUp/Down = navigate channels
     if (e.altKey && !e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
       e.preventDefault();

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -1797,6 +1797,10 @@ _setupUI() {
       document.getElementById('theme-popup').style.display = 'none';
       document.getElementById('quick-switcher-overlay')?.remove();
       document.querySelectorAll('.modal-overlay').forEach(m => m.style.display = 'none');
+      // Close the emoji picker too. Reuse its toggle so the parent/anchor
+      // restore runs, and only when it's open so Escape can't open it.
+      const emojiPicker = document.getElementById('emoji-picker');
+      if (emojiPicker && emojiPicker.style.display === 'flex') this._toggleEmojiPicker();
     }
   });
 

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -1417,6 +1417,14 @@ _toggleEmojiPicker(anchorEl) {
     parent.appendChild(btn);
   }
 
+  // Keyboard nav: highlight the first emoji so arrow keys + Enter work the
+  // moment the picker opens (Discord-style). Re-run after every grid render.
+  const highlightFirstEmoji = () => {
+    grid.querySelectorAll('.emoji-item.kb-active').forEach(el => el.classList.remove('kb-active'));
+    const first = grid.querySelector('.emoji-item');
+    if (first) first.classList.add('kb-active');
+  };
+
   function renderGrid(filter) {
     grid.innerHTML = '';
     for (const k in catSections) delete catSections[k];
@@ -1451,6 +1459,7 @@ _toggleEmojiPicker(anchorEl) {
       results.className = 'emoji-cat-grid';
       matched.forEach(e => appendEmojiButton(results, e));
       grid.appendChild(results);
+      highlightFirstEmoji();
       return;
     }
     // No filter: render every category as its own section (sticky header +
@@ -1470,6 +1479,7 @@ _toggleEmojiPicker(anchorEl) {
       grid.appendChild(section);
       catSections[cat] = section;
     }
+    highlightFirstEmoji();
   }
 
   // Scroll-spy: highlight the tab of whichever section is at the top. Compares
@@ -1495,6 +1505,44 @@ _toggleEmojiPicker(anchorEl) {
   });
 
   renderGrid();
+
+  // Arrow-key navigation + Enter to pick, bound once to the picker. Reads its
+  // state from the DOM on each keypress so it survives the grid being rebuilt
+  // on search/category changes. Enter reuses the emoji's own click handler, so
+  // there's a single source of truth for what "picking" an emoji does.
+  if (!picker._havenNavBound) {
+    picker._havenNavBound = true;
+    picker.addEventListener('keydown', (e) => {
+      if (picker.style.display === 'none') return;
+      const items = [...picker.querySelectorAll('.emoji-grid .emoji-item')];
+      if (!items.length) return;
+      const active = picker.querySelector('.emoji-item.kb-active');
+      const setActive = (el) => {
+        if (!el) return;
+        items.forEach(i => i.classList.remove('kb-active'));
+        el.classList.add('kb-active');
+        el.scrollIntoView({ block: 'nearest' });
+      };
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        const idx = active ? items.indexOf(active) : -1;
+        if (idx === -1) { setActive(items[0]); return; }
+        if (e.key === 'ArrowRight') setActive(items[Math.min(idx + 1, items.length - 1)]);
+        else if (e.key === 'ArrowLeft') setActive(items[Math.max(idx - 1, 0)]);
+        else setActive(this._emojiGridVerticalNav(items, idx, e.key === 'ArrowDown' ? 1 : -1));
+      } else if (e.key === 'Enter' && active) {
+        e.preventDefault();
+        active.click(); // insert the selected emoji (same as clicking it)
+        if (e.shiftKey) {
+          // Shift+Enter: keep the menu open to pick more; clicking moved focus
+          // to the message box, so hand it back to the search field.
+          picker.querySelector('.emoji-search-input')?.focus();
+        } else {
+          this._toggleEmojiPicker(); // plain Enter closes after one pick
+        }
+      }
+    });
+  }
 
   // On mobile with the iOS keyboard open, dynamically position the picker
   // above the input area using the visual viewport so it doesn't push
@@ -1528,6 +1576,26 @@ _toggleEmojiPicker(anchorEl) {
 
   picker.style.display = 'flex';
   searchInput.focus();
+},
+
+// Find the emoji one visual row above/below the current one (dir: -1 up, 1 down).
+// Emoji wrap into rows of varying counts across category sections, so this walks
+// by geometry rather than a fixed column count: nearest row wins first, then the
+// closest horizontal neighbour in that row.
+_emojiGridVerticalNav(items, idx, dir) {
+  const cur = items[idx].getBoundingClientRect();
+  const curX = cur.left + cur.width / 2;
+  const curY = cur.top + cur.height / 2;
+  let best = null, bestScore = Infinity;
+  for (let i = 0; i < items.length; i++) {
+    if (i === idx) continue;
+    const r = items[i].getBoundingClientRect();
+    const dy = (r.top + r.height / 2) - curY;
+    if (dir === 1 ? dy <= 2 : dy >= -2) continue; // must be strictly below/above
+    const score = Math.abs(dy) * 1000 + Math.abs((r.left + r.width / 2) - curX);
+    if (score < bestScore) { bestScore = score; best = items[i]; }
+  }
+  return best || items[idx];
 },
 
 // ═══════════════════════════════════════════════════════

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -1368,7 +1368,12 @@ _toggleEmojiPicker(anchorEl) {
       const section = catSections[cat];
       // Scroll to the section wrapper, not its header: the wrapper isn't
       // sticky, so its offsetTop is always the true layout position.
-      if (section) grid.scrollTop = section.offsetTop;
+      if (section) {
+        grid.scrollTop = section.offsetTop;
+        // Move the keyboard highlight to this category's first emoji, so
+        // arrowing/Enter continues from where the user just jumped to.
+        highlightFirstEmoji(section);
+      }
       setActiveTab(cat);
     });
     catTabs[cat] = tab;
@@ -1419,9 +1424,11 @@ _toggleEmojiPicker(anchorEl) {
 
   // Keyboard nav: highlight the first emoji so arrow keys + Enter work the
   // moment the picker opens (Discord-style). Re-run after every grid render.
-  const highlightFirstEmoji = () => {
+  // Pass a section to highlight the first emoji within it (e.g. after a
+  // category jump); defaults to the first emoji in the whole grid.
+  const highlightFirstEmoji = (scope) => {
     grid.querySelectorAll('.emoji-item.kb-active').forEach(el => el.classList.remove('kb-active'));
-    const first = grid.querySelector('.emoji-item');
+    const first = (scope || grid).querySelector('.emoji-item');
     if (first) first.classList.add('kb-active');
   };
 
@@ -1576,6 +1583,12 @@ _toggleEmojiPicker(anchorEl) {
 
   picker.style.display = 'flex';
   searchInput.focus();
+
+  // Always open scrolled to the top, so the view and the keyboard highlight
+  // both start on the first category in every browser. Chromium discards the
+  // old scroll when the grid is rebuilt; Firefox/Safari can preserve it, which
+  // would leave the view on the last-used category while the highlight resets.
+  grid.scrollTop = 0;
 },
 
 // Find the emoji one visual row above/below the current one (dir: -1 up, 1 down).


### PR DESCRIPTION
The goal of this PR is to allow users to insert emojis into their messages quicker and more comfortably without having to take their hands off the keyboard. Discord's emoji menu already behaves this way, and since most Haven users are migrating from Discord, it makes perfect sense to implement these features similar to the way Discord does. 

## Main features
- Ctrl+E is now registered as a global hotkey and toggles the open state for the emoji menu
- Added a selection box for emojis that is controllable with arrow keys
- Upon selecting desired emoji, pressing Enter will insert that emoji and automatically close the emoji menu. Shift+Enter will insert the emoji but not close the emoji menu
- Escape now closes the emoji menu

## Also includes
- The first emoji is highlighted the moment the menu opens (and after every search or category change), so Enter works immediately without arrowing first
- Clicking a category tab moves the highlight to that category's first emoji, so keyboard and mouse navigation stay in sync
- The highlight box is theme-aware and uses each theme's own accent color, so it looks right in all of them

## Bug fixes
- Upon opening the emoji menu, the menu's scroll position is always reset to the top. Firefox was preserving the previous scroll position across reopens while Chromium wasn't, which left the view and the highlight on different categories
- Arrowing up to the very first emoji no longer tucks it under the sticky category header

## How it works
Under the hood, none of this reimplements how an emoji actually gets inserted. Pressing Enter on a highlighted emoji just fires that emoji's existing click handler, so the keyboard and mouse paths always stay in sync, and Ctrl+E reuses the same toggle the emoji button already calls. The arrow-key selection is a single highlight class that moves through the grid, with up/down worked out from the emojis' real on-screen positions so it stays correct across categories that wrap into different numbers of rows.