### PR TITLE
[feat] Rem interface zoom that scales the whole UI

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -544,7 +544,7 @@
         <div id="sb-sidebar-resize-handle" class="sb-sidebar-resize-handle"></div>
         <div class="sb-sidebar-header">&#x1F3B5; Soundboard</div>
         <div class="sb-sidebar-body">
-          <input type="text" id="sb-sidebar-search" placeholder="Search sounds..." class="settings-text-input" style="width:100%;box-sizing:border-box;font-size:12px">
+          <input type="text" id="sb-sidebar-search" placeholder="Search sounds..." class="settings-text-input" style="width:100%;box-sizing:border-box;font-size:0.75rem">
           <div id="sb-sidebar-grid" class="soundboard-grid sidebar-mode"></div>
         </div>
       </aside>
@@ -559,7 +559,7 @@
         <div class="right-sidebar-voice" id="right-sidebar-voice">
           <div class="panel">
             <div class="voice-panel-header">
-              <h5 class="panel-title" style="margin-bottom:0">🔊 <span data-i18n="right_sidebar.voice_title">Voice</span></h5>
+              <h5 class="panel-title" style="margin-bottom:0"><span class="title-emoji">🔊 </span><span data-i18n="right_sidebar.voice_title">Voice</span></h5>
               <button id="mobile-right-close" class="mobile-panel-close mobile-panel-close-right" data-i18n-title="modals.common.close" data-i18n-aria-label="right_sidebar.close_panel" title="Close" aria-label="Close panel">&times;</button>
               <div class="voice-header-actions">
                 <button id="voice-mute-btn-header" class="voice-header-btn" data-i18n-title="voice.mute" title="Mute" style="display:none">🎙️</button>
@@ -575,7 +575,7 @@
         <!-- Scrollable users section -->
         <div class="right-sidebar-users" id="right-sidebar-users">
           <div class="panel">
-            <h5 class="panel-title">👥 <span data-i18n="right_sidebar.online_title">Online</span></h5>
+            <h5 class="panel-title"><span class="title-emoji">👥 </span><span data-i18n="right_sidebar.online_title">Online</span></h5>
             <div id="online-users" class="user-list">
               <p class="muted-text" data-i18n="right_sidebar.select_channel">Select a channel</p>
             </div>
@@ -1228,7 +1228,7 @@
       <!-- Soundboard Sidebar Setting -->
       <div class="settings-section" id="section-soundboard-mode" style="border-top: 1px solid var(--border-light); padding-top: 14px; margin-top: 8px;">
         <h5 class="settings-section-title">🎵 Soundboard</h5>
-        <label class="checkbox-row" style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px">
+        <label class="checkbox-row" style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:0.8125rem">
           <input type="checkbox" id="soundboard-sidebar-mode-settings" style="cursor:pointer">
           Sidebar mode
         </label>
@@ -1237,25 +1237,14 @@
 
       <!-- Font Size -->
       <div class="settings-section" id="section-font-size" style="border-top: 1px solid var(--border-light); padding-top: 16px; margin-top: 8px;">
-        <h5 class="settings-section-title">🔤 <span data-i18n="settings.font_size.title">Font Size</span></h5>
-        <div class="font-size-picker" id="font-size-picker">
-          <button type="button" class="density-btn" data-fontsize="small" data-i18n-title="settings.font_size.small_hint" title="Small — 13px base">
-            <span class="density-icon" style="font-size:11px">A</span>
-            <span class="density-label" data-i18n="settings.font_size.small">Small</span>
-          </button>
-          <button type="button" class="density-btn active" data-fontsize="normal" data-i18n-title="settings.font_size.normal_hint" title="Normal — 15px base (default)">
-            <span class="density-icon" style="font-size:14px">A</span>
-            <span class="density-label" data-i18n="settings.font_size.normal">Normal</span>
-          </button>
-          <button type="button" class="density-btn" data-fontsize="large" data-i18n-title="settings.font_size.large_hint" title="Large — 17px base">
-            <span class="density-icon" style="font-size:17px">A</span>
-            <span class="density-label" data-i18n="settings.font_size.large">Large</span>
-          </button>
-          <button type="button" class="density-btn" data-fontsize="x-large" data-i18n-title="settings.font_size.xl_hint" title="Extra Large — 20px base">
-            <span class="density-icon" style="font-size:20px">A</span>
-            <span class="density-label" data-i18n="settings.font_size.xl">XL</span>
-          </button>
+        <h5 class="settings-section-title">🔍 <span data-i18n="settings.zoom.title">Zoom</span></h5>
+        <div class="zoom-control" id="zoom-control">
+          <button type="button" class="zoom-step" id="zoom-out-btn" title="Zoom out" aria-label="Zoom out">−</button>
+          <input type="range" class="zoom-slider" id="ui-zoom-slider" min="70" max="150" step="5" value="100" aria-label="Interface zoom">
+          <button type="button" class="zoom-step" id="zoom-in-btn" title="Zoom in" aria-label="Zoom in">+</button>
+          <output class="zoom-value" id="ui-zoom-value" for="ui-zoom-slider">100%</output>
         </div>
+        <small class="settings-hint" style="margin-top:6px;display:block">Scales the whole interface. Drag for the exact size you want.</small>
       </div>
 
       <!-- Emoji Reaction Size -->
@@ -1263,19 +1252,19 @@
         <h5 class="settings-section-title">😀 Reaction Size</h5>
         <div class="font-size-picker" id="emoji-size-picker">
           <button type="button" class="density-btn" data-emojisize="small" title="Small reactions">
-            <span class="density-icon" style="font-size:11px">😀</span>
+            <span class="density-icon" style="font-size:0.6875rem">😀</span>
             <span class="density-label">Small</span>
           </button>
           <button type="button" class="density-btn active" data-emojisize="normal" title="Normal reactions (default)">
-            <span class="density-icon" style="font-size:14px">😀</span>
+            <span class="density-icon" style="font-size:0.875rem">😀</span>
             <span class="density-label">Normal</span>
           </button>
           <button type="button" class="density-btn" data-emojisize="large" title="Large reactions">
-            <span class="density-icon" style="font-size:18px">😀</span>
+            <span class="density-icon" style="font-size:1.125rem">😀</span>
             <span class="density-label">Large</span>
           </button>
           <button type="button" class="density-btn" data-emojisize="x-large" title="Extra large reactions">
-            <span class="density-icon" style="font-size:22px">😀</span>
+            <span class="density-icon" style="font-size:1.375rem">😀</span>
             <span class="density-label">XL</span>
           </button>
         </div>
@@ -1376,12 +1365,12 @@
       <!-- Banner Display (client-side) -->
       <div class="settings-section" id="section-banner-display" style="border-top: 1px solid var(--border-light); padding-top: 16px; margin-top: 8px; display:none;">
         <h5 class="settings-section-title">🏞️ Banner Display</h5>
-        <label style="margin-top:4px;display:flex;align-items:center;gap:8px;font-size:12px">
+        <label style="margin-top:4px;display:flex;align-items:center;gap:8px;font-size:0.75rem">
           <span style="white-space:nowrap">Banner height</span>
           <input type="range" id="banner-height-slider" min="80" max="400" step="10" value="180" style="flex:1">
           <span id="banner-height-value" style="min-width:36px;text-align:right;font-variant-numeric:tabular-nums">180px</span>
         </label>
-        <label style="margin-top:4px;display:flex;align-items:center;gap:8px;font-size:12px">
+        <label style="margin-top:4px;display:flex;align-items:center;gap:8px;font-size:0.75rem">
           <span style="white-space:nowrap">Vertical offset</span>
           <input type="range" id="banner-offset-slider" min="0" max="100" step="1" value="0" style="flex:1">
           <span id="banner-offset-value" style="min-width:30px;text-align:right;font-variant-numeric:tabular-nums">0%</span>
@@ -1678,11 +1667,11 @@
           </div>
           <p class="settings-hint" style="margin-bottom:4px" data-i18n="settings.two_factor_section.manual_hint">Or enter this secret manually:</p>
           <div style="display:flex;align-items:center;gap:6px;margin-bottom:12px">
-            <code id="totp-secret-text" style="font-size:14px;letter-spacing:2px;user-select:all;flex:1;word-break:break-all"></code>
+            <code id="totp-secret-text" style="font-size:0.875rem;letter-spacing:2px;user-select:all;flex:1;word-break:break-all"></code>
             <button class="btn-sm" id="totp-copy-secret" data-i18n-title="settings.two_factor_section.copy_secret_title" title="Copy secret" style="white-space:nowrap">📋 <span data-i18n="settings.two_factor_section.copy_secret_btn">Copy</span></button>
           </div>
           <div class="form-group compact">
-            <input type="text" id="totp-verify-code" data-i18n-placeholder="settings.two_factor_section.verify_placeholder" placeholder="Enter 6-digit code to confirm" maxlength="6" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code" style="text-align:center;font-size:18px;letter-spacing:6px">
+            <input type="text" id="totp-verify-code" data-i18n-placeholder="settings.two_factor_section.verify_placeholder" placeholder="Enter 6-digit code to confirm" maxlength="6" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code" style="text-align:center;font-size:1.125rem;letter-spacing:6px">
           </div>
           <button class="btn-sm btn-full" id="totp-verify-setup-btn" data-i18n="settings.two_factor_section.verify_btn">Verify & Activate</button>
           <button class="btn-sm btn-full" id="totp-cancel-setup-btn" data-i18n="modals.common.cancel" style="margin-top:6px;opacity:0.7">Cancel</button>
@@ -1693,7 +1682,7 @@
         <div id="totp-backup-area" style="display:none">
           <h5 style="margin-bottom:6px">🗝️ <span data-i18n="settings.two_factor_section.backup_title">Backup Codes</span></h5>
           <p class="settings-hint" style="margin-bottom:8px" data-i18n="settings.two_factor_section.backup_hint">Save these codes somewhere safe. Each can be used once if you lose access to your authenticator.</p>
-          <div id="totp-backup-codes" style="font-family:monospace;font-size:15px;line-height:2;background:var(--bg-primary);padding:12px;border-radius:8px;text-align:center;user-select:all"></div>
+          <div id="totp-backup-codes" style="font-family:monospace;font-size:0.9375rem;line-height:2;background:var(--bg-primary);padding:12px;border-radius:8px;text-align:center;user-select:all"></div>
           <button class="btn-sm btn-full" id="totp-copy-backup-btn" style="margin-top:8px">📋 <span data-i18n="settings.two_factor_section.copy_backup_btn">Copy Backup Codes</span></button>
           <button class="btn-sm btn-full" id="totp-backup-done-btn" data-i18n="settings.two_factor_section.done_btn" style="margin-top:6px">Done</button>
         </div>
@@ -1733,7 +1722,7 @@
         <!-- Codes display (shown after generation) -->
         <div id="recovery-codes-area" style="display:none">
           <p class="settings-hint" style="margin-bottom:8px" data-i18n="settings.recovery_section.save_hint">Save these codes now — they will not be shown again. Each code can only be used once.</p>
-          <div id="recovery-codes-list" style="font-family:monospace;font-size:15px;line-height:2;background:var(--bg-primary);padding:12px;border-radius:8px;text-align:center;user-select:all"></div>
+          <div id="recovery-codes-list" style="font-family:monospace;font-size:0.9375rem;line-height:2;background:var(--bg-primary);padding:12px;border-radius:8px;text-align:center;user-select:all"></div>
           <button class="btn-sm btn-full" id="recovery-copy-btn" style="margin-top:8px">📋 <span data-i18n="settings.recovery_section.copy_codes_btn">Copy Codes</span></button>
           <button class="btn-sm btn-full" id="recovery-codes-done-btn" data-i18n="settings.recovery_section.done_btn" style="margin-top:6px">Done</button>
         </div>
@@ -1753,9 +1742,9 @@
         <div style="display:flex;gap:8px;margin-bottom:12px;">
           <button class="btn-sm btn-accent" id="plugin-refresh-btn">🔄 <span data-i18n="settings.plugins_section.refresh_btn">Refresh</span></button>
         </div>
-        <h6 style="margin:10px 0 6px;font-size:12px;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-muted)" data-i18n="settings.plugins_section.plugins_label">Plugins</h6>
+        <h6 style="margin:10px 0 6px;font-size:0.75rem;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-muted)" data-i18n="settings.plugins_section.plugins_label">Plugins</h6>
         <div id="plugin-list" class="plugin-list"></div>
-        <h6 style="margin:14px 0 6px;font-size:12px;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-muted)" data-i18n="settings.plugins_section.themes_label">Themes</h6>
+        <h6 style="margin:14px 0 6px;font-size:0.75rem;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-muted)" data-i18n="settings.plugins_section.themes_label">Themes</h6>
         <div id="theme-list" class="plugin-list"></div>
       </div>
 
@@ -1962,7 +1951,7 @@
                 <span class="server-icon-text">⬡</span>
               </div>
               <div class="server-icon-upload-controls">
-                <input type="file" id="server-icon-file" accept="image/*" style="font-size:11px;max-width:160px">
+                <input type="file" id="server-icon-file" accept="image/*" style="font-size:0.6875rem;max-width:160px">
                 <div style="display:flex;gap:4px;margin-top:4px">
                   <button class="btn-sm btn-accent" id="server-icon-upload-btn" data-i18n="settings.admin.upload_btn">Upload</button>
                   <button class="btn-sm" id="server-icon-remove-btn" data-i18n="settings.admin.remove_btn">Remove</button>
@@ -1976,10 +1965,10 @@
             <small class="settings-group-label">Server banner (wide, max 4 MB)</small>
             <div class="server-banner-upload-area">
               <div class="server-banner-preview" id="server-banner-preview">
-                <span class="muted-text" style="font-size:11px">No banner</span>
+                <span class="muted-text" style="font-size:0.6875rem">No banner</span>
               </div>
               <div class="server-banner-upload-controls">
-                <input type="file" id="server-banner-file" accept="image/jpeg,image/png,image/gif,image/webp" style="font-size:11px;max-width:160px">
+                <input type="file" id="server-banner-file" accept="image/jpeg,image/png,image/gif,image/webp" style="font-size:0.6875rem;max-width:160px">
                 <div style="display:flex;gap:4px;margin-top:4px">
                   <button class="btn-sm btn-accent" id="server-banner-upload-btn">Upload</button>
                   <button class="btn-sm" id="server-banner-remove-btn">Remove</button>
@@ -2045,7 +2034,7 @@
             <small class="settings-group-label">Custom Themes</small>
             <p class="settings-hint" style="margin:0 0 8px">Drop <code>.theme.css</code> files into the <code>themes/</code> folder, then check the ones you want to appear in the theme picker for all users.</p>
             <div id="admin-theme-list" style="display:flex;flex-direction:column;gap:6px">
-              <span style="font-size:12px;color:var(--text-muted)">No themes found. Add <code>.theme.css</code> files to the <code>themes/</code> folder and refresh.</span>
+              <span style="font-size:0.75rem;color:var(--text-muted)">No themes found. Add <code>.theme.css</code> files to the <code>themes/</code> folder and refresh.</span>
             </div>
           </div>
         </div>
@@ -2346,7 +2335,7 @@
           <small class="settings-hint" data-i18n="settings.admin.connectivity_hint">STUN/TURN servers let voice and screen share connect between users on different networks. Leave blank to use Haven's built-in STUN pool. If users outside your local network get stuck on "ICE: Connecting...", set your own servers here.</small>
           <label class="select-row" style="margin-top:8px; align-items:flex-start">
             <span data-i18n="settings.admin.stun_urls">STUN servers</span>
-            <textarea id="stun-urls-input" rows="3" class="settings-text-input" placeholder="stun:stun.cloudflare.com:3478&#10;stun:stun.l.google.com:19302" style="flex:1; resize:vertical; font-family:monospace; font-size:12px"></textarea>
+            <textarea id="stun-urls-input" rows="3" class="settings-text-input" placeholder="stun:stun.cloudflare.com:3478&#10;stun:stun.l.google.com:19302" style="flex:1; resize:vertical; font-family:monospace; font-size:0.75rem"></textarea>
           </label>
           <small class="settings-hint" data-i18n="settings.admin.stun_urls_hint">One stun: URI per line (or comma separated). Blank = built-in defaults.</small>
           <label class="select-row" style="margin-top:8px">
@@ -2434,7 +2423,7 @@
           </label>
           <div style="margin-top:8px;display:flex;align-items:center;gap:8px;">
             <button class="btn-sm btn-accent" id="tunnel-toggle-btn" data-i18n="settings.admin.tunnel_start_btn">Start Tunnel</button>
-            <span id="tunnel-status-display" class="muted-text" data-i18n="settings.admin.tunnel_inactive" style="font-size:11px;">Inactive</span>
+            <span id="tunnel-status-display" class="muted-text" data-i18n="settings.admin.tunnel_inactive" style="font-size:0.6875rem;">Inactive</span>
           </div>
         </div>
         <!-- Webhooks / Bots (Admin only) -->
@@ -2452,7 +2441,7 @@
         <div class="admin-settings" id="section-custom-tos" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">⚖️ <span data-i18n="settings.admin.custom_tos_title">Custom Terms of Service</span></h5>
           <small class="settings-hint" data-i18n="settings.admin.custom_tos_hint">Add custom terms that appear before the default ToS on the login page. Supports plain text. Leave empty to show only the default Haven ToS.</small>
-          <textarea id="custom-tos-input" class="settings-textarea" rows="6" maxlength="50000" placeholder="Enter your custom terms of service..." style="margin-top:8px;width:100%;resize:vertical;min-height:80px;font-size:12px;padding:8px;border-radius:6px;border:1px solid var(--border);background:var(--bg-secondary);color:var(--text-primary);font-family:inherit;"></textarea>
+          <textarea id="custom-tos-input" class="settings-textarea" rows="6" maxlength="50000" placeholder="Enter your custom terms of service..." style="margin-top:8px;width:100%;resize:vertical;min-height:80px;font-size:0.75rem;padding:8px;border-radius:6px;border:1px solid var(--border);background:var(--bg-secondary);color:var(--text-primary);font-family:inherit;"></textarea>
         </div>
         <!-- Discord Import (Admin only) -->
         <div class="admin-settings" id="section-import" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
@@ -2518,7 +2507,7 @@
             <div class="import-dropzone-content">
               <span class="import-dropzone-icon">📁</span>
               <span><span data-i18n="modals.discord_import.drop_text">Drop file here or </span><a href="#" id="import-browse-link" data-i18n="modals.discord_import.browse_link">browse</a></span>
-              <span class="muted-text" style="font-size:11px" data-i18n="modals.discord_import.dropzone_hint">.json or .zip — up to 500 MB</span>
+              <span class="muted-text" style="font-size:0.6875rem" data-i18n="modals.discord_import.dropzone_hint">.json or .zip — up to 500 MB</span>
             </div>
           </div>
           <div id="import-upload-progress" style="display:none">
@@ -2561,7 +2550,7 @@
           <div id="import-connect-step-servers" style="display:none">
             <div class="import-info-bar" style="margin-bottom:8px">
               <span><span data-i18n="modals.discord_import.connected_as">Connected as</span> <strong id="import-discord-username"></strong></span>
-              <a href="#" id="import-connect-disconnect" data-i18n="modals.discord_import.disconnect" style="font-size:11px;margin-left:auto">Disconnect</a>
+              <a href="#" id="import-connect-disconnect" data-i18n="modals.discord_import.disconnect" style="font-size:0.6875rem;margin-left:auto">Disconnect</a>
             </div>
             <p class="settings-hint" style="margin-bottom:6px" data-i18n="modals.discord_import.pick_server">Pick a server to import from:</p>
             <div id="import-server-list" class="import-server-grid"></div>
@@ -2570,11 +2559,11 @@
           <div id="import-connect-step-channels" style="display:none">
             <div class="import-info-bar" style="margin-bottom:8px">
               <span id="import-connect-guild-name" style="font-weight:600"></span>
-              <a href="#" id="import-connect-back-servers" data-i18n="modals.discord_import.back_to_servers" style="font-size:11px;margin-left:auto">← Back to servers</a>
+              <a href="#" id="import-connect-back-servers" data-i18n="modals.discord_import.back_to_servers" style="font-size:0.6875rem;margin-left:auto">← Back to servers</a>
             </div>
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
               <p class="settings-hint" style="margin:0;flex:1" data-i18n="modals.discord_import.select_channels">Select channels to fetch:</p>
-              <a href="#" id="import-connect-toggle-all" data-i18n="modals.discord_import.deselect_all" style="font-size:11px;white-space:nowrap">Deselect All</a>
+              <a href="#" id="import-connect-toggle-all" data-i18n="modals.discord_import.deselect_all" style="font-size:0.6875rem;white-space:nowrap">Deselect All</a>
             </div>
             <div class="import-channel-list" id="import-connect-channel-list"></div>
             <div style="display:flex;gap:8px;margin-top:10px;justify-content:flex-end">
@@ -2594,7 +2583,7 @@
         </div>
         <div style="display:flex;align-items:center;gap:8px;margin:8px 0 6px">
           <p class="settings-hint" style="margin:0;flex:1" data-i18n="modals.discord_import.preview_select_hint">Select channels to import. You can rename them before importing.</p>
-          <a href="#" id="import-toggle-all" data-i18n="modals.discord_import.deselect_all" style="font-size:11px;white-space:nowrap">Deselect All</a>
+          <a href="#" id="import-toggle-all" data-i18n="modals.discord_import.deselect_all" style="font-size:0.6875rem;white-space:nowrap">Deselect All</a>
         </div>
         <div class="import-channel-list" id="import-channel-list"></div>
         <div style="display:flex;gap:8px;margin-top:12px;justify-content:flex-end">
@@ -2605,8 +2594,8 @@
 
       <!-- Step 3: Done -->
       <div id="import-step-done" style="display:none;text-align:center;padding:20px 0">
-        <div style="font-size:48px;margin-bottom:12px">✅</div>
-        <p id="import-done-msg" style="font-size:14px" data-i18n="modals.discord_import.import_complete">Import complete!</p>
+        <div style="font-size:3rem;margin-bottom:12px">✅</div>
+        <p id="import-done-msg" style="font-size:0.875rem" data-i18n="modals.discord_import.import_complete">Import complete!</p>
       </div>
 
       <div class="modal-actions" style="margin-top:12px">
@@ -2639,7 +2628,7 @@
   <div class="modal-overlay" id="role-members-modal" style="display:none">
     <div class="modal" style="width:460px;max-height:80vh;display:flex;flex-direction:column;gap:0">
       <h3 style="margin-bottom:4px">👥 <span id="role-members-modal-title"></span></h3>
-      <p class="muted-text" style="font-size:12px;margin-bottom:10px">Server-wide assignment only. For channel-specific roles, use the Role Assignment menu in member management.</p>
+      <p class="muted-text" style="font-size:0.75rem;margin-bottom:10px">Server-wide assignment only. For channel-specific roles, use the Role Assignment menu in member management.</p>
       <input type="text" id="role-members-search" class="settings-text-input" placeholder="Search members…" style="margin-bottom:10px;flex-shrink:0">
       <div id="role-members-list" style="overflow-y:auto;flex:1;border:1px solid var(--border);border-radius:6px;min-height:100px"></div>
       <div class="modal-actions" style="margin-top:12px;flex-shrink:0">
@@ -2754,7 +2743,7 @@
         <div class="sound-search-row">
           <input type="text" id="soundboard-search" data-i18n-placeholder="modals.sound_manager.search_placeholder" placeholder="Search sounds..." class="settings-text-input" style="flex:1">
           <button id="soundboard-popout-btn" class="icon-btn small" title="Pop out soundboard">⧉</button>
-                <div style="display:flex;gap:8px;margin-bottom:8px;font-size:12px">
+                <div style="display:flex;gap:8px;margin-bottom:8px;font-size:0.75rem">
                   <label style="display:flex;align-items:center;gap:4px"><input type="checkbox" id="soundboard-show-hidden" style="cursor:pointer"> Show hidden</label>
                   <label style="display:flex;align-items:center;gap:4px"><input type="checkbox" id="soundboard-list-mode" style="cursor:pointer"> List view</label>
                   <label style="display:flex;align-items:center;gap:4px"><input type="checkbox" id="soundboard-sidebar-mode" style="cursor:pointer"> Sidebar mode</label>
@@ -2797,7 +2786,7 @@
         <small class="settings-hint" style="display:block;margin-bottom:12px" data-i18n="modals.sound_manager.upload_hint">Upload audio files for custom sounds (max 1 MB each, mp3/ogg/wav/webm)</small>
         <div class="whitelist-add-row">
           <input type="text" id="sound-name-input" data-i18n-placeholder="modals.sound_manager.name_placeholder" placeholder="Sound name..." maxlength="30" class="settings-text-input">
-          <input type="file" id="sound-file-input" accept="audio/*" style="max-width:120px;font-size:11px">
+          <input type="file" id="sound-file-input" accept="audio/*" style="max-width:120px;font-size:0.6875rem">
           <button class="btn-sm btn-accent" id="sound-upload-btn" data-i18n="modals.sound_manager.upload_btn">Upload</button>
         </div>
         <div id="custom-sounds-list" style="margin-top:12px;">
@@ -2820,7 +2809,7 @@
       <small class="settings-hint" style="display:block;margin-bottom:12px" data-i18n="settings.admin.emojis_upload_hint">Upload images for custom server emojis (max 256 KB, png/gif/webp). Name must be lowercase, no spaces.</small>
       <div class="whitelist-add-row">
         <input type="text" id="emoji-name-input" data-i18n-placeholder="modals.emoji_mgmt.name_placeholder" placeholder="emoji_name" maxlength="30" class="settings-text-input">
-        <input type="file" id="emoji-file-input" accept="image/png,image/gif,image/webp,image/jpeg" style="max-width:120px;font-size:11px">
+        <input type="file" id="emoji-file-input" accept="image/png,image/gif,image/webp,image/jpeg" style="max-width:120px;font-size:0.6875rem">
         <button class="btn-sm btn-accent" id="emoji-upload-btn" data-i18n="modals.emoji_mgmt.upload_btn">Upload</button>
       </div>
       <div style="margin-top:6px;text-align:center">
@@ -2851,7 +2840,7 @@
       <div class="whitelist-add-row">
         <input type="text" id="sticker-name-input" data-i18n-placeholder="modals.sticker_mgmt.name_placeholder" placeholder="sticker_name (optional)" maxlength="40" class="settings-text-input">
         <input type="text" id="sticker-pack-input" data-i18n-placeholder="modals.sticker_mgmt.pack_placeholder" placeholder="Pack name (optional)" maxlength="40" class="settings-text-input">
-        <input type="file" id="sticker-file-input" accept="image/png,image/gif,image/webp,image/jpeg" style="max-width:120px;font-size:11px">
+        <input type="file" id="sticker-file-input" accept="image/png,image/gif,image/webp,image/jpeg" style="max-width:120px;font-size:0.6875rem">
         <button class="btn-sm btn-accent" id="sticker-upload-btn" data-i18n="modals.sticker_mgmt.upload_btn">Upload</button>
       </div>
       <div style="margin-top:6px;text-align:center">
@@ -2876,9 +2865,9 @@
       <small class="settings-hint" style="display:block;margin-bottom:10px" data-i18n="modals.emoji_crop.hint">Drag to reposition · Slider to zoom</small>
       <canvas id="emoji-crop-canvas" width="256" height="256" style="border-radius:var(--radius);cursor:grab;display:block;margin:0 auto 10px;border:2px solid var(--accent);max-width:100%;touch-action:none"></canvas>
       <div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;padding:0 4px">
-        <span style="font-size:13px" title="Zoom out">🔍</span>
+        <span style="font-size:0.8125rem" title="Zoom out">🔍</span>
         <input type="range" id="emoji-crop-zoom" min="100" max="500" value="100" step="1" style="flex:1;accent-color:var(--accent)">
-        <span style="font-size:13px" title="Zoom in">🔎</span>
+        <span style="font-size:0.8125rem" title="Zoom in">🔎</span>
       </div>
       <div class="modal-actions">
         <button class="btn-sm" id="emoji-crop-cancel-btn" data-i18n="modals.common.cancel">Cancel</button>
@@ -2965,10 +2954,10 @@
   <!-- All Members Modal -->
   <div class="modal-overlay" id="all-members-modal" style="display:none">
     <div class="modal modal-wide" style="max-width:720px;max-height:85vh;display:flex;flex-direction:column">
-      <h3>👥 <span data-i18n="modals.all_members.title">All Members</span> <span id="all-members-count" class="muted-text" style="font-size:13px;font-weight:normal"></span></h3>
+      <h3>👥 <span data-i18n="modals.all_members.title">All Members</span> <span id="all-members-count" class="muted-text" style="font-size:0.8125rem;font-weight:normal"></span></h3>
       <div style="margin-bottom:10px;display:flex;gap:8px;align-items:center;flex-wrap:wrap">
         <input type="text" id="all-members-search" data-i18n-placeholder="modals.all_members.search_placeholder" placeholder="Search users..." maxlength="40" class="settings-text-input" style="flex:1;min-width:140px">
-        <select id="all-members-filter" style="font-size:12px;padding:4px 8px;border-radius:var(--radius-sm);background:var(--bg-tertiary);color:var(--text-primary);border:1px solid var(--border)">
+        <select id="all-members-filter" style="font-size:0.75rem;padding:4px 8px;border-radius:var(--radius-sm);background:var(--bg-tertiary);color:var(--text-primary);border:1px solid var(--border)">
           <option value="all" data-i18n="modals.all_members.filter_all">All</option>
           <option value="online" data-i18n="modals.all_members.filter_online">Online</option>
           <option value="offline" data-i18n="modals.all_members.filter_offline">Offline</option>
@@ -3495,9 +3484,9 @@
     <div class="game-iframe-header">
       <span class="game-iframe-title" id="game-iframe-title">Game</span>
       <div class="game-iframe-actions">
-        <label style="display:flex;align-items:center;gap:6px;color:var(--text-secondary);font-size:12px;margin-right:8px;" title="Game Volume">
+        <label style="display:flex;align-items:center;gap:6px;color:var(--text-secondary);font-size:0.75rem;margin-right:8px;" title="Game Volume">
           🔊 <input type="range" id="game-volume-slider" min="0" max="100" value="80" style="width:80px;accent-color:var(--accent);">
-          <span id="game-volume-pct" style="min-width:28px;font-size:11px;">80%</span>
+          <span id="game-volume-pct" style="min-width:28px;font-size:0.6875rem;">80%</span>
         </label>
         <button class="btn-sm" id="game-iframe-popout" title="Open in new window">↗️ <span data-i18n="modals.game_overlay.popout_btn">Pop Out</span></button>
         <button class="btn-sm btn-danger" id="game-iframe-close" data-i18n="modals.game_overlay.close_btn" title="Close game">&times; Close</button>
@@ -3508,14 +3497,14 @@
 
   <div class="modal-overlay" id="push-error-modal" style="display:none">
     <div class="modal" style="width:420px;text-align:center;padding:28px 24px;">
-      <div style="font-size:48px;margin-bottom:12px;">🔕</div>
+      <div style="font-size:3rem;margin-bottom:12px;">🔕</div>
       <h3 style="margin:0 0 12px;color:var(--text-primary)" data-i18n="modals.push_error.title">Push Notifications Unavailable</h3>
-      <p id="push-error-reason" style="color:var(--text-secondary);font-size:14px;line-height:1.5;margin:0 0 16px;"></p>
-      <p style="color:var(--text-muted);font-size:12px;line-height:1.5;margin:0 0 20px;" data-i18n-html="modals.push_error.recommendation">
+      <p id="push-error-reason" style="color:var(--text-secondary);font-size:0.875rem;line-height:1.5;margin:0 0 16px;"></p>
+      <p style="color:var(--text-muted);font-size:0.75rem;line-height:1.5;margin:0 0 20px;" data-i18n-html="modals.push_error.recommendation">
         <strong>Recommended:</strong> Google Chrome, Microsoft Edge, or Opera on desktop.<br>
         iOS requires Safari 16.4+ with Haven added to your Home Screen.
       </p>
-      <button class="btn-accent" id="push-error-dismiss-btn" style="width:100%;padding:10px;font-size:14px;font-weight:600;" data-i18n="modals.push_error.got_it">Got It</button>
+      <button class="btn-accent" id="push-error-dismiss-btn" style="width:100%;padding:10px;font-size:0.875rem;font-weight:600;" data-i18n="modals.push_error.got_it">Got It</button>
     </div>
   </div>
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -44,8 +44,8 @@
   --radius:        8px;
   --radius-sm:     4px;
   --transition:    0.15s ease;
-  --sidebar-width: 270px;
-  --right-width:   260px;
+  --sidebar-width: 16.875rem; /* 270px — in rem so the sidebar scales with the zoom */
+  --right-width:   16.25rem;  /* 260px */
 
   --theme-logo:    "⬡";
   --msg-glow:      none;
@@ -718,11 +718,11 @@
 }
 
 [data-theme="minecraft"] .brand-text { color: #55bb55; text-shadow: 2px 2px 0 #2a5a2a; }
-[data-theme="minecraft"] .server-icon.home { background: #55bb55; box-shadow: 2px 2px 0 #2a5a2a; border-radius: 4px; }
-[data-theme="minecraft"] .server-icon:hover { border-radius: 4px; }
+[data-theme="minecraft"] .server-icon.home { background: #55bb55; box-shadow: 2px 2px 0 #2a5a2a; border-radius: 0.25rem; }
+[data-theme="minecraft"] .server-icon:hover { border-radius: 0.25rem; }
 [data-theme="minecraft"] .channel-item.active::before { background: #55bb55; }
 [data-theme="minecraft"] .inline-code { color: #55bbff; }
-[data-theme="minecraft"] .message-avatar, [data-theme="minecraft"] .message-avatar-img { border: 2px solid #3a3a3a; border-radius: 4px; }
+[data-theme="minecraft"] .message-avatar, [data-theme="minecraft"] .message-avatar-img { border: 2px solid #3a3a3a; border-radius: 0.25rem; }
 [data-theme="minecraft"] .channel-badge { background: #55bb55; color: #1a1a1a; }
 
 /* ─── THEME: Final Fantasy X ───────────────────────────── */
@@ -863,7 +863,7 @@
 [data-theme="fallout"] .brand-text { color: #14fe17; text-shadow: 0 0 8px rgba(20, 254, 23, 0.6); letter-spacing: 2px; text-transform: uppercase; }
 [data-theme="fallout"] .server-icon.home { background: #0a1a08; border: 1px solid #14fe17; box-shadow: 0 0 8px rgba(20, 254, 23, 0.3); color: #14fe17; }
 [data-theme="fallout"] .channel-item.active::before { background: #14fe17; box-shadow: 0 0 8px rgba(20, 254, 23, 0.6); }
-[data-theme="fallout"] .message-avatar, [data-theme="fallout"] .message-avatar-img { border: 1px solid #14fe17; border-radius: 2px; }
+[data-theme="fallout"] .message-avatar, [data-theme="fallout"] .message-avatar-img { border: 1px solid #14fe17; border-radius: 0.125rem; }
 [data-theme="fallout"] .inline-code { color: #14fe17; background: rgba(20, 254, 23, 0.08); border: 1px solid rgba(20, 254, 23, 0.2); }
 [data-theme="fallout"] .channel-badge { background: #14fe17; color: #0a0e08; }
 [data-theme="fallout"] .sidebar { border-right: 1px solid rgba(20, 254, 23, 0.2); }
@@ -871,7 +871,7 @@
 [data-theme="fallout"] .message-row { text-shadow: 0 0 2px rgba(20, 254, 23, 0.15); }
 [data-theme="fallout"] .modal { border: 1px solid rgba(20, 254, 23, 0.3); box-shadow: 0 0 20px rgba(20, 254, 23, 0.15); }
 [data-theme="fallout"] input, [data-theme="fallout"] textarea { border: 1px solid rgba(20, 254, 23, 0.15) !important; }
-[data-theme="fallout"] .message-input-container { border: 1px solid rgba(20, 254, 23, 0.2); border-radius: 2px; }
+[data-theme="fallout"] .message-input-container { border: 1px solid rgba(20, 254, 23, 0.2); border-radius: 0.125rem; }
 [data-theme="fallout"] ::selection { background: #14fe17; color: #0a0e08; }
 /* Terminal-style button override: all accent-background elements become
    dark-bg + green-text + green-border for consistent legibility */
@@ -1308,7 +1308,7 @@
 [data-theme="win95"] .sidebar .current-user { color: #000; }
 [data-theme="win95"] .sidebar .muted-text { color: #808080; }
 [data-theme="win95"] .sidebar-bottom-bar { background: #bfbfbf; border-top: 3px outset #fff; }
-[data-theme="win95"] .sidebar-bottom-btn { color: #000; background: #bfbfbf; border: 3px outset #fff; border-radius: 0; margin: 2px; }
+[data-theme="win95"] .sidebar-bottom-btn { color: #000; background: #bfbfbf; border: 3px outset #fff; border-radius: 0; margin: 0.125rem; }
 [data-theme="win95"] .sidebar-bottom-btn:hover { background: #dfdfdf; }
 [data-theme="win95"] .sidebar-bottom-btn:active { border: 3px inset #808080; }
 [data-theme="win95"] .channel-header { background: linear-gradient(90deg, #000080, #1084d0); border-bottom: 3px outset #fff; color: #fff; }
@@ -1325,7 +1325,7 @@
 /* Win95 icon buttons near username (rename, logout) — beveled */
 [data-theme="win95"] .icon-btn {
   background: #bfbfbf; color: #000; border: 2px outset #fff;
-  border-radius: 0 !important; padding: 3px 5px;
+  border-radius: 0 !important; padding: 0.1875rem 0.3125rem;
 }
 [data-theme="win95"] .icon-btn:hover { background: #dfdfdf; color: #000; }
 [data-theme="win95"] .icon-btn:active { border: 2px inset #808080; }
@@ -1361,7 +1361,7 @@
 }
 [data-theme="win95"] .msg-toolbar button:hover { background: #dfdfdf; }
 [data-theme="win95"] .modal { background: #bfbfbf; border: 3px outset #fff; border-radius: 0; box-shadow: 2px 2px 0 #000; }
-[data-theme="win95"] .modal h3 { background: linear-gradient(90deg, #000080, #1084d0); color: #fff; margin: -20px -24px 16px -24px; padding: 4px 8px; border-radius: 0; font-weight: 700; font-size: 12px; }
+[data-theme="win95"] .modal h3 { background: linear-gradient(90deg, #000080, #1084d0); color: #fff; margin: -1.25rem -1.5rem 1rem -1.5rem; padding: 0.25rem 0.5rem; border-radius: 0; font-weight: 700; font-size: 0.75rem; }
 /* Message group separators were attempted twice (per-row, then group-only)
    and both produced visually inconsistent results — sometimes a line, sometimes
    a half-line, sometimes a doubled line depending on whether the previous
@@ -1378,8 +1378,8 @@
    subtler Minecraft / dark-theme look the user expects. */
 [data-theme="win95"] .message.message-user-sep {
   border-top-color: #dfdfdf !important;
-  margin-top: 4px !important;
-  padding-top: 2px !important;
+  margin-top: 0.25rem !important;
+  padding-top: 0.125rem !important;
 }
 /* And explicitly suppress any phantom border that could land on
    .message-row itself — nothing should ever draw one, but if a stray
@@ -1425,7 +1425,7 @@
    Setting explicit scrollbar-color triggers Chrome's flat-colour renderer that ignores
    webkit pseudo-element styling and always draws rounded thumbs. */
 [data-theme="win95"] * { scrollbar-width: auto !important; scrollbar-color: auto !important; }
-[data-theme="win95"] ::-webkit-scrollbar { width: 18px !important; height: 18px !important; }
+[data-theme="win95"] ::-webkit-scrollbar { width: 1.125rem !important; height: 1.125rem !important; }
 [data-theme="win95"] ::-webkit-scrollbar-thumb {
   background:
     linear-gradient(to right,  #ffffff 0, #ffffff 2px, transparent 2px),
@@ -1440,8 +1440,8 @@
   border: none !important;
   box-shadow: none !important;
   border-radius: 0 !important;
-  min-height: 32px;
-  min-width: 32px;
+  min-height: 2rem;
+  min-width: 2rem;
 }
 [data-theme="win95"] ::-webkit-scrollbar-thumb:hover {
   background:
@@ -1477,8 +1477,8 @@
   border: none !important;
   box-shadow: none !important;
   display: block;
-  height: 18px !important;
-  width: 18px !important;
+  height: 1.125rem !important;
+  width: 1.125rem !important;
   border-radius: 0 !important;
 }
 [data-theme="win95"] ::-webkit-scrollbar-button:hover {
@@ -1521,10 +1521,10 @@
 /* Win95 sliders — rectangular gray boxes with proper 3D bevel */
 [data-theme="win95"] input[type="range"] {
   -webkit-appearance: none; appearance: none;
-  height: 22px; background: transparent;
+  height: 1.375rem; background: transparent;
 }
 [data-theme="win95"] input[type="range"]::-webkit-slider-runnable-track {
-  background: #bfbfbf !important; height: 4px !important;
+  background: #bfbfbf !important; height: 0.25rem !important;
   border-top: 2px solid #404040 !important;
   border-left: 2px solid #404040 !important;
   border-right: 2px solid #ffffff !important;
@@ -1532,7 +1532,7 @@
   border-radius: 0 !important;
 }
 [data-theme="win95"] input[type="range"]::-moz-range-track {
-  background: #bfbfbf !important; height: 4px !important;
+  background: #bfbfbf !important; height: 0.25rem !important;
   border-top: 2px solid #404040 !important;
   border-left: 2px solid #404040 !important;
   border-right: 2px solid #ffffff !important;
@@ -1541,7 +1541,7 @@
 }
 [data-theme="win95"] input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none; appearance: none;
-  width: 12px; height: 22px; margin-top: -10px;
+  width: 0.75rem; height: 1.375rem; margin-top: -0.625rem;
   background: #bfbfbf;
   border-top: 2px solid #ffffff;
   border-left: 2px solid #ffffff;
@@ -1558,7 +1558,7 @@
   box-shadow: inset 1px 1px 0 #808080, inset -1px -1px 0 #dfdfdf;
 }
 [data-theme="win95"] input[type="range"]::-moz-range-thumb {
-  width: 12px; height: 22px;
+  width: 0.75rem; height: 1.375rem;
   background: #bfbfbf;
   border-top: 2px solid #ffffff;
   border-left: 2px solid #ffffff;
@@ -1580,11 +1580,11 @@
   writing-mode: vertical-lr;
   direction: rtl;
   appearance: none;
-  width: 22px; height: auto;
+  width: 1.375rem; height: auto;
 }
 [data-theme="win95"] input[type="range"][orient="vertical"]::-webkit-slider-thumb,
 [data-theme="win95"] input[type="range"].vertical::-webkit-slider-thumb {
-  width: 22px; height: 12px; margin-top: 0; margin-left: -10px;
+  width: 1.375rem; height: 0.75rem; margin-top: 0; margin-left: -0.625rem;
 }
 
 /* Win95 text color — white text on navy backgrounds (hover/active/selected states) */
@@ -1612,13 +1612,13 @@
 /* Win95 settings modal — full blue title bar like real Win95 */
 [data-theme="win95"] .settings-header {
   background: linear-gradient(90deg, #000080, #1084d0);
-  padding: 4px 8px;
+  padding: 0.25rem 0.5rem;
   border-bottom: none;
-  min-height: 24px;
+  min-height: 1.5rem;
 }
 [data-theme="win95"] .settings-header h3 {
   color: #fff;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 700;
   font-family: "MS Sans Serif", "Microsoft Sans Serif", Tahoma, Arial, sans-serif;
   margin: 0;
@@ -1626,11 +1626,11 @@
   background: none;
 }
 [data-theme="win95"] .settings-close-btn {
-  width: 18px; height: 18px;
+  width: 1.125rem; height: 1.125rem;
   background: #bfbfbf;
   border: 2px outset #fff;
   color: #000;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 700;
   padding: 0;
   line-height: 1;
@@ -1647,7 +1647,7 @@
   color: #000 !important;
   border: 3px outset #fff;
   font-family: "MS Sans Serif", "Microsoft Sans Serif", Tahoma, Arial, sans-serif;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 [data-theme="win95"] .btn-admin-save:hover { background: #dfdfdf !important; }
 [data-theme="win95"] .btn-admin-save:active { border: 3px inset #808080; }
@@ -1692,14 +1692,14 @@
   border: 3px outset #fff;
   border-radius: 0;
   box-shadow: 2px 2px 0 #000;
-  padding: 2px;
+  padding: 0.125rem;
 }
 [data-theme="win95"] .channel-ctx-item {
   color: #000;
   border-radius: 0;
-  padding: 4px 12px;
+  padding: 0.25rem 0.75rem;
   font-family: "MS Sans Serif", "Microsoft Sans Serif", Tahoma, Arial, sans-serif;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 [data-theme="win95"] .channel-ctx-item:hover {
   background: #000080;
@@ -1713,7 +1713,7 @@
 [data-theme="win95"] .channel-ctx-sep {
   border-top: 1px solid #808080;
   border-bottom: 1px solid #fff;
-  margin: 2px 0;
+  margin: 0.125rem 0;
 }
 
 /* Win95 emoji picker — beveled box */
@@ -1864,6 +1864,11 @@ html {
   height: 100%;
   overflow: hidden;
   overscroll-behavior: contain;
+  /* Root of the rem-driven interface scale. The Zoom slider sets --ui-scale
+     (a percentage), and because every size in this file is in rem, changing it
+     rescales the whole UI at once. Defaults to 100% (16px). See the INTERFACE
+     SCALE block near the end of this file. */
+  font-size: var(--ui-scale, 100%);
 }
 
 body {
@@ -1899,39 +1904,39 @@ input, textarea { font-family: inherit; outline: none; border: none; }
    the defaults below. Themed tracks use --track-bg for colouring.  */
 input[type="range"]:not(.rgb-slider)::-webkit-slider-runnable-track {
   background: var(--track-bg, rgba(255,255,255,0.25));
-  height: var(--track-h, 6px);
-  border-radius: var(--track-r, 3px);
+  height: var(--track-h, 0.375rem);
+  border-radius: var(--track-r, 0.1875rem);
   border: var(--track-border, 1px solid rgba(255,255,255,0.15));
 }
 input[type="range"]:not(.rgb-slider)::-moz-range-track {
   background: var(--track-bg, rgba(255,255,255,0.25));
-  height: var(--track-h, 6px);
-  border-radius: var(--track-r, 3px);
+  height: var(--track-h, 0.375rem);
+  border-radius: var(--track-r, 0.1875rem);
   border: var(--track-border, 1px solid rgba(255,255,255,0.15));
 }
 /* Range thumb — centered on track */
 input[type="range"]:not(.rgb-slider)::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   border-radius: 50%;
   background: var(--accent, #7c5cfc);
   border: 2px solid rgba(255,255,255,0.3);
   cursor: pointer;
-  margin-top: calc((var(--track-h, 6px) - 14px) / 2 - 1px);
+  margin-top: calc((var(--track-h, 0.375rem) - 0.875rem) / 2 - 0.0625rem);
 }
 input[type="range"]:not(.rgb-slider)::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   border-radius: 50%;
   background: var(--accent, #7c5cfc);
   border: 2px solid rgba(255,255,255,0.3);
   cursor: pointer;
 }
 
-::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar { width: 0.375rem; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 0.1875rem; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 * { scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
 
@@ -1962,8 +1967,8 @@ html.rgb-cycling *::after {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .led {
-  width: 10px;
-  height: 10px;
+  width: 0.625rem;
+  height: 0.625rem;
   border-radius: 50%;
   flex-shrink: 0;
   transition: all 0.3s ease;
@@ -1999,21 +2004,21 @@ html.rgb-cycling *::after {
 .status-bar {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 5px 16px;
+  gap: 1rem;
+  padding: 0.3125rem 1rem;
   background: var(--bg-secondary);
   border-top: 1px solid var(--border);
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   flex-shrink: 0;
-  min-height: 28px;
+  min-height: 1.75rem;
   user-select: none;
 }
 
 .status-item {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 0.3125rem;
   white-space: nowrap;
 }
 
@@ -2021,25 +2026,25 @@ html.rgb-cycling *::after {
   text-transform: uppercase;
   letter-spacing: 0.3px;
   font-weight: 600;
-  font-size: 10px;
+  font-size: 0.625rem;
 }
 
 .status-item .value {
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 0.6875rem;
 }
 
 .status-bar .spacer { flex: 1; }
 
 #status-version {
   opacity: 0.5;
-  font-size: 10px;
+  font-size: 0.625rem;
 }
 
 .status-bar .divider {
-  width: 1px;
-  height: 14px;
+  width: 0.0625rem;
+  height: 0.875rem;
   background: var(--border);
 }
 
@@ -2065,16 +2070,16 @@ html.rgb-cycling *::after {
   bottom: 0;
   right: 12px;
   z-index: 50;
-  width: 32px;
-  height: 20px;
+  width: 2rem;
+  height: 1.25rem;
   align-items: center;
   justify-content: center;
   background: var(--bg-secondary, #1e2035);
   border: 1px solid var(--border, #333);
   border-bottom: none;
-  border-radius: 6px 6px 0 0;
+  border-radius: 0.375rem 0.375rem 0 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 0.75rem;
   cursor: pointer;
   opacity: 0.5;
   transition: opacity 0.2s;
@@ -2086,11 +2091,11 @@ html.rgb-cycling *::after {
 [data-desktop-app] .status-bar-toggle-tab { display: none !important; }
 
 /* ── Backup restore progress bar (#5438) ── */
-.restore-progress { margin-top: 10px; }
+.restore-progress { margin-top: 0.625rem; }
 .restore-progress-track {
   width: 100%;
-  height: 10px;
-  border-radius: 6px;
+  height: 0.625rem;
+  border-radius: 0.375rem;
   background: var(--bg-tertiary, rgba(255,255,255,0.08));
   border: 1px solid var(--border);
   overflow: hidden;
@@ -2099,11 +2104,11 @@ html.rgb-cycling *::after {
   height: 100%;
   width: 0;
   background: var(--accent, #6b4fdb);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   transition: width 0.3s ease;
 }
 .restore-progress-label {
-  margin-top: 4px;
+  margin-top: 0.25rem;
   display: block;
   font-family: var(--font-mono, monospace);
 }
@@ -2123,7 +2128,7 @@ html.rgb-cycling *::after {
   cursor: pointer;
   opacity: 0.6;
   transition: opacity 0.2s;
-  font-size: 10px;
+  font-size: 0.625rem;
 }
 .status-url-text:hover { opacity: 1; }
 .status-url-text.url-hidden { letter-spacing: 2px; }
@@ -2131,11 +2136,11 @@ html.rgb-cycling *::after {
   cursor: pointer;
   opacity: 0.4;
   transition: opacity 0.2s;
-  font-size: 11px;
+  font-size: 0.6875rem;
   background: none;
   border: none;
   color: inherit;
-  padding: 0 4px;
+  padding: 0 0.25rem;
   line-height: 1;
 }
 .status-url-toggle:hover { opacity: 1; }
@@ -2155,17 +2160,17 @@ html.rgb-cycling *::after {
 .sidebar-bottom-bar {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
 }
 
 .sidebar-bottom-btn {
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 5px 10px;
+  border-radius: 0.375rem;
+  padding: 0.3125rem 0.625rem;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-secondary);
   transition: all 0.2s;
   line-height: 1;
@@ -2185,7 +2190,7 @@ html.rgb-cycling *::after {
   border: 1px solid var(--border);
   border-bottom: none;
   border-radius: var(--radius) var(--radius) 0 0;
-  padding: 12px;
+  padding: 0.75rem;
   z-index: 100;
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.4);
   max-height: 60vh;
@@ -2196,10 +2201,10 @@ html.rgb-cycling *::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 .theme-popup-title {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1.2px;
@@ -2213,13 +2218,13 @@ html.rgb-cycling *::after {
 .theme-selector {
   display: flex;
   flex-wrap: wrap;
-  gap: 5px;
-  padding: 4px 0;
+  gap: 0.3125rem;
+  padding: 0.25rem 0;
 }
 
 .theme-btn {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   border: 2px solid var(--border);
   cursor: pointer;
@@ -2228,7 +2233,7 @@ html.rgb-cycling *::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1;
 }
 
@@ -2288,20 +2293,20 @@ html.rgb-cycling *::after {
 
 .effect-overlay-section {
   border-top: 1px solid var(--border);
-  margin-top: 8px;
-  padding-top: 6px;
+  margin-top: 0.5rem;
+  padding-top: 0.375rem;
 }
 
 .effect-selector {
   display: flex;
   flex-wrap: wrap;
-  gap: 5px;
-  padding: 4px 0;
+  gap: 0.3125rem;
+  padding: 0.25rem 0;
 }
 
 .effect-btn {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   border: 2px solid var(--border);
   background: var(--bg-tertiary);
@@ -2310,7 +2315,7 @@ html.rgb-cycling *::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1;
   color: var(--text-secondary);
 }
@@ -2369,7 +2374,7 @@ html.rgb-cycling *::after {
 }
 [data-theme="ffx"] .main { position: relative; }
 [data-theme="ffx"] .main::after {
-  content: ''; position: fixed; bottom: 0; left: 0; right: 0; height: 6px;
+  content: ''; position: fixed; bottom: 0; left: 0; right: 0; height: 0.375rem;
   pointer-events: none; z-index: 99998;
   background: linear-gradient(90deg,
     transparent, rgba(64,168,224,0.6), rgba(100,200,255,0.8), rgba(64,168,224,0.6), transparent
@@ -2391,7 +2396,7 @@ html.rgb-cycling *::after {
 [data-theme="ice"] .channel-header { position: relative; overflow: visible !important; }
 [data-theme="ice"] .channel-header::after {
   content: '';
-  position: absolute; bottom: -12px; left: 0; right: 0; height: 12px;
+  position: absolute; bottom: -12px; left: 0; right: 0; height: 0.75rem;
   pointer-events: none; z-index: 2;
   background:
     linear-gradient(180deg, rgba(180,230,255,0.7), rgba(180,230,255,0.0));
@@ -2406,7 +2411,7 @@ html.rgb-cycling *::after {
 [data-theme="ice"] .sidebar-header { position: relative; overflow: visible !important; }
 [data-theme="ice"] .sidebar-header::after {
   content: '';
-  position: absolute; bottom: -10px; left: 0; right: 0; height: 10px;
+  position: absolute; bottom: -10px; left: 0; right: 0; height: 0.625rem;
   pointer-events: none; z-index: 2;
   background:
     linear-gradient(180deg, rgba(180,230,255,0.6), rgba(180,230,255,0.0));
@@ -2457,7 +2462,7 @@ html.rgb-cycling *::after {
 }
 [data-theme="darksouls"] .main { position: relative; }
 [data-theme="darksouls"] .main::before {
-  content: ''; position: fixed; bottom: 0; left: 0; right: 0; height: 10px;
+  content: ''; position: fixed; bottom: 0; left: 0; right: 0; height: 0.625rem;
   pointer-events: none; z-index: 99998;
   background: linear-gradient(90deg,
     transparent 0%,
@@ -2496,14 +2501,14 @@ html.rgb-cycling *::after {
   100%     { opacity: 0.5; }
 }
 @keyframes ds-fireline {
-  0%   { opacity: 0.3; filter: blur(4px); height: 8px; }
-  12%  { opacity: 0.55; filter: blur(6px); height: 12px; }
-  28%  { opacity: 0.2; filter: blur(3px); height: 6px; }
-  45%  { opacity: 0.5; filter: blur(5px); height: 11px; }
-  60%  { opacity: 0.15; filter: blur(3px); height: 7px; }
-  75%  { opacity: 0.45; filter: blur(6px); height: 13px; }
-  90%  { opacity: 0.25; filter: blur(4px); height: 9px; }
-  100% { opacity: 0.35; filter: blur(5px); height: 10px; }
+  0%   { opacity: 0.3; filter: blur(4px); height: 0.5rem; }
+  12%  { opacity: 0.55; filter: blur(6px); height: 0.75rem; }
+  28%  { opacity: 0.2; filter: blur(3px); height: 0.375rem; }
+  45%  { opacity: 0.5; filter: blur(5px); height: 0.6875rem; }
+  60%  { opacity: 0.15; filter: blur(3px); height: 0.4375rem; }
+  75%  { opacity: 0.45; filter: blur(6px); height: 0.8125rem; }
+  90%  { opacity: 0.25; filter: blur(4px); height: 0.5625rem; }
+  100% { opacity: 0.35; filter: blur(5px); height: 0.625rem; }
 }
 @keyframes ds-ambient {
   0%, 100% { opacity: 0.3; }
@@ -2549,8 +2554,8 @@ html.rgb-cycling *::after {
 /* ── Minecraft: Pixelated border style ─────────────── */
 [data-theme="minecraft"] .message-avatar,
 [data-theme="minecraft"] .message-avatar-img { image-rendering: pixelated; border-radius: 0 !important; }
-[data-theme="minecraft"] .server-icon { border-radius: 2px; image-rendering: pixelated; }
-[data-theme="minecraft"] .user-item-avatar { border-radius: 2px; image-rendering: pixelated; }
+[data-theme="minecraft"] .server-icon { border-radius: 0.125rem; image-rendering: pixelated; }
+[data-theme="minecraft"] .user-item-avatar { border-radius: 0.125rem; image-rendering: pixelated; }
 [data-theme="minecraft"] .sidebar { border-right: 3px solid #3a3a2a; }
 [data-theme="minecraft"] .channel-header { border-bottom: 3px solid #3a3a2a; }
 
@@ -2681,7 +2686,7 @@ html.rgb-cycling *::after {
     rgba(0,0,0,0.08) 0%, rgba(0,0,0,0.35) 45%, rgba(0,0,0,1) 100%);
   mask-image: radial-gradient(ellipse 85% 75% at 50% 50%,
     rgba(0,0,0,0.08) 0%, rgba(0,0,0,0.35) 45%, rgba(0,0,0,1) 100%);
-  border-radius: 22px / 18px;
+  border-radius: 1.375rem / 1.125rem;
   z-index: 99998;
   pointer-events: none;
 }
@@ -2716,7 +2721,7 @@ html.rgb-cycling *::after {
 
 /* ── FFX wave bar overlay ─────────────────────────────── */
 .fx-ffx-wave {
-  position: fixed; bottom: 0; left: 0; right: 0; height: 6px;
+  position: fixed; bottom: 0; left: 0; right: 0; height: 0.375rem;
   background: linear-gradient(90deg,
     transparent, rgba(64,168,224,0.6), rgba(100,200,255,0.8),
     rgba(64,168,224,0.6), transparent);
@@ -2742,7 +2747,7 @@ html.rgb-cycling *::after {
 
 /* ── Ice icicles overlays ─────────────────────────────── */
 .fx-ice-icicle {
-  position: absolute; bottom: -12px; left: 0; right: 0; height: 12px;
+  position: absolute; bottom: -12px; left: 0; right: 0; height: 0.75rem;
   pointer-events: none; z-index: 2;
   background: linear-gradient(180deg, rgba(180,230,255,0.7), rgba(180,230,255,0.0));
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 12' preserveAspectRatio='none'%3E%3Cpolygon points='0,0 8,0 10,10 12,0 20,0 22,7 24,0 32,0 35,12 38,0 46,0 48,8 50,0 58,0 61,11 64,0 72,0 74,6 76,0 84,0 87,12 90,0 98,0 100,9 102,0 110,0 113,11 116,0 124,0 126,7 128,0 136,0 139,12 142,0 150,0 152,8 154,0 162,0 165,10 168,0 176,0 178,6 180,0 188,0 191,12 194,0 200,0 200,0 0,0'/%3E%3C/svg%3E");
@@ -2752,7 +2757,7 @@ html.rgb-cycling *::after {
   animation: ice-drip calc(3s * var(--fx-mult, 1)) ease-in-out infinite;
 }
 .fx-ice-icicle-sb {
-  position: absolute; bottom: -10px; left: 0; right: 0; height: 10px;
+  position: absolute; bottom: -10px; left: 0; right: 0; height: 0.625rem;
   pointer-events: none; z-index: 2;
   background: linear-gradient(180deg, rgba(180,230,255,0.6), rgba(180,230,255,0.0));
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 12' preserveAspectRatio='none'%3E%3Cpolygon points='0,0 8,0 10,10 12,0 20,0 22,7 24,0 32,0 35,12 38,0 46,0 48,8 50,0 58,0 61,11 64,0 72,0 74,6 76,0 84,0 87,12 90,0 98,0 100,9 102,0 110,0 113,11 116,0 124,0 126,7 128,0 136,0 139,12 142,0 150,0 152,8 154,0 162,0 165,10 168,0 176,0 178,6 180,0 188,0 191,12 194,0 200,0 200,0 0,0'/%3E%3C/svg%3E");
@@ -2775,7 +2780,7 @@ html.rgb-cycling *::after {
 
 /* ── Dark Souls fireline overlay ──────────────────────── */
 .fx-ds-fireline {
-  position: fixed; bottom: 0; left: 0; right: 0; height: 10px;
+  position: fixed; bottom: 0; left: 0; right: 0; height: 0.625rem;
   background: linear-gradient(90deg,
     transparent 0%, rgba(180,60,5,0.25) 15%, rgba(200,110,20,0.4) 35%,
     rgba(210,140,40,0.5) 50%, rgba(200,110,20,0.4) 65%,
@@ -2887,23 +2892,23 @@ html.rgb-cycling *::after {
 
 /* ─── Custom Theme Triangle Picker ───────────────────── */
 #custom-theme-editor {
-  margin-top: 8px;
-  padding: 8px;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
 }
 #custom-hue-bar {
   width: 100%;
-  height: 18px;
+  height: 1.125rem;
   border-radius: var(--radius-sm);
   cursor: crosshair;
   display: block;
-  margin-bottom: 6px;
+  margin-bottom: 0.375rem;
 }
 #custom-triangle {
   width: 100%;
-  height: 180px;
+  height: 11.25rem;
   cursor: crosshair;
   display: block;
   border-radius: var(--radius-sm);
@@ -2911,8 +2916,8 @@ html.rgb-cycling *::after {
 
 /* ─── RGB Theme Editor ───────────────────────── */
 .rgb-theme-editor {
-  margin-top: 8px;
-  padding: 8px 10px;
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.625rem;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -2921,20 +2926,20 @@ html.rgb-cycling *::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 4px;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
   cursor: default;
 }
 .rgb-slider-row:last-child { margin-bottom: 0; }
 .rgb-slider-label {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 600;
   color: var(--text-secondary);
-  min-width: 50px;
+  min-width: 3.125rem;
 }
 .rgb-slider {
   flex: 1;
-  height: 4px;
+  height: 0.25rem;
   accent-color: var(--accent);
   cursor: pointer;
 }
@@ -2952,37 +2957,37 @@ html.rgb-cycling *::after {
   overflow-y: auto;
 }
 
-.auth-container { width: 100%; max-width: 400px; padding: 20px; margin: auto 0; }
+.auth-container { width: 100%; max-width: 25rem; padding: 1.25rem; margin: auto 0; }
 
 .auth-card {
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 32px;
+  border-radius: 0.75rem;
+  padding: 2rem;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
 }
 
-.auth-header { text-align: center; margin-bottom: 28px; }
+.auth-header { text-align: center; margin-bottom: 1.75rem; }
 
-.auth-header .logo { font-size: 48px; color: var(--accent); line-height: 1; }
+.auth-header .logo { font-size: 3rem; color: var(--accent); line-height: 1; }
 
 .auth-header h1 {
-  font-size: 28px;
+  font-size: 1.75rem;
   font-weight: 700;
   letter-spacing: 6px;
   color: var(--text-primary);
-  margin: 6px 0 0;
+  margin: 0.375rem 0 0;
   font-family: var(--font-heading);
 }
 
-.auth-header .tagline { color: var(--text-secondary); font-size: 12px; margin: 1px 0 0; }
+.auth-header .tagline { color: var(--text-secondary); font-size: 0.75rem; margin: 0.0625rem 0 0; }
 
 .auth-header .server-title {
   color: var(--text-primary);
-  font-size: 24px;
+  font-size: 1.5rem;
   font-weight: 600;
   letter-spacing: 1px;
-  margin: 6px 0 0;
+  margin: 0.375rem 0 0;
   font-family: var(--font-heading);
   word-break: break-word;
 }
@@ -2992,8 +2997,8 @@ html.rgb-cycling *::after {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  margin-top: 6px;
+  gap: 0.125rem;
+  margin-top: 0.375rem;
 }
 .auth-recovery-links a {
   color: var(--text-muted);
@@ -3003,20 +3008,20 @@ html.rgb-cycling *::after {
 
 .auth-tabs {
   display: flex;
-  gap: 4px;
+  gap: 0.25rem;
   background: var(--bg-primary);
   border-radius: var(--radius);
-  padding: 4px;
-  margin-bottom: 24px;
+  padding: 0.25rem;
+  margin-bottom: 1.5rem;
 }
 
 .auth-tab {
   flex: 1;
-  padding: 8px;
+  padding: 0.5rem;
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
   transition: all var(--transition);
 }
@@ -3024,12 +3029,12 @@ html.rgb-cycling *::after {
 .auth-tab:hover { color: var(--text-primary); }
 .auth-tab.active { background: var(--accent); color: white; }
 
-.auth-form { display: flex; flex-direction: column; gap: 16px; }
+.auth-form { display: flex; flex-direction: column; gap: 1rem; }
 
-.form-group { display: flex; flex-direction: column; gap: 4px; }
+.form-group { display: flex; flex-direction: column; gap: 0.25rem; }
 
 .form-group label {
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -3037,25 +3042,25 @@ html.rgb-cycling *::after {
 }
 
 .form-group input {
-  padding: 10px 12px;
+  padding: 0.625rem 0.75rem;
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 15px;
+  font-size: 0.9375rem;
   transition: border-color var(--transition);
 }
 
 .form-group input:focus { border-color: var(--accent); }
-.form-group small { font-size: 11px; color: var(--text-muted); }
+.form-group small { font-size: 0.6875rem; color: var(--text-muted); }
 
 .form-select {
-  padding: 10px 12px;
+  padding: 0.625rem 0.75rem;
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 0.875rem;
   transition: border-color var(--transition);
   cursor: pointer;
   appearance: auto;
@@ -3063,26 +3068,26 @@ html.rgb-cycling *::after {
 .form-select:focus { border-color: var(--accent); outline: none; }
 
 .btn-primary {
-  padding: 11px 20px;
+  padding: 0.6875rem 1.25rem;
   background: var(--accent);
   color: white;
   border-radius: var(--radius);
-  font-size: 15px;
+  font-size: 0.9375rem;
   font-weight: 600;
   transition: background var(--transition);
-  margin-top: 4px;
+  margin-top: 0.25rem;
 }
 
 .btn-primary:hover { background: var(--accent-hover); }
 
 .auth-error {
-  margin-top: 16px;
-  padding: 10px 14px;
+  margin-top: 1rem;
+  padding: 0.625rem 0.875rem;
   background: rgba(240,71,71,0.12);
   border: 1px solid var(--danger);
   border-radius: var(--radius-sm);
   color: var(--danger);
-  font-size: 13px;
+  font-size: 0.8125rem;
   text-align: center;
 }
 
@@ -3090,32 +3095,32 @@ html.rgb-cycling *::after {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 6px;
-  margin-top: 20px;
-  padding: 16px 12px 0;
+  gap: 0.375rem;
+  margin-top: 1.25rem;
+  padding: 1rem 0.75rem 0;
   border-top: 1px solid var(--border);
-  max-width: 360px;
+  max-width: 22.5rem;
   margin-left: auto;
   margin-right: auto;
 }
 
 .auth-theme-bar .theme-btn {
-  width: 28px;
-  height: 28px;
-  font-size: 11px;
+  width: 1.75rem;
+  height: 1.75rem;
+  font-size: 0.6875rem;
   flex-shrink: 0;
 }
 
 .auth-lang-bar {
   display: flex;
   justify-content: center;
-  margin-top: 10px;
+  margin-top: 0.625rem;
 }
 
 .auth-version {
   text-align: center;
-  margin-top: 12px;
-  font-size: 11px;
+  margin-top: 0.75rem;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   font-family: var(--font-mono);
   opacity: 0.7;
@@ -3145,8 +3150,8 @@ html.rgb-cycling *::after {
 
 .sidebar {
   width: var(--sidebar-width);
-  min-width: 200px;
-  max-width: 400px;
+  min-width: 12.5rem;
+  max-width: 25rem;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border);
   display: flex;
@@ -3160,7 +3165,7 @@ html.rgb-cycling *::after {
   position: absolute;
   top: 0;
   right: -3px;
-  width: 6px;
+  width: 0.375rem;
   height: 100%;
   cursor: col-resize;
   z-index: 10;
@@ -3177,14 +3182,14 @@ html.rgb-cycling *::after {
   opacity: 0.5;
 }
 
-.sidebar-header { padding: 16px; border-bottom: 1px solid var(--border); }
+.sidebar-header { padding: 1rem; border-bottom: 1px solid var(--border); }
 
-.brand { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
-.logo-sm { font-size: 24px; color: var(--accent); }
-.brand-icon { width: 28px; height: 28px; border-radius: 6px; object-fit: cover; flex-shrink: 0; }
+.brand { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+.logo-sm { font-size: 1.5rem; color: var(--accent); }
+.brand-icon { width: 1.75rem; height: 1.75rem; border-radius: 0.375rem; object-fit: cover; flex-shrink: 0; }
 
 .brand-text {
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 700;
   letter-spacing: 4px;
   color: var(--text-primary);
@@ -3194,8 +3199,8 @@ html.rgb-cycling *::after {
 .user-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
   background: var(--bg-primary);
   border-radius: var(--radius-sm);
 }
@@ -3209,7 +3214,7 @@ html.rgb-cycling *::after {
 }
 
 .current-user {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-primary);
   overflow: hidden;
@@ -3218,7 +3223,7 @@ html.rgb-cycling *::after {
 }
 
 .login-name {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
   opacity: 0.7;
   overflow: hidden;
@@ -3230,8 +3235,8 @@ html.rgb-cycling *::after {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  font-size: 16px;
-  padding: 4px;
+  font-size: 1rem;
+  padding: 0.25rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all var(--transition);
@@ -3242,10 +3247,10 @@ html.rgb-cycling *::after {
 
 .icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
 .icon-btn.active { color: var(--accent); background: rgba(var(--accent-rgb, 124,92,252), 0.15); }
-.icon-btn.small { font-size: 13px; }
+.icon-btn.small { font-size: 0.8125rem; }
 .icon-btn.danger:hover { color: var(--danger); }
 
-.sidebar-section { padding: 12px 16px; border-bottom: 1px solid var(--border); }
+.sidebar-section { padding: 0.75rem 1rem; border-bottom: 1px solid var(--border); }
 .sidebar-section.channel-section {
   flex: 1;
   min-height: 0;
@@ -3256,35 +3261,35 @@ html.rgb-cycling *::after {
 }
 
 .section-label {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.8px;
   color: var(--text-muted);
-  margin-bottom: 6px;
+  margin-bottom: 0.375rem;
 }
 
-.input-row { display: flex; gap: 6px; }
+.input-row { display: flex; gap: 0.375rem; }
 
 .input-row input {
   flex: 1;
-  padding: 7px 10px;
+  padding: 0.4375rem 0.625rem;
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   min-width: 0;
 }
 
 .input-row input:focus { border-color: var(--accent); }
 
 .btn-sm {
-  padding: 7px 12px;
+  padding: 0.4375rem 0.75rem;
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   transition: all var(--transition);
   white-space: nowrap;
@@ -3314,20 +3319,20 @@ html.rgb-cycling *::after {
 }
 
 .btn-sm:hover { background: var(--bg-hover); color: var(--text-primary); }
-.btn-sm.btn-accent { background: var(--accent); color: white; font-size: 16px; padding: 7px 10px; line-height: 1; }
+.btn-sm.btn-accent { background: var(--accent); color: white; font-size: 1rem; padding: 0.4375rem 0.625rem; line-height: 1; }
 .btn-sm.btn-accent:hover { background: var(--accent-hover); }
-.btn-sm.btn-danger { background: var(--danger, #e74c3c); color: white; font-size: 16px; padding: 7px 10px; line-height: 1; }
+.btn-sm.btn-danger { background: var(--danger, #e74c3c); color: white; font-size: 1rem; padding: 0.4375rem 0.625rem; line-height: 1; }
 .btn-sm.btn-danger:hover { filter: brightness(1.15); }
 
 /* ── Channel List ──────────────────────────────────────── */
 
-.channel-list { flex: 1; overflow-y: auto; padding: 4px 0; }
+.channel-list { flex: 1; overflow-y: auto; padding: 0.25rem 0; }
 
 .channel-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;       /* 8px 16px */
   cursor: pointer;
   transition: background var(--transition);
   position: relative;
@@ -3342,15 +3347,15 @@ html.rgb-cycling *::after {
   content: '';
   position: absolute;
   left: 0; top: 4px; bottom: 4px;
-  width: 3px;
+  width: 0.1875rem;
   background: var(--accent);
-  border-radius: 0 2px 2px 0;
+  border-radius: 0 0.125rem 0.125rem 0;
 }
 
-.channel-hash { color: var(--text-muted); font-weight: 700; font-size: 16px; flex-shrink: 0; }
+.channel-hash { color: var(--text-muted); font-weight: 700; font-size: 1rem; flex-shrink: 0; }
 
 .channel-name {
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-secondary);
   flex: 1;
   overflow: hidden;
@@ -3364,24 +3369,24 @@ html.rgb-cycling *::after {
 .channel-badge {
   background: var(--danger);
   color: white;
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
-  min-width: 18px;
-  height: 18px;
-  border-radius: 9px;
+  min-width: 1.125rem;
+  height: 1.125rem;
+  border-radius: 0.5625rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 5px;
+  padding: 0 0.3125rem;
 }
 
 /* Thread @mention bell badge in sidebar — distinct amber/yellow */
 .channel-badge.thread-mention-badge {
   background: #f5a623;
   color: #1a1a1a;
-  font-size: 10px;
-  margin-left: 4px;
-  padding: 0 6px;
+  font-size: 0.625rem;
+  margin-left: 0.25rem;
+  padding: 0 0.375rem;
 }
 
 /* Nested-unread dot — small marker on category labels and parent
@@ -3391,8 +3396,8 @@ html.rgb-cycling *::after {
    itself. (#5302-ish parent-notif request) */
 .channel-badge-nested-dot {
   display: inline-block;
-  width: 7px;
-  height: 7px;
+  width: 0.4375rem;
+  height: 0.4375rem;
   border-radius: 50%;
   background: var(--accent, #5865f2);
   opacity: 0.85;
@@ -3409,13 +3414,13 @@ html.rgb-cycling *::after {
   background: rgba(245, 166, 35, 0.18);
   color: #f5a623;
   border: 1px solid rgba(245, 166, 35, 0.6);
-  padding: 2px 8px;
+  padding: 0.125rem 0.5rem;
   font-weight: 700;
-  border-radius: 12px;
+  border-radius: 0.75rem;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
 }
 .thread-mentions-pill:hover {
   background: rgba(245, 166, 35, 0.32);
@@ -3433,18 +3438,18 @@ html.rgb-cycling *::after {
   flex-direction: column;
   background: var(--bg-primary, #1e1e1e);
   border: 1px solid var(--border, #444);
-  border-radius: 10px;
+  border-radius: 0.625rem;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
   overflow: hidden;
   resize: both;
-  min-width: 280px;
-  min-height: 220px;
+  min-width: 17.5rem;
+  min-height: 13.75rem;
 }
 .pins-pip-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
   background: rgba(20, 20, 20, 0.55);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
@@ -3453,10 +3458,10 @@ html.rgb-cycling *::after {
   user-select: none;
   flex-shrink: 0;
 }
-.pins-pip-icon { font-size: 15px; flex: 0 0 auto; }
+.pins-pip-icon { font-size: 0.9375rem; flex: 0 0 auto; }
 .pins-pip-title {
   font-weight: 600;
-  font-size: 13px;
+  font-size: 0.8125rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3465,12 +3470,12 @@ html.rgb-cycling *::after {
 .pins-pip-list {
   flex: 1;
   overflow-y: auto;
-  padding: 4px 0;
+  padding: 0.25rem 0;
   min-height: 0;
 }
-.pins-pip-panel.pins-pip-maximized { left: 50% !important; top: 50% !important; transform: translate(-50%, -50%); width: 90vw !important; height: 85vh !important; border-radius: 12px; resize: none; }
+.pins-pip-panel.pins-pip-maximized { left: 50% !important; top: 50% !important; transform: translate(-50%, -50%); width: 90vw !important; height: 85vh !important; border-radius: 0.75rem; resize: none; }
 .pins-pip-panel.pins-pip-maximized .pins-pip-header { cursor: default; }
-.pinned-panel-actions { display: flex; align-items: center; gap: 2px; }
+.pinned-panel-actions { display: flex; align-items: center; gap: 0.125rem; }
 
 /* ── DM Picture-in-Picture floating panel ──────────
    A draggable/resizable overlay that hosts a full-fidelity DM
@@ -3486,12 +3491,12 @@ html.rgb-cycling *::after {
   flex-direction: column;
   background: var(--bg-primary, #1e1e1e);
   border: 1px solid var(--border, #444);
-  border-radius: 10px;
+  border-radius: 0.625rem;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
   overflow: hidden;
   resize: both;
-  min-width: 320px;
-  min-height: 280px;
+  min-width: 20rem;
+  min-height: 17.5rem;
 }
 /* Banner background — rendered behind everything else */
 .dm-pip-banner {
@@ -3522,8 +3527,8 @@ html.rgb-cycling *::after {
 .dm-pip-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
   background: rgba(20, 20, 20, 0.55);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
@@ -3533,15 +3538,15 @@ html.rgb-cycling *::after {
 }
 .dm-pip-avatar-wrap {
   position: relative;
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   flex: 0 0 28px;
   border-radius: 50%;
   background: var(--bg-secondary, #2a2a2a);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 700;
   color: #fff;
   /* Inner avatar imagery is rounded by inheriting the wrap's border-radius
@@ -3556,9 +3561,9 @@ html.rgb-cycling *::after {
   border-radius: inherit;
 }
 .dm-pip-avatar-wrap.avatar-square,
-.dm-pip-avatar-wrap.avatar-square img { border-radius: 6px; }
+.dm-pip-avatar-wrap.avatar-square img { border-radius: 0.375rem; }
 .dm-pip-avatar-wrap.avatar-rounded,
-.dm-pip-avatar-wrap.avatar-rounded img { border-radius: 8px; }
+.dm-pip-avatar-wrap.avatar-rounded img { border-radius: 0.5rem; }
 .dm-pip-avatar-initial {
   position: relative;
   z-index: 0;
@@ -3569,8 +3574,8 @@ html.rgb-cycling *::after {
   position: absolute;
   right: -2px;
   bottom: -2px;
-  width: 10px;
-  height: 10px;
+  width: 0.625rem;
+  height: 0.625rem;
   border-radius: 50%;
   background: #2ecc71; /* online (default) */
   border: 2px solid var(--bg-primary, #1e1e1e);
@@ -3580,36 +3585,37 @@ html.rgb-cycling *::after {
 .dm-pip-status-dot.away    { background: #95a5a6; }
 .dm-pip-status-dot.dnd     { background: #e74c3c; }
 .dm-pip-status-dot.invisible { background: transparent; border-color: var(--text-muted, #888); }
-.dm-pip-title { font-weight: 600; font-size: 13px; }
+.dm-pip-title { font-weight: 600; font-size: 0.8125rem; }
 .dm-pip-spacer { flex: 1; }
 .dm-pip-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 6px 8px 8px;
-  font-size: 13px;
+  padding: 0.375rem 0.5rem 0.5rem;
+  font-size: 0.8125rem;
   line-height: 1.4;
 }
 .dm-pip-loading {
   opacity: 0.7;
   font-style: italic;
   text-align: center;
-  padding: 12px;
+  padding: 0.75rem;
 }
 /* ── Reuse main message DOM but compact it for PiP ── */
 .dm-pip-messages .message,
 .dm-pip-messages .message-compact {
-  padding: 2px 6px;
+  padding: 0.125rem 0.375rem;
   margin: 0;
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 /* Defeat density-overrides (e.g. [data-density="compact"] .message-compact
-   { padding-left: 44px }) that would otherwise recess follow-up messages
-   in the PiP, making them look misaligned with the first message in a
-   group. PiP always uses a flush left edge for both root and follow-ups. */
+   { padding-left: 2.75rem }) that would otherwise recess follow-up messages
+   to align under the avatar and misalign them with the first message in a
+   group inside the PiP. PiP always uses a flush left edge for both root and
+   follow-ups. */
 .dm-pip-panel .dm-pip-messages .message,
 .dm-pip-panel .dm-pip-messages .message-compact {
-  padding-left: 6px;
-  padding-right: 6px;
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
 }
 .dm-pip-messages .message-row {
   gap: 0;
@@ -3641,19 +3647,19 @@ html.rgb-cycling *::after {
 }
 .dm-pip-messages .message.message-has-status .message-body,
 .dm-pip-messages .message-compact.message-has-status .message-body {
-  padding-right: 28px;
+  padding-right: 1.75rem;
 }
 .dm-pip-messages .message-inline-status {
   right: 12px;
 }
 .dm-pip-messages .message-header {
-  gap: 6px;
-  margin-bottom: 1px;
+  gap: 0.375rem;
+  margin-bottom: 0.0625rem;
 }
-.dm-pip-messages .message-author { font-size: 12.5px; font-weight: 600; }
-.dm-pip-messages .message-time { font-size: 10.5px; opacity: 0.7; }
+.dm-pip-messages .message-author { font-size: 0.78125rem; font-weight: 600; }
+.dm-pip-messages .message-time { font-size: 0.65625rem; opacity: 0.7; }
 .dm-pip-messages .message-content {
-  font-size: 13px;
+  font-size: 0.8125rem;
   word-wrap: break-word;
   overflow-wrap: anywhere;
 }
@@ -3661,7 +3667,7 @@ html.rgb-cycling *::after {
    timestamp on the right side of the row instead. That way it appears
    on hover without shifting any content leftward. */
 .dm-pip-messages .message-compact .compact-time {
-  font-size: 10px;
+  font-size: 0.625rem;
   text-align: right;
   left: auto;
   right: 6px;
@@ -3670,41 +3676,41 @@ html.rgb-cycling *::after {
   padding-right: 0;
 }
 /* Slim reactions, polls, link previews to fit the smaller frame */
-.dm-pip-messages .reactions-row { gap: 4px; margin-top: 2px; }
+.dm-pip-messages .reactions-row { gap: 0.25rem; margin-top: 0.125rem; }
 .dm-pip-messages .reaction-badge {
-  padding: 1px 6px;
-  font-size: 11px;
+  padding: 0.0625rem 0.375rem;
+  font-size: 0.6875rem;
 }
 .dm-pip-messages .reply-banner {
-  font-size: 11px;
-  padding: 2px 6px;
-  margin-bottom: 2px;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  margin-bottom: 0.125rem;
 }
 .dm-pip-messages img,
 .dm-pip-messages video,
 .dm-pip-messages .link-preview {
   max-width: 100%;
 }
-.dm-pip-messages .link-preview { font-size: 11px; }
+.dm-pip-messages .link-preview { font-size: 0.6875rem; }
 /* Toolbar buttons stay clickable but become more compact */
-.dm-pip-messages .msg-toolbar { font-size: 11px; }
-.dm-pip-messages .msg-toolbar button { padding: 2px 4px; }
+.dm-pip-messages .msg-toolbar { font-size: 0.6875rem; }
+.dm-pip-messages .msg-toolbar button { padding: 0.125rem 0.25rem; }
 .dm-pip-reply-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 10px;
+  gap: 0.5rem;
+  padding: 0.25rem 0.625rem;
   background: rgba(20, 20, 20, 0.65);
   border-top: 1px solid var(--border, #444);
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-secondary, #aaa);
 }
 .dm-pip-reply-bar > span { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .dm-pip-input-area {
   display: flex;
   align-items: flex-end;
-  gap: 6px;
-  padding: 14px 8px 8px;
+  gap: 0.375rem;
+  padding: 0.875rem 0.5rem 0.5rem;
   border-top: 1px solid var(--border, #444);
   background: rgba(20, 20, 20, 0.55);
   backdrop-filter: blur(6px);
@@ -3713,23 +3719,23 @@ html.rgb-cycling *::after {
 .dm-pip-input {
   flex: 1;
   resize: none;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   border: 1px solid var(--border, #444);
   background: var(--bg-primary, #1e1e1e);
   color: var(--text-primary, #ddd);
-  padding: 6px 8px;
+  padding: 0.375rem 0.5rem;
   font-family: inherit;
-  font-size: 13px;
-  min-height: 34px;
-  max-height: 200px;
+  font-size: 0.8125rem;
+  min-height: 2.125rem;
+  max-height: 12.5rem;
   overflow-y: auto;
 }
 .dm-pip-send {
   background: var(--accent, #5865f2);
   color: #fff;
   border: none;
-  border-radius: 6px;
-  padding: 0 10px;
+  border-radius: 0.375rem;
+  padding: 0 0.625rem;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -3743,7 +3749,7 @@ html.rgb-cycling *::after {
   top: 0;
   left: 0;
   right: 0;
-  height: 14px;
+  height: 0.875rem;
   cursor: ns-resize;
   display: flex;
   align-items: center;
@@ -3752,10 +3758,10 @@ html.rgb-cycling *::after {
 }
 .pip-input-resizer::before {
   content: '';
-  width: 36px;
-  height: 3px;
+  width: 2.25rem;
+  height: 0.1875rem;
   background: var(--border, #555);
-  border-radius: 2px;
+  border-radius: 0.125rem;
   opacity: 0.5;
   transition: opacity 0.15s, background 0.15s;
 }
@@ -3769,10 +3775,10 @@ html.rgb-cycling *::after {
   flex-shrink: 0;
   background: none;
   border: none;
-  border-radius: 6px;
-  font-size: 18px;
+  border-radius: 0.375rem;
+  font-size: 1.125rem;
   line-height: 1;
-  padding: 4px 5px;
+  padding: 0.25rem 0.3125rem;
   cursor: pointer;
   opacity: 0.7;
   transition: opacity 0.15s, background 0.15s;
@@ -3784,8 +3790,8 @@ html.rgb-cycling *::after {
 }
 .pip-input-emoji-btn:hover { opacity: 1; background: var(--bg-tertiary); }
 .pip-input-emoji-btn .tb-icon { display: inline-flex; align-items: center; justify-content: center; }
-.pip-input-emoji-btn .tb-icon-emoji { font-size: 18px; }
-.pip-input-emoji-btn svg { width: 20px; height: 20px; display: block; }
+.pip-input-emoji-btn .tb-icon-emoji { font-size: 1.125rem; }
+.pip-input-emoji-btn svg { width: 1.25rem; height: 1.25rem; display: block; }
 
 /* ── Private channel styling (muted appearance) ─── */
 .channel-item.private-channel .channel-name { opacity: 0.6; }
@@ -3797,25 +3803,25 @@ html.rgb-cycling *::after {
 
 /* ── Role channel access panel ─── */
 .role-channel-access-section {
-  margin-top: 16px;
+  margin-top: 1rem;
   border-top: 1px solid var(--border);
-  padding-top: 12px;
+  padding-top: 0.75rem;
 }
-.role-channel-access-section h5 { margin: 0 0 8px; }
+.role-channel-access-section h5 { margin: 0 0 0.5rem; }
 .role-channel-access-list {
-  max-height: 260px;
+  max-height: 16.25rem;
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-secondary);
-  padding: 4px 0;
+  padding: 0.25rem 0;
 }
 .rca-channel-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  font-size: 13px;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
 }
 .rca-channel-row:hover { background: var(--bg-hover); }
 .rca-channel-name {
@@ -3825,19 +3831,19 @@ html.rgb-cycling *::after {
   white-space: nowrap;
   color: var(--text-secondary);
 }
-.rca-channel-name.rca-sub { padding-left: 16px; opacity: 0.85; }
+.rca-channel-name.rca-sub { padding-left: 1rem; opacity: 0.85; }
 .rca-channel-row label {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 11px;
+  gap: 0.25rem;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   white-space: nowrap;
   cursor: pointer;
 }
 .rca-reapply-btn {
-  margin-top: 8px;
-  font-size: 12px;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
 }
 
 /* ── Main Content ──────────────────────────────────────── */
@@ -3856,24 +3862,24 @@ html.rgb-cycling *::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 20px;
+  padding: 0.75rem 1.25rem;
   border-bottom: 1px solid var(--border);
-  min-height: 52px;
-  gap: 12px;
+  min-height: 3.25rem;
+  gap: 0.75rem;
   position: relative;
   z-index: 1;
 }
 
-.channel-info { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.channel-info { display: flex; align-items: center; gap: 0.625rem; min-width: 0; }
 
 /* ── Header actions box (code/settings | search/pin) ── */
 .header-actions-box {
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding: 3px 8px;
+  gap: 0.3125rem;
+  padding: 0.1875rem 0.5rem;
   border: 1px solid var(--border, rgba(255,255,255,0.1));
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: var(--bg-tertiary, rgba(255,255,255,0.03));
   flex-shrink: 0;
 }
@@ -3885,17 +3891,17 @@ html.rgb-cycling *::after {
   opacity: 1;
 }
 .header-actions-divider {
-  width: 1px;
-  height: 18px;
+  width: 0.0625rem;
+  height: 1.125rem;
   background: var(--border, rgba(255,255,255,0.12));
   flex-shrink: 0;
-  margin: 0 2px;
+  margin: 0 0.125rem;
 }
 
 .header-left-actions {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 0.3125rem;
   flex-shrink: 0;
 }
 
@@ -3903,13 +3909,13 @@ html.rgb-cycling *::after {
 .update-banner {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 12px;
+  gap: 0.375rem;
+  padding: 0.25rem 0.75rem;
   background: linear-gradient(135deg, var(--accent), var(--accent-hover));
   color: #fff;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
-  border-radius: 20px;
+  border-radius: 1.25rem;
   text-decoration: none;
   white-space: nowrap;
   flex-shrink: 0;
@@ -3923,8 +3929,8 @@ html.rgb-cycling *::after {
   color: #fff;
 }
 .update-pulse {
-  width: 8px;
-  height: 8px;
+  width: 0.5rem;
+  height: 0.5rem;
   background: #fff;
   border-radius: 50%;
   animation: updatePulse 1.5s ease-in-out infinite;
@@ -3942,13 +3948,13 @@ html.rgb-cycling *::after {
 .desktop-app-banner {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 12px;
+  gap: 0.375rem;
+  padding: 0.25rem 0.75rem;
   background: linear-gradient(135deg, #1abc9c, #16a085);
   color: #fff;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
-  border-radius: 20px;
+  border-radius: 1.25rem;
   text-decoration: none;
   white-space: nowrap;
   flex-shrink: 0;
@@ -3963,7 +3969,7 @@ html.rgb-cycling *::after {
   color: #fff;
 }
 .desktop-app-icon {
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1;
 }
 .desktop-app-text {
@@ -3973,9 +3979,9 @@ html.rgb-cycling *::after {
   background: none;
   border: none;
   color: rgba(255,255,255,0.7);
-  font-size: 15px;
+  font-size: 0.9375rem;
   cursor: pointer;
-  padding: 0 0 0 4px;
+  padding: 0 0 0 0.25rem;
   line-height: 1;
   transition: color 0.15s;
 }
@@ -3987,13 +3993,13 @@ html.rgb-cycling *::after {
 .android-beta-banner {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 12px;
+  gap: 0.375rem;
+  padding: 0.25rem 0.75rem;
   background: linear-gradient(135deg, #3ddc84, #2bb55e);
   color: #fff;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
-  border-radius: 20px;
+  border-radius: 1.25rem;
   border: none;
   text-decoration: none;
   white-space: nowrap;
@@ -4009,7 +4015,7 @@ html.rgb-cycling *::after {
   color: #fff;
 }
 .android-beta-icon {
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1;
 }
 .android-beta-text {
@@ -4019,9 +4025,9 @@ html.rgb-cycling *::after {
   background: none;
   border: none;
   color: rgba(255,255,255,0.7);
-  font-size: 15px;
+  font-size: 0.9375rem;
   cursor: pointer;
-  padding: 0 0 0 4px;
+  padding: 0 0 0 0.25rem;
   line-height: 1;
   transition: color 0.15s;
 }
@@ -4031,82 +4037,82 @@ html.rgb-cycling *::after {
 
 /* ── Android Beta Promo Popup ── */
 .android-beta-promo {
-  max-width: 460px;
+  max-width: 28.75rem;
   text-align: center;
-  padding: 36px 32px 28px;
+  padding: 2.25rem 2rem 1.75rem;
   border: 1px solid var(--border-light);
-  border-radius: 16px;
+  border-radius: 1rem;
   animation: desktopPromoIn 0.35s ease;
 }
 .android-beta-promo-icon {
-  font-size: 48px;
-  width: 80px;
-  height: 80px;
+  font-size: 3rem;
+  width: 5rem;
+  height: 5rem;
   line-height: 80px;
-  margin: 0 auto 16px;
+  margin: 0 auto 1rem;
   background: linear-gradient(135deg, #3ddc84, #2bb55e);
-  border-radius: 18px;
+  border-radius: 1.125rem;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 .android-beta-promo-title {
-  font-size: 22px;
+  font-size: 1.375rem;
   font-weight: 700;
   color: var(--text-primary);
-  margin: 0 0 4px;
+  margin: 0 0 0.25rem;
   text-align: center;
 }
 .android-beta-promo-badge {
   display: inline-block;
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.6px;
   background: linear-gradient(135deg, #3ddc84, #2bb55e);
   color: #fff;
-  padding: 2px 8px;
-  border-radius: 10px;
-  margin-bottom: 6px;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.625rem;
+  margin-bottom: 0.375rem;
 }
 .android-beta-promo-subtitle {
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-secondary);
-  margin: 0 0 16px;
+  margin: 0 0 1rem;
 }
 .android-beta-promo-features {
   list-style: none;
   padding: 0;
-  margin: 0 0 16px;
+  margin: 0 0 1rem;
   text-align: left;
   display: inline-block;
 }
 .android-beta-promo-features li {
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-primary);
-  padding: 4px 0;
+  padding: 0.25rem 0;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 0.625rem;
 }
 .android-beta-promo-note {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
-  margin: 0 0 16px;
+  margin: 0 0 1rem;
 }
 .android-beta-form {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
-  margin: 0 0 16px;
+  gap: 0.625rem;
+  margin: 0 0 1rem;
 }
 .android-beta-email-input {
   width: 100%;
-  max-width: 320px;
-  padding: 10px 14px;
-  font-size: 14px;
-  border-radius: 8px;
+  max-width: 20rem;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.875rem;
+  border-radius: 0.5rem;
   border: 1px solid var(--border);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -4118,10 +4124,10 @@ html.rgb-cycling *::after {
   box-shadow: 0 0 0 2px rgba(61, 220, 132, 0.2);
 }
 .android-beta-submit {
-  padding: 10px 24px;
-  font-size: 14px;
+  padding: 0.625rem 1.5rem;
+  font-size: 0.875rem;
   font-weight: 600;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: linear-gradient(135deg, #3ddc84, #2bb55e);
   color: #fff;
   border: none;
@@ -4133,22 +4139,22 @@ html.rgb-cycling *::after {
   box-shadow: 0 4px 16px rgba(61, 220, 132, 0.3);
 }
 .android-beta-promo-credit {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
-  margin: 0 0 16px;
+  margin: 0 0 1rem;
   font-style: italic;
 }
 .android-beta-promo-actions {
   display: flex;
   justify-content: center;
-  gap: 10px;
-  margin: 0 0 12px;
+  gap: 0.625rem;
+  margin: 0 0 0.75rem;
 }
 .android-beta-promo-later {
-  padding: 10px 20px;
-  font-size: 14px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
   font-weight: 500;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--border);
@@ -4159,12 +4165,12 @@ html.rgb-cycling *::after {
   background: var(--bg-tertiary);
 }
 .android-beta-promo-dismiss-label {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 0.375rem;
   cursor: pointer;
   user-select: none;
 }
@@ -4175,11 +4181,11 @@ html.rgb-cycling *::after {
 
 /* ── Desktop App Promo Popup ── */
 .desktop-promo {
-  max-width: 440px;
+  max-width: 27.5rem;
   text-align: center;
-  padding: 36px 32px 28px;
+  padding: 2.25rem 2rem 1.75rem;
   border: 1px solid var(--border-light);
-  border-radius: 16px;
+  border-radius: 1rem;
   animation: desktopPromoIn 0.35s ease;
 }
 @keyframes desktopPromoIn {
@@ -4187,83 +4193,83 @@ html.rgb-cycling *::after {
   to   { opacity: 1; transform: scale(1) translateY(0); }
 }
 .desktop-promo-icon {
-  font-size: 48px;
-  width: 80px;
-  height: 80px;
+  font-size: 3rem;
+  width: 5rem;
+  height: 5rem;
   line-height: 80px;
-  margin: 0 auto 16px;
+  margin: 0 auto 1rem;
   background: var(--accent);
-  border-radius: 18px;
+  border-radius: 1.125rem;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 .desktop-promo-title {
-  font-size: 22px;
+  font-size: 1.375rem;
   font-weight: 700;
   color: var(--text-primary);
-  margin: 0 0 4px;
+  margin: 0 0 0.25rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .desktop-promo-badge {
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.6px;
   background: var(--accent);
   color: #fff;
-  padding: 2px 8px;
-  border-radius: 10px;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.625rem;
 }
 .desktop-promo-subtitle {
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-secondary);
-  margin: 0 0 20px;
+  margin: 0 0 1.25rem;
 }
 .desktop-promo-features {
   list-style: none;
   padding: 0;
-  margin: 0 0 16px;
+  margin: 0 0 1rem;
   text-align: left;
   display: inline-block;
 }
 .desktop-promo-features li {
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-primary);
-  padding: 4px 0;
+  padding: 0.25rem 0;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 0.625rem;
 }
 .promo-check {
   color: var(--accent);
   font-weight: 700;
-  font-size: 16px;
+  font-size: 1rem;
   flex-shrink: 0;
 }
 .desktop-promo-meta {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
-  margin: 0 0 20px;
+  margin: 0 0 1.25rem;
 }
 .desktop-promo-actions {
   display: flex;
   justify-content: center;
-  gap: 10px;
-  margin: 0 0 16px;
+  gap: 0.625rem;
+  margin: 0 0 1rem;
 }
 .desktop-promo-install {
-  padding: 10px 24px;
-  font-size: 14px;
+  padding: 0.625rem 1.5rem;
+  font-size: 0.875rem;
   font-weight: 600;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   text-decoration: none;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   background: var(--accent);
   color: #fff;
   border: none;
@@ -4276,10 +4282,10 @@ html.rgb-cycling *::after {
   transform: scale(1.03);
 }
 .desktop-promo-later {
-  padding: 10px 20px;
-  font-size: 14px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
   font-weight: 500;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--border);
@@ -4290,12 +4296,12 @@ html.rgb-cycling *::after {
   background: var(--bg-tertiary);
 }
 .desktop-promo-dismiss-label {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 0.375rem;
   cursor: pointer;
   user-select: none;
 }
@@ -4310,8 +4316,8 @@ html.rgb-cycling *::after {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   font-size: 0.65rem;
   opacity: 0.75;
   overflow: hidden;
@@ -4319,8 +4325,8 @@ html.rgb-cycling *::after {
 .ch-disabled-badge::after {
   content: '';
   position: absolute;
-  width: 2px;
-  height: 20px;
+  width: 0.125rem;
+  height: 1.25rem;
   background: #e74c3c;
   top: 50%;
   left: 50%;
@@ -4337,10 +4343,10 @@ html.rgb-cycling *::after {
 .category-label[draggable="true"],
 .sub-channel-item[draggable="true"] { cursor: grab; }
 .ch-drag-indicator {
-  height: 2px;
+  height: 0.125rem;
   background: var(--accent);
-  border-radius: 2px;
-  margin: 1px 8px;
+  border-radius: 0.125rem;
+  margin: 0.0625rem 0.5rem;
   pointer-events: none;
   flex-shrink: 0;
 }
@@ -4348,9 +4354,9 @@ html.rgb-cycling *::after {
   background: none;
   border: none;
   color: var(--text-secondary);
-  font-size: 16px;
+  font-size: 1rem;
   cursor: pointer;
-  padding: 2px 5px;
+  padding: 0.125rem 0.3125rem;
   border-radius: var(--radius-sm);
   opacity: 0;
   pointer-events: none;
@@ -4373,18 +4379,18 @@ html.rgb-cycling *::after {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: 0 4px 16px rgba(0,0,0,0.35);
-  min-width: 170px;
-  padding: 4px;
+  min-width: 10.625rem;
+  padding: 0.25rem;
 }
 .channel-ctx-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
   background: none;
   border: none;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
   border-radius: var(--radius-sm);
   white-space: nowrap;
@@ -4397,7 +4403,7 @@ html.rgb-cycling *::after {
 .ctx-indicator {
   margin-left: auto;
   font-size: 0.85em;
-  padding-left: 10px;
+  padding-left: 0.625rem;
   white-space: nowrap;
 }
 
@@ -4405,23 +4411,23 @@ html.rgb-cycling *::after {
 .channel-functions-panel {
   position: fixed;
   background: var(--bg-secondary);
-  border-radius: 6px;
-  padding: 3px 0;
+  border-radius: 0.375rem;
+  padding: 0.1875rem 0;
   border: 1px solid var(--border);
   box-shadow: 0 4px 16px rgba(0,0,0,0.35);
   z-index: 10000;
-  min-width: 170px;
+  min-width: 10.625rem;
 }
 .cfn-divider {
   border-top: 1px solid var(--border);
-  margin: 3px 8px;
+  margin: 0.1875rem 0.5rem;
 }
 .cfn-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 5px 10px;
-  border-radius: 4px;
+  padding: 0.3125rem 0.625rem;
+  border-radius: 0.25rem;
   cursor: pointer;
   user-select: none;
   transition: background 0.1s;
@@ -4437,15 +4443,15 @@ html.rgb-cycling *::after {
   text-decoration-color: rgba(255,255,255,0.45);
 }
 .cfn-label {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-secondary);
 }
 .cfn-badge {
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
-  padding: 2px 7px;
-  border-radius: 3px;
-  min-width: 30px;
+  padding: 0.125rem 0.4375rem;
+  border-radius: 0.1875rem;
+  min-width: 1.875rem;
   text-align: center;
   letter-spacing: 0.3px;
 }
@@ -4458,36 +4464,36 @@ html.rgb-cycling *::after {
   color: var(--text-muted);
 }
 .cfn-input {
-  width: 54px;
+  width: 3.375rem;
   background: var(--bg-primary);
   border: 1px solid var(--accent, var(--border));
-  border-radius: 3px;
+  border-radius: 0.1875rem;
   color: var(--text-primary);
-  font-size: 11px;
-  padding: 2px 5px;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.3125rem;
   text-align: right;
   outline: none;
 }
 select.cfn-select.cfn-input {
   width: auto;
-  max-width: 120px;
+  max-width: 7.5rem;
   text-align: left;
 }
 /* Arrow indicator on the Channel Functions button */
 .channel-ctx-item [class="cfn-arrow"] {
   margin-left: auto;
-  font-size: 9px;
+  font-size: 0.5625rem;
   color: var(--text-muted);
 }
 
 .channel-ctx-sep {
   border: none;
   border-top: 1px solid var(--border);
-  margin: 3px 6px;
+  margin: 0.1875rem 0.375rem;
 }
 
 .channel-info h3 {
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -4496,11 +4502,11 @@ select.cfn-select.cfn-input {
 }
 
 .channel-code-tag {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-family: var(--font-mono);
   color: var(--text-muted);
   background: var(--bg-tertiary);
-  padding: 2px 8px;
+  padding: 0.125rem 0.5rem;   /* 2px 8px — scales with the font like the tag text */
   border-radius: 10px;
   letter-spacing: 0.5px;
 }
@@ -4513,16 +4519,16 @@ select.cfn-select.cfn-input {
 
 .welcome-content { text-align: center; color: var(--text-secondary); }
 
-.welcome-icon { font-size: 72px; color: var(--accent); opacity: 0.5; margin-bottom: 16px; }
+.welcome-icon { font-size: 4.5rem; color: var(--accent); opacity: 0.5; margin-bottom: 1rem; }
 
 .welcome-content h2 {
-  font-size: 24px;
+  font-size: 1.5rem;
   color: var(--text-primary);
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
   font-family: var(--font-heading);
 }
 
-.welcome-content p { font-size: 14px; line-height: 1.6; }
+.welcome-content p { font-size: 0.875rem; line-height: 1.6; }
 
 /* ── Message Area ──────────────────────────────────────── */
 
@@ -4534,8 +4540,8 @@ select.cfn-select.cfn-input {
   bottom: 120px;
   right: 24px;
   z-index: 50;
-  width: 36px;
-  height: 36px;
+  width: 2.25rem;
+  height: 2.25rem;
   border-radius: 50%;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
@@ -4565,10 +4571,10 @@ select.cfn-select.cfn-input {
   flex: 1;
   overflow-y: auto;
   overflow-anchor: none;
-  padding: 16px 20px;
+  padding: 1rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
   position: relative; /* for absolutely-positioned children like #msg-more-btn */
 }
 
@@ -4587,32 +4593,32 @@ select.cfn-select.cfn-input {
 
 .message-row {
   display: flex;
-  gap: 12px;
-  padding: 4px 8px;
+  gap: 0.75rem;               /* 12px */
+  padding: 0.25rem 0.5rem;    /* 4px 8px */
   position: relative;
 }
 
 .message-avatar {
-  width: 36px;
-  height: 36px;
+  width: 2.25rem;             /* 36px */
+  height: 2.25rem;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: 14px;
+  font-size: 0.875rem;        /* 14px */
   color: white;
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 
 .message-avatar-img {
-  width: 36px;
-  height: 36px;
+  width: 2.25rem;             /* 36px */
+  height: 2.25rem;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 
 /* User list avatars */
@@ -4620,16 +4626,16 @@ select.cfn-select.cfn-input {
 .user-avatar-wrapper {
   position: relative;
   flex-shrink: 0;
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .user-status-dot {
   position: absolute;
   bottom: -2px;
   right: -2px;
-  width: 10px;
-  height: 10px;
+  width: 0.625rem;
+  height: 0.625rem;
   border-radius: 50%;
   background: var(--success);
   border: 2px solid var(--bg-secondary);
@@ -4639,13 +4645,13 @@ select.cfn-select.cfn-input {
 /* Away: half-circle (dome) — visually distinct from full circle */
 .user-status-dot.away {
   background: #faa61a;
-  border-radius: 2px 2px 50% 50%;
+  border-radius: 0.125rem 0.125rem 50% 50%;
 }
 
 /* DND: square — immediately distinguishable */
 .user-status-dot.dnd {
   background: var(--danger);
-  border-radius: 2px;
+  border-radius: 0.125rem;
 }
 
 /* Invisible / Offline: hollow circle outline */
@@ -4660,35 +4666,35 @@ select.cfn-select.cfn-input {
 }
 
 .user-item-avatar {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: 10px;
+  font-size: 0.625rem;
   color: white;
   flex-shrink: 0;
 }
 
 .user-item-avatar-img {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
 }
 
 /* Avatar settings */
-.avatar-settings { padding: 4px 0; position: relative; z-index: 1; }
-.settings-section-subtitle { font-size: 13px; font-weight: 600; color: var(--text-secondary); margin-bottom: 10px; margin-top: 16px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
+.avatar-settings { padding: 0.25rem 0; position: relative; z-index: 1; }
+.settings-section-subtitle { font-size: 0.8125rem; font-weight: 600; color: var(--text-secondary); margin-bottom: 0.625rem; margin-top: 1rem; padding-bottom: 0.375rem; border-bottom: 1px solid var(--border); }
 
 /* Avatar Upload Row (Anmire-style) */
-.avatar-upload-row { display: flex; align-items: center; gap: 8px; }
+.avatar-upload-row { display: flex; align-items: center; gap: 0.5rem; }
 .avatar-upload-preview {
-  width: 48px;
-  height: 48px;
+  width: 3rem;
+  height: 3rem;
   border-radius: 50%;
   overflow: hidden;
   flex-shrink: 0;
@@ -4703,26 +4709,26 @@ select.cfn-select.cfn-input {
 }
 
 /* Avatar Shape Picker */
-.avatar-shape-picker { display: flex; gap: 8px; flex-wrap: wrap; }
+.avatar-shape-picker { display: flex; gap: 0.5rem; flex-wrap: wrap; }
 .avatar-shape-btn {
-  width: 38px; height: 38px;
+  width: 2.375rem; height: 2.375rem;
   display: flex; align-items: center; justify-content: center;
   background: var(--bg-tertiary, #2a2a2e); border: 2px solid var(--border);
-  border-radius: 6px; cursor: pointer;
+  border-radius: 0.375rem; cursor: pointer;
   transition: border-color 0.2s, box-shadow 0.2s;
 }
 .avatar-shape-btn:hover { border-color: var(--text-secondary); }
 .avatar-shape-btn.active { border-color: var(--accent); box-shadow: 0 0 8px rgba(var(--accent-rgb, 88,101,242), 0.4); }
-.shape-preview { width: 20px; height: 20px; background: var(--accent, #5865f2); }
+.shape-preview { width: 1.25rem; height: 1.25rem; background: var(--accent, #5865f2); }
 .shape-circle   { border-radius: 50%; }
-.shape-rounded  { border-radius: 4px; }
+.shape-rounded  { border-radius: 0.25rem; }
 .shape-squircle { border-radius: 28%; }
 .shape-hex      { clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%); }
 .shape-diamond  { clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%); }
 
 /* Avatar Shape Classes — applied to .message-avatar and .message-avatar-img */
 .avatar-circle   { border-radius: 50% !important; }
-.avatar-rounded  { border-radius: 6px !important; }
+.avatar-rounded  { border-radius: 0.375rem !important; }
 .avatar-squircle { border-radius: 28% !important; }
 .avatar-hex      { clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%); border-radius: 0 !important; }
 .avatar-diamond  { clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%); border-radius: 0 !important; }
@@ -4732,21 +4738,21 @@ select.cfn-select.cfn-input {
   width: 100%;
   -webkit-appearance: none;
   appearance: none;
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   background: var(--bg-tertiary, #2a2a2e);
   outline: none;
 }
 #avatar-size-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 16px; height: 16px;
+  width: 1rem; height: 1rem;
   border-radius: 50%;
   background: var(--accent, #5865f2);
   cursor: pointer;
   border: 2px solid var(--bg-primary, #1e1e22);
 }
 #avatar-size-slider::-moz-range-thumb {
-  width: 16px; height: 16px;
+  width: 1rem; height: 1rem;
   border-radius: 50%;
   background: var(--accent, #5865f2);
   cursor: pointer;
@@ -4757,21 +4763,21 @@ select.cfn-select.cfn-input {
 .custom-sound-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 0;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
   border-bottom: 1px solid var(--border);
 }
 .custom-sound-item:last-child { border-bottom: none; }
-.custom-sound-name { flex: 1; font-size: 13px; color: var(--text-primary); }
+.custom-sound-name { flex: 1; font-size: 0.8125rem; color: var(--text-primary); }
 .custom-sound-name-input {
-  flex: 1; font-size: 12px; padding: 2px 6px; border-radius: 4px;
+  flex: 1; font-size: 0.75rem; padding: 0.125rem 0.375rem; border-radius: 0.25rem;
   border: 1px solid var(--accent); background: var(--bg-input);
   color: var(--text-primary); outline: none;
 }
 .btn-xs {
-  padding: 2px 8px;
-  font-size: 11px;
-  border-radius: 4px;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  border-radius: 0.25rem;
   border: 1px solid var(--border);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -4782,11 +4788,11 @@ select.cfn-select.cfn-input {
 
 /* ── Sound Manager Popout ─────────────────────────────────── */
 .sound-modal-tabs {
-  display: flex; gap: 4px; margin-bottom: 12px;
-  border-bottom: 1px solid var(--border); padding-bottom: 8px;
+  display: flex; gap: 0.25rem; margin-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;
 }
 .sound-tab {
-  padding: 5px 12px; font-size: 12px; border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  padding: 0.3125rem 0.75rem; font-size: 0.75rem; border-radius: var(--radius-sm) var(--radius-sm) 0 0;
   border: 1px solid var(--border); border-bottom: none; background: var(--bg-tertiary);
   color: var(--text-secondary); cursor: pointer; transition: background 0.15s, color 0.15s;
 }
@@ -4798,87 +4804,87 @@ select.cfn-select.cfn-input {
 /* Soundboard grid */
 .soundboard-grid {
   display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 6px; max-height: 280px; overflow-y: auto; padding: 4px 0;
+  gap: 0.375rem; max-height: 17.5rem; overflow-y: auto; padding: 0.25rem 0;
 }
 .soundboard-btn {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
-  gap: 4px; padding: 10px 6px; border-radius: var(--radius);
+  gap: 0.25rem; padding: 0.625rem 0.375rem; border-radius: var(--radius);
   border: 1px solid var(--border); background: var(--bg-secondary);
-  color: var(--text-primary); cursor: pointer; min-height: 60px;
+  color: var(--text-primary); cursor: pointer; min-height: 3.75rem;
   transition: background 0.15s, border-color 0.15s, transform 0.1s;
 }
 .soundboard-btn:hover { background: var(--bg-hover); border-color: var(--accent); }
 .soundboard-btn:active { transform: scale(0.96); }
-.soundboard-btn .sb-name { font-size: 12px; font-weight: 600; text-align: center; word-break: break-word; }
+.soundboard-btn .sb-name { font-size: 0.75rem; font-weight: 600; text-align: center; word-break: break-word; }
 .soundboard-btn .sb-hotkey {
-  font-size: 9px; color: var(--text-muted); background: var(--bg-tertiary);
-  padding: 1px 6px; border-radius: 3px; font-family: var(--font-mono);
+  font-size: 0.5625rem; color: var(--text-muted); background: var(--bg-tertiary);
+  padding: 0.0625rem 0.375rem; border-radius: 0.1875rem; font-family: var(--font-mono);
 }
 .sb-hotkey-row {
-  display: inline-flex; align-items: center; gap: 4px;
+  display: inline-flex; align-items: center; gap: 0.25rem;
 }
 .sb-hotkey-clear {
-  font-size: 13px; line-height: 1; color: var(--text-muted); cursor: pointer;
-  padding: 0 2px; border-radius: 3px; transition: color 0.15s, background 0.15s;
+  font-size: 0.8125rem; line-height: 1; color: var(--text-muted); cursor: pointer;
+  padding: 0 0.125rem; border-radius: 0.1875rem; transition: color 0.15s, background 0.15s;
 }
 .sb-hotkey-clear:hover { color: var(--danger); background: rgba(240,71,71,0.15); }
 .sb-hotkey-set {
-  font-size: 9px; color: var(--accent); cursor: pointer; opacity: 0.7;
+  font-size: 0.5625rem; color: var(--accent); cursor: pointer; opacity: 0.7;
   transition: opacity 0.15s;
 }
 .sb-hotkey-set:hover { opacity: 1; text-decoration: underline; }
-.sound-search-row { display: flex; gap: 8px; margin-bottom: 8px; }
-.sound-assign-list { display: flex; flex-direction: column; gap: 4px; }
-.sound-assign-select { min-width: 140px; }
+.sound-search-row { display: flex; gap: 0.5rem; margin-bottom: 0.5rem; }
+.sound-assign-list { display: flex; flex-direction: column; gap: 0.25rem; }
+.sound-assign-select { min-width: 8.75rem; }
 
 /* Sidebar layout mode for soundboard (used by the sidebar panel grid only) */
 .soundboard-grid.sidebar-mode {
   display: flex !important; 
   flex-direction: column;
-  gap: 4px;
-  max-height: 300px;
+  gap: 0.25rem;
+  max-height: 18.75rem;
   grid-template-columns: auto;
 }
 .soundboard-grid.sidebar-mode .soundboard-btn {
-  min-height: 32px;
+  min-height: 2rem;
   justify-content: space-between;
   flex-direction: row;
-  padding: 6px 8px;
+  padding: 0.375rem 0.5rem;
 }
 .soundboard-grid.sidebar-mode .soundboard-btn .sb-name {
   text-align: left;
   flex: 1;
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 /* List view mode for popup/pip soundboard (separate from sidebar-mode) */
 .soundboard-grid.list-mode {
   display: flex !important;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
   grid-template-columns: auto;
 }
 .soundboard-grid.list-mode .soundboard-btn {
-  min-height: 32px;
+  min-height: 2rem;
   justify-content: space-between;
   flex-direction: row;
-  padding: 6px 8px;
+  padding: 0.375rem 0.5rem;
 }
 .soundboard-grid.list-mode .soundboard-btn .sb-name {
   text-align: left;
   flex: 1;
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 .soundboard-btn.hidden-sound { opacity: 0.4; }
 /* Eye (hide/unhide) toggle on each tile. Always rendered with a reserved
    width and at low opacity so it never shifts the tile contents on hover. */
 .soundboard-btn .sb-hide-btn {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 2px;
-  width: 18px;
-  height: 18px;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.125rem;
+  width: 1.125rem;
+  height: 1.125rem;
   line-height: 14px;
   text-align: center;
   opacity: 0.35;
@@ -4902,7 +4908,7 @@ select.cfn-select.cfn-input {
 
 /* Collapsible sections in the Manage tab sound list */
 .sound-section {
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
 }
 .sound-section-label {
   cursor: pointer;
@@ -4911,15 +4917,15 @@ select.cfn-select.cfn-input {
   text-transform: uppercase;
   letter-spacing: .06em;
   color: var(--text-muted);
-  padding: 4px 0 4px 0;
+  padding: 0.25rem 0 0.25rem 0;
   list-style: none;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
 }
 .sound-section-label::before {
   content: '\25BE'; /* small down triangle */
-  font-size: 10px;
+  font-size: 0.625rem;
   transition: transform 0.15s;
 }
 details.sound-section:not([open]) .sound-section-label::before {
@@ -4929,12 +4935,12 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .message-body { flex: 1; min-width: 0; }
 
-.message-header { display: flex; align-items: baseline; gap: 8px; margin-bottom: 2px; }
-.message-author { font-weight: 600; font-size: 14px; }
-.message-time { font-size: 11px; color: var(--text-muted); }
+.message-header { display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.125rem; }
+.message-author { font-weight: 600; font-size: 0.875rem; }
+.message-time { font-size: 0.6875rem; color: var(--text-muted); }
 
 .message-content {
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-primary);
   word-wrap: break-word;
   overflow-wrap: break-word;
@@ -4946,7 +4952,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 .message-compact {
   display: flex;
   position: relative;
-  padding: 1px 8px 1px 56px;
+  padding: 0.0625rem 0.5rem 0.0625rem 3.5rem;   /* 1px 8px 1px 56px */
   border-radius: var(--radius-sm);
   transition: background var(--transition);
   flex-shrink: 0;
@@ -4956,16 +4962,16 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 /* Thin horizontal separator between different users' message groups */
 .message-user-sep {
-  margin-top: 8px;
+  margin-top: 0.5rem;
   border-top: 1px solid var(--border);
-  padding-top: 4px;
+  padding-top: 0.25rem;
 }
 
 .message-compact .compact-time {
   position: absolute;
   left: 8px;
   top: 2px;
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
   display: none;
 }
@@ -4976,30 +4982,30 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .system-message {
-  padding: 4px 8px;
-  font-size: 12px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
   font-style: italic;
   text-align: center;
 }
 
 .welcome-message {
-  padding: 10px 16px;
-  margin: 8px auto;
-  max-width: 480px;
-  font-size: 14px;
+  padding: 0.625rem 1rem;
+  margin: 0.5rem auto;
+  max-width: 30rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--accent, #5865f2);
   text-align: center;
   background: var(--bg-secondary, #2b2d31);
   border: 1px solid var(--border-light, #3a3c42);
-  border-radius: 8px;
+  border-radius: 0.5rem;
 }
 
 .typing-indicator {
-  padding: 0 20px;
-  height: 20px;
-  font-size: 12px;
+  padding: 0 1.25rem;
+  height: 1.25rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
   display: flex;
   align-items: center;
@@ -5010,8 +5016,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 .message-input-area {
   display: flex;
   align-items: flex-end;
-  gap: 8px;
-  padding: 16px 20px 16px;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem 1rem;
   position: relative;
   /* Above #fx-layers (z:99990) so theme particles/embers don't float over
      the textarea, send button, and toolbar. The composer is a critical
@@ -5022,14 +5028,14 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .message-input-area textarea {
   flex: 1;
-  padding: 10px 14px;
+  padding: 0.625rem 0.875rem;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 0.875rem;
   resize: none;
-  max-height: 120px;
+  max-height: 7.5rem;
   line-height: 1.4;
   transition: border-color var(--transition);
 }
@@ -5038,8 +5044,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 .message-input-area textarea::placeholder { color: var(--text-muted); }
 
 .btn-send {
-  width: 42px;
-  height: 42px;
+  width: 2.625rem;
+  height: 2.625rem;
   background: var(--accent);
   color: white;
   border-radius: var(--radius);
@@ -5056,8 +5062,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .right-sidebar {
   width: var(--right-width);
-  min-width: 200px;
-  max-width: 400px;
+  min-width: 12.5rem;
+  max-width: 25rem;
   background: var(--bg-secondary);
   border-left: 1px solid var(--border);
   display: flex;
@@ -5083,16 +5089,16 @@ details.sound-section:not([open]) .sound-section-label::before {
   right: 0;
   top: 72px;          /* near top — where the voice panel header sits */
   transform: none;
-  width: 20px;
-  height: 36px;
+  width: 1.25rem;
+  height: 2.25rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 0.6875rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-right: none;
-  border-radius: 6px 0 0 6px;
+  border-radius: 0.375rem 0 0 0.375rem;
   color: var(--text-muted);
   cursor: pointer;
   padding: 0;
@@ -5118,7 +5124,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   top: 0;
   left: -3px;
-  width: 6px;
+  width: 0.375rem;
   height: 100%;
   cursor: col-resize;
   z-index: 10;
@@ -5131,26 +5137,26 @@ details.sound-section:not([open]) .sound-section-label::before {
   opacity: 0.5;
 }
 
-.panel { padding: 16px; border-bottom: 1px solid var(--border); }
+.panel { padding: 1rem; border-bottom: 1px solid var(--border); }
 
 .panel-title {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.8px;
   color: var(--text-muted);
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 
-.user-list { display: flex; flex-direction: column; gap: 4px; }
+.user-list { display: flex; flex-direction: column; gap: 0.25rem; }
 
-.muted-text { font-size: 12px; color: var(--text-muted); font-style: italic; }
+.muted-text { font-size: 0.75rem; color: var(--text-muted); font-style: italic; }
 
 .user-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 6px;
+  gap: 0.5rem;
+  padding: 0.25rem 0.375rem;   /* 4px 6px */
   border-radius: var(--radius-sm);
   position: relative;
 }
@@ -5159,9 +5165,9 @@ details.sound-section:not([open]) .sound-section-label::before {
   background: var(--bg-hover);
 }
 
-.user-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--success); flex-shrink: 0; }
+.user-dot { width: 0.5rem; height: 0.5rem; border-radius: 50%; background: var(--success); flex-shrink: 0; }
 .user-item-name {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5172,8 +5178,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 /* Role color dot (to the left of the username, inside avatar wrapper) */
 .user-role-dot {
-  width: 8px;
-  height: 8px;
+  width: 0.5rem;
+  height: 0.5rem;
   border-radius: 50%;
   flex-shrink: 0;
   border: 1px solid rgba(0,0,0,0.3);
@@ -5189,14 +5195,14 @@ details.sound-section:not([open]) .sound-section-label::before {
   background: var(--bg-secondary);
   border: 1px solid var(--border-light);
   border-radius: var(--radius);
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   z-index: 1000;
   white-space: nowrap;
   pointer-events: none;
   box-shadow: 0 6px 20px rgba(0,0,0,0.6);
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-primary);
-  max-width: 220px;
+  max-width: 13.75rem;
   opacity: 1;
   backdrop-filter: none;
 }
@@ -5214,18 +5220,18 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 .tooltip-username {
   font-weight: 700;
-  font-size: 13px;
-  margin-bottom: 2px;
+  font-size: 0.8125rem;
+  margin-bottom: 0.125rem;
 }
 .tooltip-role {
-  font-size: 11px;
+  font-size: 0.6875rem;
   opacity: 0.8;
 }
 .tooltip-status {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   font-style: italic;
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -5235,7 +5241,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 .profile-popup {
   position: fixed;
   z-index: 10001;
-  width: 320px;
+  width: 20rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border-light);
   border-radius: var(--radius);
@@ -5289,7 +5295,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .profile-popup-banner {
-  height: 60px;
+  height: 3.75rem;
   position: relative;
   background: var(--bg-tertiary);
 }
@@ -5299,29 +5305,29 @@ details.sound-section:not([open]) .sound-section-label::before {
   top: 6px; right: 8px;
   background: none; border: none;
   color: var(--text-muted);
-  font-size: 18px;
+  font-size: 1.125rem;
   cursor: pointer;
   line-height: 1;
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
 }
 .profile-popup-close:hover { background: rgba(255,255,255,0.1); color: var(--text-primary); }
 
 .profile-popup-avatar-wrapper {
   position: relative;
-  width: 72px; height: 72px;
-  margin: -36px 0 0 16px;
+  width: 4.5rem; height: 4.5rem;
+  margin: -2.25rem 0 0 1rem;
 }
 
 .profile-popup-avatar {
-  width: 72px; height: 72px;
+  width: 4.5rem; height: 4.5rem;
   border-radius: 50%;
   border: 4px solid var(--bg-primary);
   object-fit: cover;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 28px;
+  font-size: 1.75rem;
   font-weight: 700;
   color: #fff;
 }
@@ -5337,7 +5343,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 .profile-popup-status-dot {
   position: absolute;
   bottom: 2px; right: 2px;
-  width: 16px; height: 16px;
+  width: 1rem; height: 1rem;
   border-radius: 50%;
   background: var(--success);
   border: 3px solid var(--bg-primary);
@@ -5347,126 +5353,126 @@ details.sound-section:not([open]) .sound-section-label::before {
 .profile-popup-status-dot.invisible { background: var(--text-muted); }
 
 .profile-popup-body {
-  padding: 10px 16px 16px;
+  padding: 0.625rem 1rem 1rem;
   background: var(--bg-secondary);
 }
 
 .profile-popup-names {
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  margin-bottom: 6px;
+  gap: 0.0625rem;
+  margin-bottom: 0.375rem;
 }
 
 .profile-popup-displayname {
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 700;
   color: var(--text-primary);
   line-height: 1.2;
 }
 
 .profile-popup-nickname {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--accent);
   line-height: 1.2;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .profile-popup-username {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-muted);
 }
 
 .profile-popup-status-text {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   font-style: italic;
-  padding: 4px 8px;
+  padding: 0.25rem 0.5rem;
   background: var(--bg-secondary);
   border-radius: var(--radius-sm);
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 
 .profile-popup-bio {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   line-height: 1.4;
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
   word-break: break-word;
 }
 
 .profile-bio-empty {
   color: var(--text-muted);
   font-style: italic;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 .profile-bio-toggle {
   background: none; border: none;
   color: var(--accent);
   cursor: pointer;
-  font-size: 12px;
-  padding: 2px 0;
+  font-size: 0.75rem;
+  padding: 0.125rem 0;
 }
 .profile-bio-toggle:hover { text-decoration: underline; }
 
 .profile-popup-divider {
-  height: 1px;
+  height: 0.0625rem;
   background: var(--border);
-  margin: 8px 0;
+  margin: 0.5rem 0;
 }
 
 .profile-popup-section-label {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
   color: var(--text-muted);
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
   letter-spacing: 0.03em;
 }
 
 .profile-popup-roles {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
-  margin-bottom: 8px;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
 }
 
 .profile-popup-role {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  font-size: 12px;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
   border: 1px solid;
-  border-radius: 12px;
+  border-radius: 0.75rem;
   background: var(--bg-secondary);
 }
 
 .profile-role-dot {
-  width: 8px; height: 8px;
+  width: 0.5rem; height: 0.5rem;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
 .profile-popup-join-date {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-secondary);
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 
 .profile-popup-actions {
-  margin-top: 8px;
+  margin-top: 0.5rem;
 }
 
 .profile-popup-action-btn {
   width: 100%;
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   transition: background var(--transition), transform 0.1s;
 }
@@ -5488,7 +5494,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 .profile-nick-btn {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
-  margin-top: 6px;
+  margin-top: 0.375rem;
   border: 1px solid var(--border-light) !important;
 }
 .profile-nick-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
@@ -5496,36 +5502,36 @@ details.sound-section:not([open]) .sound-section-label::before {
 .profile-gear-btn {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
-  margin-top: 6px;
+  margin-top: 0.375rem;
   border: 1px solid var(--border-light) !important;
 }
 .profile-gear-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 /* ── Edit Profile Modal ──────────────────────────── */
 .edit-profile-modal-box {
-  width: 380px;
+  width: 23.75rem;
   max-width: 95vw;
 }
 
 .edit-profile-label {
   display: block;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   color: var(--text-muted);
-  margin: 12px 0 6px;
+  margin: 0.75rem 0 0.375rem;
   letter-spacing: 0.03em;
 }
 
 .edit-profile-textarea {
   width: 100%;
-  min-height: 80px;
-  padding: 8px 10px;
+  min-height: 5rem;
+  padding: 0.5rem 0.625rem;
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-family: var(--font-main);
   resize: vertical;
 }
@@ -5535,10 +5541,10 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .edit-profile-char-count {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   text-align: right;
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 
 /* Clickable message author and sidebar user items for profile popup */
@@ -5560,21 +5566,21 @@ details.sound-section:not([open]) .sound-section-label::before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   pointer-events: none;
 }
 
 .toast {
-  padding: 10px 18px;
+  padding: 0.625rem 1.125rem;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   box-shadow: 0 4px 16px rgba(0,0,0,0.45);
   animation: toastIn 0.25s ease, toastOut 0.3s ease 3.5s forwards;
   pointer-events: auto;
-  max-width: 360px;
+  max-width: 22.5rem;
   word-break: break-word;
   /* Force opaque background even when a translucent theme variable is in use
      so toasts remain readable against the busy chat backdrop. */
@@ -5600,12 +5606,12 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .toast-action-btn {
   flex-shrink: 0;
-  padding: 2px 10px;
+  padding: 0.125rem 0.625rem;
   background: rgba(255,255,255,0.15);
   border: 1px solid rgba(255,255,255,0.3);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   color: inherit;
-  font-size: 12px;
+  font-size: 0.75rem;
   cursor: pointer;
 }
 .toast-action-btn:hover { background: rgba(255,255,255,0.28); }
@@ -5625,22 +5631,22 @@ details.sound-section:not([open]) .sound-section-label::before {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .server-bar {
-  width: 56px;
-  min-width: 56px;
+  width: 3.5rem;
+  min-width: 3.5rem;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 8px 0;
-  gap: 4px;
+  padding: 0.5rem 0;
+  gap: 0.25rem;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .server-icon {
-  width: 40px;
-  height: 40px;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -5652,8 +5658,8 @@ details.sound-section:not([open]) .sound-section-label::before {
   flex-shrink: 0;
 }
 
-.server-icon:hover { border-radius: 12px; background: var(--accent); }
-.server-icon.home { border-radius: 12px; background: var(--accent); }
+.server-icon:hover { border-radius: 0.75rem; background: var(--accent); }
+.server-icon.home { border-radius: 0.75rem; background: var(--accent); }
 
 .server-icon.home.bounce {
   animation: serverBounce 0.4s ease;
@@ -5666,7 +5672,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .server-icon-text {
-  font-size: 18px;
+  font-size: 1.125rem;
   color: var(--text-primary);
   pointer-events: none;
   font-weight: 700;
@@ -5688,11 +5694,11 @@ details.sound-section:not([open]) .sound-section-label::before {
 .server-icon.add-server:hover {
   border-color: var(--accent);
   background: transparent;
-  border-radius: 12px;
+  border-radius: 0.75rem;
 }
 
 .server-icon.add-server .server-icon-text {
-  font-size: 22px;
+  font-size: 1.375rem;
   color: var(--accent);
   line-height: 1;
   display: flex;
@@ -5706,8 +5712,8 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   bottom: -1px;
   right: -1px;
-  width: 12px;
-  height: 12px;
+  width: 0.75rem;
+  height: 0.75rem;
   border-radius: 50%;
   border: 2px solid var(--bg-secondary);
 }
@@ -5717,11 +5723,11 @@ details.sound-section:not([open]) .sound-section-label::before {
 .server-status-dot.unknown { background: var(--warning); }
 
 .server-separator {
-  width: 24px;
-  height: 2px;
+  width: 1.5rem;
+  height: 0.125rem;
   background: var(--border);
-  border-radius: 1px;
-  margin: 4px 0;
+  border-radius: 0.0625rem;
+  margin: 0.25rem 0;
   flex-shrink: 0;
 }
 
@@ -5729,12 +5735,12 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   top: -4px;
   right: -4px;
-  width: 16px;
-  height: 16px;
+  width: 1rem;
+  height: 1rem;
   border-radius: 50%;
   background: var(--danger);
   color: white;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1;
   display: none;
   align-items: center;
@@ -5751,10 +5757,10 @@ details.sound-section:not([open]) .sound-section-label::before {
 .server-icon.remote[draggable="true"]:active { cursor: grabbing; }
 .server-icon.server-dragging { opacity: 0.4; }
 .server-drop-indicator {
-  height: 2px;
+  height: 0.125rem;
   background: var(--accent, #7c5cfc);
-  margin: 2px 8px;
-  border-radius: 2px;
+  margin: 0.125rem 0.5rem;
+  border-radius: 0.125rem;
   pointer-events: none;
 }
 
@@ -5762,15 +5768,15 @@ details.sound-section:not([open]) .sound-section-label::before {
 .server-icon.manage-servers {
   background: transparent;
   border: 2px dashed var(--border-light);
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 .server-icon.manage-servers:hover {
   border-color: var(--accent);
   background: transparent;
-  border-radius: 12px;
+  border-radius: 0.75rem;
 }
 .server-icon.manage-servers .server-icon-text {
-  font-size: 18px;
+  font-size: 1.125rem;
   color: var(--text-secondary);
   transition: color 0.15s;
 }
@@ -5780,7 +5786,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 /* Manage Servers modal list */
 .manage-servers-modal-inner {
-  width: 480px;
+  width: 30rem;
   max-width: 90vw;
   /* Make the inner modal a column flex container so the list can grow
      to fill the available vertical space when the user resizes the
@@ -5791,25 +5797,25 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 .manage-servers-list {
   flex: 1 1 auto;
-  min-height: 120px;
+  min-height: 7.5rem;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin: 12px 0;
+  gap: 0.375rem;
+  margin: 0.75rem 0;
 }
 .manage-servers-list:empty::before {
   content: 'No servers added yet. Click "+ Add Server" below.';
   color: var(--text-muted);
   text-align: center;
-  padding: 24px 0;
-  font-size: 13px;
+  padding: 1.5rem 0;
+  font-size: 0.8125rem;
 }
 .manage-server-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
+  gap: 0.625rem;
+  padding: 0.5rem 0.625rem;
   background: var(--bg-tertiary);
   border-radius: var(--radius);
   border: 1px solid var(--border);
@@ -5819,15 +5825,15 @@ details.sound-section:not([open]) .sound-section-label::before {
   background: var(--bg-hover);
 }
 .manage-server-icon {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   border-radius: 50%;
   background: var(--bg-secondary);
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 700;
   color: var(--text-primary);
   overflow: hidden;
@@ -5843,7 +5849,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   min-width: 0;
 }
 .manage-server-name {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-primary);
   white-space: nowrap;
@@ -5851,7 +5857,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   text-overflow: ellipsis;
 }
 .manage-server-url {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;
@@ -5859,9 +5865,9 @@ details.sound-section:not([open]) .sound-section-label::before {
   font-family: var(--font-mono);
 }
 .manage-server-status {
-  font-size: 11px;
-  padding: 2px 6px;
-  border-radius: 9px;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.5625rem;
   flex-shrink: 0;
 }
 .manage-server-status.online {
@@ -5878,15 +5884,15 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 .manage-server-actions {
   display: flex;
-  gap: 4px;
+  gap: 0.25rem;
   flex-shrink: 0;
 }
 .manage-server-actions button {
   background: none;
   border: none;
-  font-size: 14px;
+  font-size: 0.875rem;
   cursor: pointer;
-  padding: 4px 6px;
+  padding: 0.25rem 0.375rem;
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   transition: background 0.15s, color 0.15s;
@@ -5904,15 +5910,15 @@ details.sound-section:not([open]) .sound-section-label::before {
 .server-icon.sync-servers {
   background: transparent;
   border: 2px dashed var(--border-light);
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 .server-icon.sync-servers:hover {
   border-color: var(--accent);
   background: transparent;
-  border-radius: 12px;
+  border-radius: 0.75rem;
 }
 .server-icon.sync-servers .server-icon-text {
-  font-size: 20px;
+  font-size: 1.25rem;
   color: var(--text-secondary);
   transition: color 0.15s;
 }
@@ -5932,11 +5938,11 @@ details.sound-section:not([open]) .sound-section-label::before {
 .manage-server-drag-handle {
   cursor: grab;
   color: var(--text-muted);
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 1;
   user-select: none;
   flex-shrink: 0;
-  padding: 0 2px;
+  padding: 0 0.125rem;
   letter-spacing: 1px;
   opacity: 0.5;
   transition: opacity 0.15s, color 0.15s;
@@ -5983,16 +5989,16 @@ details.sound-section:not([open]) .sound-section-label::before {
 .modal {
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 12px;
-  padding: 28px;
-  width: min(90%, 400px);
+  border-radius: 0.75rem;
+  padding: 1.75rem;
+  width: min(90%, 25rem);   /* 400px at Normal; scales with the font setting */
   max-width: 90vw;
   max-height: 85vh;
   box-shadow: 0 12px 48px rgba(0,0,0,0.5);
   resize: both;
   overflow: auto;
-  min-width: 280px;
-  min-height: 180px;
+  min-width: 17.5rem;
+  min-height: 11.25rem;
   position: relative;
 }
 
@@ -6005,7 +6011,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   right: 12px;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   z-index: 5;
 }
 
@@ -6049,7 +6055,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   height: 92vh !important;
   max-width: 96vw !important;
   max-height: 92vh !important;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   transition: none;
 }
 
@@ -6057,9 +6063,9 @@ details.sound-section:not([open]) .sound-section-label::before {
 .modal.modal-confirm {
   resize: none;
   min-height: unset;
-  max-width: 380px;
-  width: min(90%, 380px);
-  padding: 22px 24px 20px;
+  max-width: 23.75rem;
+  width: min(90%, 23.75rem);
+  padding: 1.375rem 1.5rem 1.25rem;
 }
 
 /* Expand/restore toggle button in modal headers */
@@ -6067,15 +6073,15 @@ details.sound-section:not([open]) .sound-section-label::before {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
-  font-size: 14px;
+  width: 1.625rem;
+  height: 1.625rem;
+  font-size: 0.875rem;
   background: none;
   border: 1px solid rgba(255,255,255,0.1);
   color: var(--text-muted);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   cursor: pointer;
-  margin-left: 8px;
+  margin-left: 0.5rem;
   padding: 0;
   vertical-align: middle;
   transition: all 0.15s ease;
@@ -6094,36 +6100,36 @@ details.sound-section:not([open]) .sound-section-label::before {
    where the absolute .modal-controls wrap was misaligning with the
    close × in the header. */
 .modal-expand-btn.modal-expand-btn-inline {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   margin-left: 0;
-  margin-right: 4px;
+  margin-right: 0.25rem;
   border: none;
   border-radius: var(--radius-sm);
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .modal h3 {
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: 700;
   color: var(--text-primary);
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
   font-family: var(--font-heading);
 }
 
 .modal .modal-desc {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 }
 
-.modal .form-group { margin-bottom: 14px; }
+.modal .form-group { margin-bottom: 0.875rem; }
 
 .modal-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 20px;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
 }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -6131,39 +6137,39 @@ details.sound-section:not([open]) .sound-section-label::before {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .modal-wizard {
-  max-width: 560px;
+  max-width: 35rem;
   padding: 0;
   overflow: hidden;
 }
 
 .wizard-header {
   text-align: center;
-  padding: 32px 28px 20px;
+  padding: 2rem 1.75rem 1.25rem;
   border-bottom: 1px solid var(--border-light);
 }
 
 .wizard-hex {
   font-size: 2.5rem;
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
   filter: drop-shadow(0 0 12px var(--accent-glow, rgba(124,92,252,0.3)));
 }
 
 .wizard-header h2 {
-  font-size: 22px;
+  font-size: 1.375rem;
   font-weight: 700;
   color: var(--text-primary);
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
 }
 
 .wizard-subtitle {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
 }
 
 .wizard-steps {
-  padding: 24px 28px;
-  min-height: 280px;
+  padding: 1.5rem 1.75rem;
+  min-height: 17.5rem;
 }
 
 .wizard-step-indicators {
@@ -6171,19 +6177,19 @@ details.sound-section:not([open]) .sound-section-label::before {
   align-items: center;
   justify-content: center;
   gap: 0;
-  margin-bottom: 24px;
+  margin-bottom: 1.5rem;
 }
 
 .wizard-indicator {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   border-radius: 50%;
   background: var(--bg-hover, #2c2f4a);
   border: 2px solid var(--border-light);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 700;
   color: var(--text-secondary);
   transition: all 0.2s ease;
@@ -6203,67 +6209,67 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .wizard-indicator-line {
-  width: 32px;
-  height: 2px;
+  width: 2rem;
+  height: 0.125rem;
   background: var(--border-light);
-  margin: 0 4px;
+  margin: 0 0.25rem;
 }
 
 .wizard-step h3 {
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 700;
   color: var(--text-primary);
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 
 .wizard-step > p {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
-  margin-bottom: 16px;
+  margin-bottom: 1rem;
   line-height: 1.6;
 }
 
 .wizard-checklist {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-bottom: 16px;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 .wizard-check {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-primary);
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   background: var(--bg-hover, rgba(255,255,255,0.03));
-  border-radius: 8px;
+  border-radius: 0.5rem;
   border: 1px solid var(--border-light);
 }
 
 .wizard-info-box {
   background: var(--bg-hover, rgba(255,255,255,0.03));
   border: 1px solid var(--border-light);
-  border-radius: 8px;
-  padding: 14px;
-  margin-bottom: 12px;
+  border-radius: 0.5rem;
+  padding: 0.875rem;
+  margin-bottom: 0.75rem;
 }
 
 .wizard-info-box strong {
   display: block;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 
 .wizard-input {
   width: 100%;
-  padding: 10px 12px;
+  padding: 0.625rem 0.75rem;
   background: var(--bg-input, #15172a);
   border: 1px solid var(--border-light);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-family: inherit;
   outline: none;
   transition: border-color 0.15s ease;
@@ -6276,31 +6282,31 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .wizard-hint {
   display: block;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-dim, #5d6180);
-  margin-top: 6px;
+  margin-top: 0.375rem;
   line-height: 1.5;
 }
 
 .wizard-code-display {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
+  gap: 0.625rem;
+  padding: 0.625rem 0.75rem;
   background: var(--bg-input, #15172a);
   border: 1px solid var(--border-light);
-  border-radius: 6px;
-  margin-top: 8px;
-  margin-bottom: 4px;
+  border-radius: 0.375rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 
 .wizard-code-display span {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-secondary);
 }
 
 .wizard-code-display code {
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--accent, #7c5cfc);
   letter-spacing: 0.1em;
@@ -6310,10 +6316,10 @@ details.sound-section:not([open]) .sound-section-label::before {
 .wizard-btn-small {
   background: var(--bg-hover, #2c2f4a);
   border: 1px solid var(--border-light);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   color: var(--text-primary);
-  font-size: 11px;
-  padding: 4px 10px;
+  font-size: 0.6875rem;
+  padding: 0.25rem 0.625rem;
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -6324,34 +6330,34 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .wizard-steps-list {
-  margin: 8px 0 0 20px;
-  font-size: 13px;
+  margin: 0.5rem 0 0 1.25rem;
+  font-size: 0.8125rem;
   color: var(--text-primary);
   line-height: 1.8;
 }
 
 .wizard-steps-list code {
   background: var(--bg-input, #15172a);
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-size: 12px;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.1875rem;
+  font-size: 0.75rem;
 }
 
 .wizard-footer {
   display: flex;
   align-items: center;
-  padding: 16px 28px;
+  padding: 1rem 1.75rem;
   border-top: 1px solid var(--border-light);
-  gap: 8px;
+  gap: 0.5rem;
 }
 
 .wizard-btn-primary {
   background: var(--accent, #7c5cfc);
   color: #fff;
   border: none;
-  border-radius: 6px;
-  padding: 10px 24px;
-  font-size: 14px;
+  border-radius: 0.375rem;
+  padding: 0.625rem 1.5rem;
+  font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -6367,9 +6373,9 @@ details.sound-section:not([open]) .sound-section-label::before {
   background: var(--bg-hover, #2c2f4a);
   color: var(--text-primary);
   border: 1px solid var(--border-light);
-  border-radius: 6px;
-  padding: 10px 20px;
-  font-size: 14px;
+  border-radius: 0.375rem;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -6384,9 +6390,9 @@ details.sound-section:not([open]) .sound-section-label::before {
   background: none;
   border: none;
   color: var(--text-dim, #5d6180);
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   transition: color 0.15s ease;
   font-family: inherit;
 }
@@ -6396,15 +6402,15 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .wizard-spinner {
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
   border: 2px solid var(--border-light);
   border-top-color: var(--accent, #7c5cfc);
   border-radius: 50%;
   animation: wizard-spin 0.7s linear infinite;
   display: inline-block;
   vertical-align: middle;
-  margin-right: 8px;
+  margin-right: 0.5rem;
 }
 
 @keyframes wizard-spin {
@@ -6412,35 +6418,35 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .wizard-port-success {
-  padding: 12px;
+  padding: 0.75rem;
   background: rgba(67, 181, 129, 0.1);
   border: 1px solid rgba(67, 181, 129, 0.3);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.6;
 }
 
 .wizard-port-fail {
-  padding: 12px;
+  padding: 0.75rem;
   background: rgba(240, 71, 71, 0.08);
   border: 1px solid rgba(240, 71, 71, 0.25);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.6;
 }
 
 .wizard-port-fail ol {
-  margin: 8px 0 0 20px;
+  margin: 0.5rem 0 0 1.25rem;
   line-height: 1.8;
 }
 
 .wizard-port-fail code {
   background: var(--bg-input, #15172a);
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-size: 12px;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.1875rem;
+  font-size: 0.75rem;
 }
 
 
@@ -6450,16 +6456,16 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 /* Default: thumbnail mode */
 .chat-image {
-  max-width: 180px;
-  max-height: 180px;
+  max-width: 11.25rem;
+  max-height: 11.25rem;
   /* Reserve minimum space before the image loads so the layout doesn't jump
      from 0×0 to full-size. Without this, each image load causes a large
      reflow that the scroll-to-bottom handlers react to individually, making
      the chat jump repeatedly. */
   min-width: 60px;
-  min-height: 60px;
+  min-height: 3.75rem;
   border-radius: var(--radius);
-  margin-top: 4px;
+  margin-top: 0.25rem;
   cursor: pointer;
   transition: opacity 0.15s ease;
   display: block;
@@ -6471,8 +6477,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 /* E2E encrypted image loading states */
 .e2e-img-pending,
 .e2e-img-loading {
-  width: 180px;
-  height: 120px;
+  width: 11.25rem;
+  height: 7.5rem;
   background: var(--bg-tertiary, rgba(255,255,255,0.05));
   border: 1px dashed var(--text-muted);
   display: flex;
@@ -6485,8 +6491,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 /* Full inline mode (Discord-style, toggled via client setting) */
 .image-mode-full .chat-image {
-  max-width: min(400px, 70%);
-  max-height: 300px;
+  max-width: min(25rem, 70%);
+  max-height: 18.75rem;
   object-fit: contain;
 }
 
@@ -6494,26 +6500,26 @@ details.sound-section:not([open]) .sound-section-label::before {
 .embed-size-off .link-preview { display: none !important; }
 
 .embed-size-full .link-preview--rich .lp-image,
-.embed-size-full .link-preview--rich .lp-video { max-height: 520px; }
+.embed-size-full .link-preview--rich .lp-video { max-height: 32.5rem; }
 .embed-size-full .link-preview--rich .lp-text { -webkit-line-clamp: 14; }
-.embed-size-full .link-preview--yt .link-preview-yt { max-width: 480px; }
+.embed-size-full .link-preview--yt .link-preview-yt { max-width: 30rem; }
 
 .embed-size-medium .link-preview--rich .lp-media,
 .embed-size-medium .link-preview--rich .lp-video,
-.embed-size-medium .link-preview--rich .link-preview-gallery { max-width: 340px; }
+.embed-size-medium .link-preview--rich .link-preview-gallery { max-width: 21.25rem; }
 .embed-size-medium .link-preview--rich .lp-image,
-.embed-size-medium .link-preview--rich .lp-video { max-height: 300px; }
+.embed-size-medium .link-preview--rich .lp-video { max-height: 18.75rem; }
 .embed-size-medium .link-preview--rich .lp-text { -webkit-line-clamp: 8; }
-.embed-size-medium .link-preview--yt .link-preview-yt { max-width: 380px; }
+.embed-size-medium .link-preview--yt .link-preview-yt { max-width: 23.75rem; }
 
-.embed-size-small .link-preview { max-width: 360px; }
+.embed-size-small .link-preview { max-width: 22.5rem; }
 .embed-size-small .link-preview--rich .lp-media,
 .embed-size-small .link-preview--rich .lp-video,
-.embed-size-small .link-preview--rich .link-preview-gallery { max-width: 220px; }
+.embed-size-small .link-preview--rich .link-preview-gallery { max-width: 13.75rem; }
 .embed-size-small .link-preview--rich .lp-image,
-.embed-size-small .link-preview--rich .lp-video { max-height: 160px; }
+.embed-size-small .link-preview--rich .lp-video { max-height: 10rem; }
 .embed-size-small .link-preview--rich .lp-text { -webkit-line-clamp: 4; }
-.embed-size-small .link-preview--yt .link-preview-yt { max-width: 280px; }
+.embed-size-small .link-preview--yt .link-preview-yt { max-width: 17.5rem; }
 
 /* Image lightbox overlay */
 .image-lightbox {
@@ -6532,7 +6538,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 .lightbox-img {
   max-width: 92vw;
   max-height: 92vh;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   box-shadow: 0 12px 48px rgba(0,0,0,0.6);
   object-fit: contain;
   cursor: default;
@@ -6548,8 +6554,8 @@ details.sound-section:not([open]) .sound-section-label::before {
   top: 50%;
   transform: translateY(-50%);
   z-index: 10001;
-  width: 44px;
-  height: 44px;
+  width: 2.75rem;
+  height: 2.75rem;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.5);
   border: 1px solid rgba(255, 255, 255, 0.15);
@@ -6583,20 +6589,20 @@ details.sound-section:not([open]) .sound-section-label::before {
   z-index: 100020;
   background: var(--bg-secondary, #23263a);
   border: 1px solid var(--border, rgba(255,255,255,0.12));
-  border-radius: 8px;
-  padding: 4px 0;
-  min-width: 160px;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0;
+  min-width: 10rem;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
   animation: lightbox-fade-in 0.1s ease;
 }
 .image-context-menu button {
   display: block;
   width: 100%;
-  padding: 8px 14px;
+  padding: 0.5rem 0.875rem;
   background: none;
   border: none;
   color: var(--text-primary, #e2e4f0);
-  font-size: 13px;
+  font-size: 0.8125rem;
   text-align: left;
   cursor: pointer;
   transition: background 0.12s;
@@ -6613,30 +6619,30 @@ details.sound-section:not([open]) .sound-section-label::before {
   z-index: 100020;
   background: var(--bg-secondary, #23263a);
   border: 1px solid var(--border, rgba(255,255,255,0.12));
-  border-radius: 8px;
-  padding: 4px 0;
-  min-width: 200px;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0;
+  min-width: 12.5rem;
   overflow: visible;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
   animation: lightbox-fade-in 0.1s ease;
 }
 .user-ctx-header {
-  padding: 8px 14px 6px;
-  font-size: 12px;
+  padding: 0.5rem 0.875rem 0.375rem;
+  font-size: 0.75rem;
   font-weight: 700;
   color: var(--text-primary);
   border-bottom: 1px solid var(--border, rgba(255,255,255,0.08));
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 .user-context-menu > button,
 .user-ctx-submenu-trigger {
   display: block;
   width: 100%;
-  padding: 7px 14px;
+  padding: 0.4375rem 0.875rem;
   background: none;
   border: none;
   color: var(--text-primary, #e2e4f0);
-  font-size: 13px;
+  font-size: 0.8125rem;
   text-align: left;
   cursor: pointer;
   transition: background 0.12s;
@@ -6651,7 +6657,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 .user-ctx-arrow {
   float: right;
   opacity: 0.5;
-  font-size: 11px;
+  font-size: 0.6875rem;
 }
 
 /* Submenu wrapper for invite-to-channel */
@@ -6663,13 +6669,13 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   left: 100%;
   top: 0;
-  min-width: 180px;
-  max-height: 280px;
+  min-width: 11.25rem;
+  max-height: 17.5rem;
   overflow-y: auto;
   background: var(--bg-secondary, #23263a);
   border: 1px solid var(--border, rgba(255,255,255,0.12));
-  border-radius: 8px;
-  padding: 4px 0;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
   z-index: 10002;
 }
@@ -6679,11 +6685,11 @@ details.sound-section:not([open]) .sound-section-label::before {
 .user-ctx-submenu button {
   display: block;
   width: 100%;
-  padding: 6px 14px;
+  padding: 0.375rem 0.875rem;
   background: none;
   border: none;
   color: var(--text-primary, #e2e4f0);
-  font-size: 13px;
+  font-size: 0.8125rem;
   text-align: left;
   cursor: pointer;
   transition: background 0.12s;
@@ -6704,31 +6710,38 @@ details.sound-section:not([open]) .sound-section-label::before {
 .input-actions-box {
   display: flex;
   align-items: center;
-  gap: 2px;
-  padding: 3px 6px;
+  gap: 0.125rem;
+  padding: 0.1875rem 0.375rem;
   border: 1px solid var(--border, rgba(255,255,255,0.1));
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: var(--bg-tertiary, rgba(255,255,255,0.03));
   flex-shrink: 0;
   position: relative;
   z-index: 1001;
 }
+/* The toolbar glyphs are inline SVGs with hard-coded width/height attributes,
+   so they ignore font size. Size them in rem here so they scale with it and
+   stay proportional to the buttons around them. */
+.input-actions-box button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
 .input-actions-divider {
-  width: 1px;
-  height: 20px;
+  width: 0.0625rem;
+  height: 1.25rem;
   background: var(--border, rgba(255,255,255,0.12));
   flex-shrink: 0;
-  margin: 0 1px;
+  margin: 0 0.0625rem;
 }
 
 /* Clippy icon hidden by default, shown only on Win95 */
 .upload-icon-clippy { display: none; }
 [data-theme="win95"] .upload-icon-default { display: none; }
-[data-theme="win95"] .upload-icon-clippy { display: inline; font-size: 18px; }
+[data-theme="win95"] .upload-icon-clippy { display: inline; font-size: 1.125rem; }
 
 .btn-upload {
-  width: 34px;
-  height: 34px;
+  width: 2.125rem;
+  height: 2.125rem;
   background: transparent;
   color: var(--text-muted);
   border-radius: var(--radius);
@@ -6750,43 +6763,43 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .volume-slider {
   width: 100%;
-  height: 14px;
-  margin-top: 4px;
+  height: 0.875rem;
+  margin-top: 0.25rem;
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
-  border-radius: 2px;
+  border-radius: 0.125rem;
   outline: none;
   cursor: pointer;
 }
 
 .volume-slider::-webkit-slider-runnable-track {
   background: rgba(255,255,255,0.3);
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   border: 1px solid rgba(255,255,255,0.15);
 }
 
 .volume-slider::-moz-range-track {
   background: rgba(255,255,255,0.3);
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   border: 1px solid rgba(255,255,255,0.15);
 }
 
 .volume-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 12px;
-  height: 12px;
+  width: 0.75rem;
+  height: 0.75rem;
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
-  margin-top: -4px;
+  margin-top: -0.25rem;
 }
 
 .volume-slider::-moz-range-thumb {
-  width: 12px;
-  height: 12px;
+  width: 0.75rem;
+  height: 0.75rem;
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
@@ -6798,63 +6811,63 @@ details.sound-section:not([open]) .sound-section-label::before {
    NOTIFICATION SETTINGS
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
-.notif-settings { display: flex; flex-direction: column; gap: 10px; }
+.notif-settings { display: flex; flex-direction: column; gap: 0.625rem; }
 
 .toggle-row, .volume-row, .select-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-secondary);
-  gap: 8px;
+  gap: 0.5rem;
 }
 
 .toggle-row input[type="checkbox"] {
   accent-color: var(--accent);
-  width: 16px;
-  height: 16px;
+  width: 1rem;
+  height: 1rem;
   cursor: pointer;
 }
 
 .slider-sm {
-  width: 80px;
-  height: 14px;
+  width: 5rem;
+  height: 0.875rem;
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
-  border-radius: 2px;
+  border-radius: 0.125rem;
   outline: none;
   cursor: pointer;
 }
 
 .slider-sm::-webkit-slider-runnable-track {
   background: rgba(255,255,255,0.25);
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   border: 1px solid rgba(255,255,255,0.12);
 }
 
 .slider-sm::-moz-range-track {
   background: rgba(255,255,255,0.25);
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   border: 1px solid rgba(255,255,255,0.12);
 }
 
 .slider-sm::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 12px;
-  height: 12px;
+  width: 0.75rem;
+  height: 0.75rem;
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
-  margin-top: -4px;
+  margin-top: -0.25rem;
   box-shadow: 0 0 4px var(--accent-glow, rgba(124,92,252,0.3));
 }
 
 .slider-sm::-moz-range-thumb {
-  width: 12px;
-  height: 12px;
+  width: 0.75rem;
+  height: 0.75rem;
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
@@ -6867,8 +6880,8 @@ details.sound-section:not([open]) .sound-section-label::before {
   color: var(--text-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 3px 6px;
-  font-size: 11px;
+  padding: 0.1875rem 0.375rem;
+  font-size: 0.6875rem;
   font-family: inherit;
   cursor: pointer;
   outline: none;
@@ -6882,8 +6895,8 @@ details.sound-section:not([open]) .sound-section-label::before {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .btn-emoji {
-  width: 34px;
-  height: 34px;
+  width: 2.125rem;
+  height: 2.125rem;
   background: transparent;
   color: var(--text-muted);
   border-radius: var(--radius);
@@ -6892,7 +6905,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   justify-content: center;
   transition: all var(--transition);
   flex-shrink: 0;
-  font-size: 18px;
+  font-size: 1.125rem;
 }
 
 .btn-emoji:hover { color: var(--text-primary); background: var(--bg-tertiary); }
@@ -6901,23 +6914,23 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   bottom: 100%;
   left: 0;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 12px;
-  padding: 8px;
+  border-radius: 0.75rem;
+  padding: 0.5rem;
   display: flex;
   flex-direction: column;
-  width: 340px;
-  max-height: 360px;
+  width: 21.25rem;
+  max-height: 22.5rem;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
   z-index: 1050;
 }
 
 .emoji-search-row {
-  padding: 0 2px 6px;
+  padding: 0 0.125rem 0.375rem;
   display: flex;
-  gap: 6px;
+  gap: 0.375rem;
   align-items: center;
   position: relative; /* anchor for the skin-tone dropdown */
 }
@@ -6925,12 +6938,12 @@ details.sound-section:not([open]) .sound-section-label::before {
 .emoji-search-input {
   flex: 1;
   min-width: 0;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   outline: none;
 }
 .emoji-search-input:focus {
@@ -6940,9 +6953,9 @@ details.sound-section:not([open]) .sound-section-label::before {
 /* Skin-tone selector (hand button + tone dropdown) */
 .emoji-skin-btn {
   flex: 0 0 auto;
-  width: 30px;
-  height: 30px;
-  font-size: 17px;
+  width: 1.875rem;
+  height: 1.875rem;
+  font-size: 1.0625rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6957,10 +6970,10 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   top: 100%;
   right: 2px;
-  margin-top: 4px;
+  margin-top: 0.25rem;
   display: flex;
-  gap: 2px;
-  padding: 4px;
+  gap: 0.125rem;
+  padding: 0.25rem;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-sm);
@@ -6968,9 +6981,9 @@ details.sound-section:not([open]) .sound-section-label::before {
   z-index: 2;
 }
 .emoji-skin-opt {
-  width: 30px;
-  height: 30px;
-  font-size: 17px;
+  width: 1.875rem;
+  height: 1.875rem;
+  font-size: 1.0625rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6983,16 +6996,16 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .emoji-tab-row {
   display: flex;
-  gap: 2px;
-  padding: 0 2px 6px;
+  gap: 0.125rem;
+  padding: 0 0.125rem 0.375rem;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 6px;
+  margin-bottom: 0.375rem;
 }
 
 .emoji-tab {
   flex: 1;
-  padding: 4px 0;
-  font-size: 16px;
+  padding: 0.25rem 0;
+  font-size: 1rem;
   text-align: center;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -7006,8 +7019,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .emoji-grid {
   overflow-y: scroll;
-  max-height: 240px;
-  padding: 2px;
+  max-height: 15rem;
+  padding: 0.125rem;
   position: relative; /* offsetParent for category sections, so tab clicks can scroll to them */
   /* Reserve the sticky .emoji-cat-header strip (26px) so keyboard scrollIntoView
      lands emoji below the header instead of tucked underneath it. */
@@ -7017,14 +7030,14 @@ details.sound-section:not([open]) .sound-section-label::before {
 .emoji-cat-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .emoji-cat-header {
   position: sticky;
   top: 0;
-  padding: 6px 4px 3px;
-  font-size: 11px;
+  padding: 0.375rem 0.25rem 0.1875rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -7032,15 +7045,15 @@ details.sound-section:not([open]) .sound-section-label::before {
   background: var(--bg-card);
   z-index: 1;
 }
-.emoji-cat:first-child .emoji-cat-header { padding-top: 2px; }
+.emoji-cat:first-child .emoji-cat-header { padding-top: 0.125rem; }
 
 .emoji-item {
-  width: 36px;
-  height: 36px;
+  width: 2.25rem;
+  height: 2.25rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
+  font-size: 1.25rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
   background: none;
@@ -7063,27 +7076,27 @@ details.sound-section:not([open]) .sound-section-label::before {
 /* ── Stickers ───────────────────────────────────────── */
 /* Inline rendered sticker in messages — larger than chat-image, no background. */
 .sticker-img {
-  max-width: 180px;
-  max-height: 180px;
+  max-width: 11.25rem;
+  max-height: 11.25rem;
   width: auto;
   height: auto;
   border-radius: var(--radius);
   display: block;
-  margin: 4px 0;
+  margin: 0.25rem 0;
 }
 
 /* Picker section toggle (Emoji | Sticker) */
 .emoji-section-row {
   display: flex;
-  gap: 4px;
-  padding: 2px 2px 6px;
+  gap: 0.25rem;
+  padding: 0.125rem 0.125rem 0.375rem;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 6px;
+  margin-bottom: 0.375rem;
 }
 .emoji-section-tab {
   flex: 1;
-  padding: 6px 0;
-  font-size: 12px;
+  padding: 0.375rem 0;
+  font-size: 0.75rem;
   font-weight: 600;
   text-align: center;
   border-radius: var(--radius-sm);
@@ -7105,16 +7118,16 @@ details.sound-section:not([open]) .sound-section-label::before {
 .sticker-pack-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
-  padding: 0 2px 6px;
+  gap: 0.25rem;
+  padding: 0 0.125rem 0.375rem;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 6px;
-  max-height: 64px;
+  margin-bottom: 0.375rem;
+  max-height: 4rem;
   overflow-y: auto;
 }
 .sticker-pack-btn {
-  padding: 3px 8px;
-  font-size: 11px;
+  padding: 0.1875rem 0.5rem;
+  font-size: 0.6875rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
   background: var(--bg-tertiary);
@@ -7122,7 +7135,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   color: var(--text-secondary);
   opacity: 0.75;
   transition: opacity var(--transition), background var(--transition), color var(--transition);
-  max-width: 120px;
+  max-width: 7.5rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -7138,16 +7151,16 @@ details.sound-section:not([open]) .sound-section-label::before {
 .sticker-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 6px;
+  gap: 0.375rem;
   overflow-y: auto;
-  max-height: 240px;
-  padding: 2px;
+  max-height: 15rem;
+  padding: 0.125rem;
 }
 .sticker-picker-item {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4px;
+  padding: 0.25rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
   background: var(--bg-tertiary);
@@ -7160,7 +7173,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 .sticker-picker-thumb {
   width: 100%;
-  height: 64px;
+  height: 4rem;
   object-fit: contain;
   display: block;
 }
@@ -7172,7 +7185,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   vertical-align: middle;
   object-fit: contain;
   display: inline;
-  margin: 0 1px;
+  margin: 0 0.0625rem;
 }
 /* Jumbo rendering when a message contains only emoji */
 .emoji-only-msg {
@@ -7185,15 +7198,15 @@ details.sound-section:not([open]) .sound-section-label::before {
   height: 1em;
 }
 .emoji-item .custom-emoji {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 .reaction-full-btn .custom-emoji {
-  width: 22px;
-  height: 22px;
+  width: 1.375rem;
+  height: 1.375rem;
 }
 .custom-emoji-preview {
-  border-radius: 4px;
+  border-radius: 0.25rem;
 }
 
 
@@ -7202,8 +7215,8 @@ details.sound-section:not([open]) .sound-section-label::before {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .btn-gif {
-  width: 34px;
-  height: 24px;
+  width: 2.125rem;
+  height: 1.5rem;
   background: transparent;
   color: var(--text-muted);
   border: 1px solid var(--text-muted);
@@ -7213,7 +7226,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   justify-content: center;
   transition: all var(--transition);
   flex-shrink: 0;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   letter-spacing: 0.5px;
   cursor: pointer;
@@ -7230,12 +7243,12 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   bottom: 100%;
   left: 88px;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 12px;
-  width: 340px;
-  max-height: 420px;
+  border-radius: 0.75rem;
+  width: 21.25rem;
+  max-height: 26.25rem;
   display: flex;
   flex-direction: column;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
@@ -7245,19 +7258,19 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .gif-picker-tabs {
   display: flex;
-  gap: 4px;
-  padding: 8px 10px 0;
+  gap: 0.25rem;
+  padding: 0.5rem 0.625rem 0;
   flex-shrink: 0;
 }
 
 .gif-tab {
   flex: 1;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--bg-primary);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 0.75rem;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }
@@ -7271,19 +7284,19 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .gif-picker-header {
-  padding: 10px;
+  padding: 0.625rem;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
 .gif-picker-header input {
   width: 100%;
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   border-radius: var(--radius);
   border: 1px solid var(--border);
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   outline: none;
 }
 
@@ -7294,11 +7307,11 @@ details.sound-section:not([open]) .sound-section-label::before {
 .gif-picker-grid {
   flex: 1;
   overflow-y: auto;
-  padding: 6px;
+  padding: 0.375rem;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 6px;
-  min-height: 200px;
+  gap: 0.375rem;
+  min-height: 12.5rem;
 }
 
 .gif-picker-grid img {
@@ -7324,8 +7337,8 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   top: 4px;
   right: 4px;
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   padding: 0;
   display: flex;
   align-items: center;
@@ -7334,7 +7347,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.55);
   color: #fff;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 1;
   cursor: pointer;
   opacity: 0;
@@ -7357,8 +7370,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .gif-picker-footer {
-  padding: 4px 10px;
-  font-size: 10px;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.625rem;
   color: var(--text-muted);
   text-align: right;
   border-top: 1px solid var(--border);
@@ -7368,89 +7381,89 @@ details.sound-section:not([open]) .sound-section-label::before {
 .gif-picker-empty {
   grid-column: 1 / -1;
   text-align: center;
-  padding: 40px 10px;
+  padding: 2.5rem 0.625rem;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 
 /* /gif slash command inline picker */
 .gif-slash-picker {
   background: var(--bg-secondary); border: 1px solid var(--border);
-  border-radius: 8px; margin: 0 8px 4px; max-height: 240px;
+  border-radius: 0.5rem; margin: 0 0.5rem 0.25rem; max-height: 15rem;
   overflow-y: auto; box-shadow: 0 -4px 12px rgba(0,0,0,0.3);
 }
 .gif-slash-header {
   display: flex; justify-content: space-between; align-items: center;
-  padding: 6px 10px; font-size: 12px; color: var(--text-muted);
+  padding: 0.375rem 0.625rem; font-size: 0.75rem; color: var(--text-muted);
   border-bottom: 1px solid var(--border); position: sticky; top: 0;
   background: var(--bg-secondary); z-index: 1;
 }
 .gif-slash-grid {
   display: grid; grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
-  gap: 4px; padding: 6px;
+  gap: 0.25rem; padding: 0.375rem;
 }
 .gif-slash-grid img {
-  width: 100%; height: 80px; object-fit: cover;
-  border-radius: 4px; cursor: pointer; transition: transform 0.1s;
+  width: 100%; height: 5rem; object-fit: cover;
+  border-radius: 0.25rem; cursor: pointer; transition: transform 0.1s;
 }
 .gif-slash-grid img:hover { transform: scale(1.05); }
 .gif-slash-loading {
-  padding: 20px; text-align: center; color: var(--text-muted); font-size: 13px;
+  padding: 1.25rem; text-align: center; color: var(--text-muted); font-size: 0.8125rem;
 }
 
 /* GIF setup guide (shown when GIPHY key not configured) */
 .gif-setup-guide {
   grid-column: 1 / -1;
-  padding: 16px 20px;
+  padding: 1rem 1.25rem;
   text-align: left;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.5;
 }
 .gif-setup-guide h3 {
-  margin: 0 0 8px;
-  font-size: 15px;
+  margin: 0 0 0.5rem;
+  font-size: 0.9375rem;
 }
 .gif-setup-guide ol {
-  margin: 8px 0;
-  padding-left: 20px;
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
 }
 .gif-setup-guide li {
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
 }
 .gif-setup-guide a {
   color: var(--accent);
 }
 .gif-setup-input-row {
   display: flex;
-  gap: 8px;
-  margin: 10px 0;
+  gap: 0.5rem;
+  margin: 0.625rem 0;
 }
 .gif-setup-input-row input {
   flex: 1;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-family: monospace;
 }
 .gif-setup-input-row button {
-  padding: 6px 16px;
+  padding: 0.375rem 1rem;
   border: none;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   background: var(--accent);
   color: #fff;
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
 }
 .gif-setup-input-row button:hover {
   opacity: 0.9;
 }
 .gif-setup-note {
-  margin: 6px 0 0;
-  font-size: 12px;
+  margin: 0.375rem 0 0;
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 
@@ -7462,28 +7475,28 @@ details.sound-section:not([open]) .sound-section-label::before {
 .reactions-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 4px;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
 }
 
 .reaction-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
   background: var(--bg-tertiary);
   border: 1px solid transparent;
-  border-radius: 12px;
-  font-size: 13px;
+  border-radius: 0.75rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   cursor: pointer;
   transition: all var(--transition);
 }
 
 /* Emoji Reaction Size tiers */
-[data-emojisize="small"]   .reaction-badge { font-size: 11px; padding: 1px 6px; }
-[data-emojisize="large"]   .reaction-badge { font-size: 18px; padding: 3px 10px; }
-[data-emojisize="x-large"] .reaction-badge { font-size: 22px; padding: 4px 12px; }
+[data-emojisize="small"]   .reaction-badge { font-size: 0.6875rem; padding: 0.0625rem 0.375rem; }
+[data-emojisize="large"]   .reaction-badge { font-size: 1.125rem; padding: 0.1875rem 0.625rem; }
+[data-emojisize="x-large"] .reaction-badge { font-size: 1.375rem; padding: 0.25rem 0.75rem; }
 
 .reaction-badge:hover {
   background: rgba(124, 92, 252, 0.15);
@@ -7504,9 +7517,9 @@ details.sound-section:not([open]) .sound-section-label::before {
   border: 1px solid var(--border-light);
   border-radius: var(--radius);
   box-shadow: 0 8px 24px rgba(0,0,0,0.4);
-  min-width: 140px;
-  max-width: 240px;
-  max-height: 240px;
+  min-width: 8.75rem;
+  max-width: 15rem;
+  max-height: 15rem;
   overflow-y: auto;
   animation: popout-in 0.12s ease-out;
 }
@@ -7517,21 +7530,21 @@ details.sound-section:not([open]) .sound-section-label::before {
 .reaction-popout-header {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 12px 4px;
-  font-size: 16px;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem 0.25rem;
+  font-size: 1rem;
   border-bottom: 1px solid var(--border-light);
 }
 .reaction-popout-count {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 .reaction-popout-list {
-  padding: 4px 0;
+  padding: 0.25rem 0;
 }
 .reaction-popout-user {
-  padding: 4px 12px;
-  font-size: 13px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8125rem;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -7546,22 +7559,22 @@ details.sound-section:not([open]) .sound-section-label::before {
   top: -44px;
   right: 8px;
   display: flex;
-  gap: 2px;
+  gap: 0.125rem;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 10px;
-  padding: 4px 6px;
+  border-radius: 0.625rem;
+  padding: 0.25rem 0.375rem;
   box-shadow: 0 4px 20px rgba(0,0,0,0.35);
   z-index: 100;
 }
 
 .reaction-pick-btn {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
+  font-size: 1.125rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
   background: none;
@@ -7575,7 +7588,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 
 .reaction-more-btn {
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--text-muted);
   letter-spacing: 1px;
@@ -7583,16 +7596,16 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .reaction-pick-sep {
   color: var(--text-muted);
-  font-size: 16px;
+  font-size: 1rem;
   opacity: 0.4;
   user-select: none;
   display: flex;
   align-items: center;
-  padding: 0 1px;
+  padding: 0 0.0625rem;
 }
 
 .reaction-gear-btn {
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-muted);
   opacity: 0.6;
   transition: opacity 0.15s;
@@ -7603,10 +7616,10 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .quick-emoji-slots {
   display: flex;
-  gap: 4px;
-  padding: 4px 8px;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
   /* The slot row is what you click to choose which emoji to replace, so it
      must never scroll out of reach behind the emoji grid. Pinning it and
      refusing to let flex shrink it keeps it visible at any panel height. */
@@ -7631,32 +7644,32 @@ details.sound-section:not([open]) .sound-section-label::before {
   position: absolute;
   bottom: calc(100% + 6px);
   right: 0;
-  width: 320px;
-  max-height: 340px;
+  width: 20rem;
+  max-height: 21.25rem;
   display: flex;
   flex-direction: column;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 10px;
+  border-radius: 0.625rem;
   box-shadow: 0 8px 30px rgba(0,0,0,0.45);
   z-index: 101;
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
   overflow: hidden;
 }
 
 .reaction-full-search {
-  padding: 8px 10px 4px;
+  padding: 0.5rem 0.625rem 0.25rem;
   flex-shrink: 0;
 }
 
 .reaction-full-search-input {
   width: 100%;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   outline: none;
 }
 .reaction-full-search-input:focus {
@@ -7666,31 +7679,31 @@ details.sound-section:not([open]) .sound-section-label::before {
 .reaction-full-grid {
   flex: 1;
   overflow-y: auto;
-  padding: 4px 10px 8px;
+  padding: 0.25rem 0.625rem 0.5rem;
 }
 
 .reaction-full-category {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  padding: 6px 0 2px;
+  padding: 0.375rem 0 0.125rem;
 }
 
 .reaction-full-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 2px;
+  gap: 0.125rem;
 }
 
 .reaction-full-btn {
-  width: 34px;
-  height: 34px;
+  width: 2.125rem;
+  height: 2.125rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
+  font-size: 1.25rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
   background: none;
@@ -7717,17 +7730,17 @@ details.sound-section:not([open]) .sound-section-label::before {
   top: 2px;
   right: 8px;
   display: none;
-  gap: 2px;
+  gap: 0.125rem;
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 2px 4px;
+  border-radius: 0.5rem;
+  padding: 0.125rem 0.25rem;
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
   z-index: 20;
 }
 .msg-toolbar-group {
   display: flex;
-  gap: 2px;
+  gap: 0.125rem;
 }
 .msg-toolbar-more,
 .thread-msg-more {
@@ -7742,12 +7755,12 @@ details.sound-section:not([open]) .sound-section-label::before {
   right: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  min-width: 36px;
+  gap: 0.125rem;
+  min-width: 2.25rem;
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 4px;
+  border-radius: 0.5rem;
+  padding: 0.25rem;
   box-shadow: 0 4px 16px rgba(0,0,0,0.25);
   z-index: 200;
   opacity: 0;
@@ -7786,8 +7799,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 .message-compact.editing .msg-toolbar { display: none !important; }
 
 .msg-toolbar button {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -7806,8 +7819,8 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .msg-toolbar button svg,
 .thread-msg-toolbar button svg {
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   stroke: currentColor;
   fill: none;
 }
@@ -7818,7 +7831,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   line-height: 1;
 }
 .tb-icon-emoji {
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 .tb-icon-mono {
   display: inline-flex;
@@ -7868,9 +7881,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 4px;
-  font-size: 12px;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
 }
 
 .toolbar-slots-row input[type="range"] {
@@ -7879,14 +7892,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .toolbar-slots-value {
-  min-width: 14px;
+  min-width: 0.875rem;
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
 .toolbar-order-wrap {
-  margin-top: 8px;
-  padding: 8px;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-primary);
@@ -7896,44 +7909,44 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 6px;
-  font-size: 12px;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
+  font-size: 0.75rem;
   font-weight: 600;
 }
 
 .toolbar-order-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .toolbar-order-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 6px 8px;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: var(--bg-tertiary);
 }
 
 .toolbar-order-item-label {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-primary);
 }
 
 .toolbar-order-item-controls {
   display: flex;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .toolbar-order-move {
-  min-width: 26px;
-  height: 24px;
+  min-width: 1.625rem;
+  height: 1.5rem;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   background: var(--bg-secondary);
   color: var(--text-primary);
   cursor: pointer;
@@ -7951,24 +7964,24 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .reply-banner {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 10px;
+  gap: 0.5rem;
+  padding: 0.3125rem 0.625rem;
   font-size: 0.8em;
   color: var(--text-muted);
   cursor: pointer;
   overflow: hidden;
   background: var(--bg-tertiary);
-  border-radius: 6px;
-  margin-bottom: 4px;
+  border-radius: 0.375rem;
+  margin-bottom: 0.25rem;
   max-width: fit-content;
 }
 
 .reply-banner:hover { background: var(--bg-secondary); }
 
 .reply-line {
-  width: 3px;
-  height: 16px;
-  border-radius: 2px;
+  width: 0.1875rem;
+  height: 1rem;
+  border-radius: 0.125rem;
   flex-shrink: 0;
 }
 
@@ -7984,11 +7997,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .reply-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 20px;
+  gap: 0.5rem;
+  padding: 0.375rem 1.25rem;
   background: var(--bg-tertiary);
   border-top: 2px solid var(--accent);
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
 }
 
@@ -8000,8 +8013,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .reply-bar-close {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -8010,7 +8023,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   background: none;
   border: none;
   color: var(--text-muted);
-  font-size: 16px;
+  font-size: 1rem;
   flex-shrink: 0;
   transition: all var(--transition);
 }
@@ -8023,14 +8036,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .thread-preview {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-top: 6px;
-  padding: 4px 10px;
+  gap: 0.375rem;
+  margin-top: 0.375rem;
+  padding: 0.25rem 0.625rem;
   background: none;
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--accent);
   font-weight: 600;
   transition: background 0.15s;
@@ -8039,33 +8052,33 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   background: var(--bg-tertiary);
 }
 .thread-participant-avatar {
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
 }
 .thread-participant-avatar + .thread-participant-avatar {
-  margin-left: -6px;
+  margin-left: -0.375rem;
 }
 .thread-participant-initial {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
   color: #fff;
 }
 .thread-preview-count {
-  margin-left: 4px;
+  margin-left: 0.25rem;
 }
 .thread-preview-time {
   color: var(--text-muted);
   font-weight: 400;
-  margin-left: 4px;
+  margin-left: 0.25rem;
 }
 .thread-preview-arrow {
-  font-size: 16px;
+  font-size: 1rem;
   opacity: 0;
   transition: opacity 0.15s;
 }
@@ -8079,9 +8092,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   top: 0;
   right: 0;
   bottom: var(--thread-footer-offset, 0px);
-  width: 380px;
-  min-width: 300px;
-  max-width: min(78vw, 920px);
+  width: 23.75rem;
+  min-width: 18.75rem;
+  max-width: min(78vw, 57.5rem);
   max-width: 100vw;
   background: var(--bg-primary);
   border-left: 1px solid var(--border-light);
@@ -8098,7 +8111,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   left: 0;
   top: 0;
   bottom: 0;
-  width: 8px;
+  width: 0.5rem;
   cursor: ew-resize;
   z-index: 2;
 }
@@ -8106,11 +8119,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   top: auto;
   right: 14px;
   bottom: calc(var(--thread-footer-offset, 0px) + 14px);
-  width: min(420px, calc(100vw - 28px));
-  height: min(58vh, 520px);
-  max-height: calc(100vh - var(--thread-footer-offset, 0px) - 28px);
+  width: min(26.25rem, calc(100vw - 1.75rem));
+  height: min(58vh, 32.5rem);
+  max-height: calc(100vh - var(--thread-footer-offset, 0) - 1.75rem);
   border: 1px solid var(--border-light);
-  border-radius: 12px;
+  border-radius: 0.75rem;
   resize: both;
   overflow: hidden;
   /* Must sit above .message-input-area (z:99995) — same reason the docked
@@ -8125,61 +8138,61 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   to   { transform: translateX(0); }
 }
 .thread-panel-header {
-  padding: 14px 16px 10px;
+  padding: 0.875rem 1rem 0.625rem;
   border-bottom: 1px solid var(--border-light);
   flex-shrink: 0;
 }
 .thread-panel-header-top {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .thread-panel.pip .thread-panel-header-top {
   cursor: move;
 }
-.thread-panel-icon { font-size: 18px; }
+.thread-panel-icon { font-size: 1.125rem; }
 .thread-panel-title {
   flex: 1;
-  font-size: 15px;
+  font-size: 0.9375rem;
   font-weight: 700;
   color: var(--text-primary);
 }
 .thread-parent-meta {
-  margin-top: 8px;
+  margin-top: 0.5rem;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .thread-parent-avatar-wrap {
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
   flex-shrink: 0;
 }
 .thread-parent-avatar {
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
   border-radius: 50%;
   object-fit: cover;
 }
 .thread-parent-avatar.thread-parent-avatar-square {
-  border-radius: 6px;
+  border-radius: 0.375rem;
 }
 .thread-parent-avatar-initial {
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   color: #fff;
 }
 .thread-parent-avatar-initial.thread-parent-avatar-square {
-  border-radius: 6px;
+  border-radius: 0.375rem;
 }
 .thread-parent-name {
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--text-secondary);
   overflow: hidden;
@@ -8187,8 +8200,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   white-space: nowrap;
 }
 .thread-parent-preview {
-  margin-top: 6px;
-  font-size: 12px;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
   line-height: 1.4;
   overflow: hidden;
@@ -8200,10 +8213,10 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .thread-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 14px;
+  padding: 0.75rem 0.875rem;
 }
 .thread-message {
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
   position: relative;
   border-radius: var(--radius-sm);
   transition: background var(--transition), box-shadow var(--transition);
@@ -8212,7 +8225,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
    author. Avatar/author header are dropped; a timestamp shows in the avatar
    gutter on hover, like the main channel's compact rows. */
 .thread-message.thread-compact {
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 .thread-msg-compact-spacer {
   background: transparent !important;
@@ -8221,7 +8234,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   justify-content: center;
 }
 .thread-compact-time {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
   opacity: 0;
   transition: opacity var(--transition);
@@ -8240,12 +8253,12 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 .thread-msg-row {
   display: flex;
-  gap: 10px;
-  padding: 4px 8px;
+  gap: 0.625rem;
+  padding: 0.25rem 0.5rem;
 }
 .thread-msg-avatar {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   flex-shrink: 0;
   object-fit: cover;
@@ -8254,7 +8267,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 700;
   color: #fff;
 }
@@ -8262,8 +8275,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .thread-msg-header {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 2px;
+  gap: 0.375rem;
+  margin-bottom: 0.125rem;
 }
 .thread-msg-header-spacer { flex: 1; }
 .thread-msg-toolbar {
@@ -8271,11 +8284,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   top: 2px;
   right: 8px;
   display: none;
-  gap: 2px;
+  gap: 0.125rem;
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 2px 4px;
+  border-radius: 0.5rem;
+  padding: 0.125rem 0.25rem;
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
   z-index: 10;
 }
@@ -8295,12 +8308,12 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: none !important;
 }
 .thread-msg-toolbar button {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
   background: none;
@@ -8312,21 +8325,21 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   color: var(--text-primary);
 }
 .thread-action-react-icon {
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   stroke: currentColor;
   fill: none;
 }
 .thread-msg-author {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
 }
 .thread-msg-time {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
 }
 .thread-msg-content {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-primary);
   line-height: 1.4;
   word-wrap: break-word;
@@ -8343,15 +8356,15 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   pointer-events: auto;
 }
 .thread-react-btn {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border: none;
   background: transparent;
   color: var(--text-muted);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   padding: 0;
   cursor: pointer;
 }
@@ -8360,16 +8373,16 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   color: var(--text-primary);
 }
 .thread-react-btn svg {
-  width: 16px;
-  height: 16px;
+  width: 1rem;
+  height: 1rem;
   stroke: currentColor;
   fill: none;
 }
 .thread-input-area {
   display: flex;
   align-items: flex-end;
-  gap: 8px;
-  padding: 14px 14px 10px;
+  gap: 0.5rem;
+  padding: 0.875rem 0.875rem 0.625rem;
   border-top: 1px solid var(--border-light);
   flex-shrink: 0;
   /* Anchor for autocomplete dropdowns positioned with bottom: 100% (#5296) */
@@ -8379,11 +8392,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
   border-top: 1px solid var(--border-light);
   background: var(--bg-secondary);
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 #thread-reply-preview-text {
@@ -8404,17 +8417,17 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   border-radius: var(--radius);
   background: var(--bg-secondary);
   color: var(--text-primary);
-  padding: 8px 12px;
-  font-size: 13px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
   font-family: inherit;
-  min-height: 36px;
-  max-height: 200px;
+  min-height: 2.25rem;
+  max-height: 12.5rem;
   overflow-y: auto;
 }
 .thread-input:focus { outline: none; border-color: var(--accent); }
 .thread-send-btn {
-  width: 34px;
-  height: 34px;
+  width: 2.125rem;
+  height: 2.125rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -8435,8 +8448,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .image-queue-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
   background: var(--bg-tertiary);
   border-top: 1px solid var(--border);
   overflow-x: auto;
@@ -8447,23 +8460,23 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .upload-progress-bar {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 6px 14px;
+  gap: 0.625rem;
+  padding: 0.375rem 0.875rem;
   background: var(--bg-tertiary);
   border-top: 1px solid var(--border);
 }
 .upload-progress-track {
   flex: 1;
-  height: 6px;
+  height: 0.375rem;
   background: var(--bg-secondary);
-  border-radius: 3px;
+  border-radius: 0.1875rem;
   overflow: hidden;
 }
 .upload-progress-fill {
   height: 100%;
   width: 0%;
   background: var(--accent);
-  border-radius: 3px;
+  border-radius: 0.1875rem;
   transition: width 0.15s ease;
 }
 .upload-progress-text {
@@ -8474,9 +8487,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 .image-queue-thumb {
   position: relative;
-  width: 64px;
-  height: 64px;
-  border-radius: 6px;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 0.375rem;
   overflow: hidden;
   border: 2px solid var(--border);
   flex-shrink: 0;
@@ -8499,13 +8512,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   top: 2px;
   right: 2px;
-  width: 18px;
-  height: 18px;
+  width: 1.125rem;
+  height: 1.125rem;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
   border: none;
   border-radius: 50%;
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1;
   cursor: pointer;
   display: flex;
@@ -8530,19 +8543,19 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .custom-select-wrap {
   display: inline-block;
   vertical-align: middle;
-  min-width: 140px;
+  min-width: 8.75rem;
 }
 .custom-select-display {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 6px;
+  gap: 0.375rem;
   width: 100%;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   background: var(--bg-input, var(--bg-secondary));
   color: var(--text-primary);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   font-size: 0.85rem;
   cursor: pointer;
   text-align: left;
@@ -8567,11 +8580,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   top: calc(100% + 4px);
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   box-shadow: 0 6px 20px rgba(0,0,0,0.35);
   overflow-y: auto;
   z-index: 1100;
-  padding: 4px;
+  padding: 0.25rem;
 }
 .custom-select-panel.flip-up {
   top: auto;
@@ -8583,11 +8596,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   text-transform: uppercase;
   letter-spacing: 0.6px;
   color: var(--text-muted);
-  padding: 6px 8px 2px;
+  padding: 0.375rem 0.5rem 0.125rem;
 }
 .custom-select-option {
-  padding: 6px 10px;
-  border-radius: 4px;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.25rem;
   cursor: pointer;
   color: var(--text-primary);
   font-size: 0.85rem;
@@ -8606,11 +8619,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: relative;
   display: flex;
   align-items: center;
-  gap: 6px;
-  max-width: 220px;
-  height: 36px;
-  padding: 0 28px 0 10px;
-  border-radius: 6px;
+  gap: 0.375rem;
+  max-width: 13.75rem;
+  height: 2.25rem;
+  padding: 0 1.75rem 0 0.625rem;
+  border-radius: 0.375rem;
   border: 1px solid var(--border);
   background: var(--bg-secondary);
   font-size: 0.78rem;
@@ -8621,7 +8634,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   border-color: var(--accent);
 }
 .file-queue-chip-icon {
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 1;
 }
 .file-queue-chip-name {
@@ -8645,9 +8658,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   color: var(--text-muted);
-  border-radius: 4px;
-  padding: 4px 10px;
-  font-size: 11px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.6875rem;
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
@@ -8667,8 +8680,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .mention {
   background: rgba(124, 92, 252, 0.15);
   color: var(--accent);
-  padding: 0 3px;
-  border-radius: 4px;
+  padding: 0 0.1875rem;
+  border-radius: 0.25rem;
   font-weight: 600;
   cursor: default;
 }
@@ -8685,8 +8698,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .channel-link {
   background: rgba(124, 92, 252, 0.12);
   color: var(--accent);
-  padding: 0 4px;
-  border-radius: 4px;
+  padding: 0 0.25rem;
+  border-radius: 0.25rem;
   font-weight: 500;
   cursor: pointer;
   transition: background 0.12s;
@@ -8705,8 +8718,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   top: 4px;
   right: 4px;
-  width: 8px;
-  height: 8px;
+  width: 0.5rem;
+  height: 0.5rem;
   border-radius: 50%;
   background: var(--accent, #7c5cfc);
   box-shadow: 0 0 0 2px var(--bg-secondary, #1c1c20);
@@ -8718,20 +8731,20 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   bottom: 100%;
   left: 48px;
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   overflow: hidden;
-  min-width: 180px;
-  max-width: 260px;
+  min-width: 11.25rem;
+  max-width: 16.25rem;
   box-shadow: 0 8px 24px rgba(0,0,0,0.35);
   z-index: 1001;
 }
 
 .mention-item {
-  padding: 8px 14px;
-  font-size: 13px;
+  padding: 0.5rem 0.875rem;
+  font-size: 0.8125rem;
   color: var(--text-primary);
   cursor: pointer;
   transition: background var(--transition);
@@ -8743,7 +8756,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .mention-item-handle {
-  margin-left: 6px;
+  margin-left: 0.375rem;
   opacity: 0.65;
   font-size: 0.85em;
 }
@@ -8753,23 +8766,23 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   bottom: 100%;
   left: 0;
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   overflow-y: auto;
-  max-height: 320px;
-  min-width: 260px;
-  max-width: 380px;
+  max-height: 20rem;
+  min-width: 16.25rem;
+  max-width: 23.75rem;
   box-shadow: 0 8px 24px rgba(0,0,0,0.35);
   z-index: 1000;
-  padding: 4px 0;
+  padding: 0.25rem 0;
 }
 .emoji-ac-item {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 7px 14px;
+  gap: 0.625rem;
+  padding: 0.4375rem 0.875rem;
   cursor: pointer;
   transition: background var(--transition);
 }
@@ -8779,7 +8792,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 .emoji-ac-preview {
   flex-shrink: 0;
-  width: 22px;
+  width: 1.375rem;
   text-align: center;
 }
 .emoji-ac-preview-char {
@@ -8795,14 +8808,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   bottom: 100%;
   left: 48px;
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   overflow-y: auto;
-  max-height: 320px;
-  min-width: 280px;
-  max-width: 400px;
+  max-height: 20rem;
+  min-width: 17.5rem;
+  max-width: 25rem;
   box-shadow: 0 8px 24px rgba(0,0,0,0.35);
   z-index: 1002;
 }
@@ -8810,9 +8823,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .slash-item {
   display: flex;
   align-items: baseline;
-  gap: 8px;
-  padding: 8px 14px;
-  font-size: 13px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  font-size: 0.8125rem;
   color: var(--text-primary);
   cursor: pointer;
   transition: background var(--transition);
@@ -8829,7 +8842,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .slash-cmd {
   font-weight: 700;
   color: var(--accent);
-  min-width: 82px;
+  min-width: 5.125rem;
   flex-shrink: 0;
 }
 
@@ -8839,7 +8852,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .slash-args {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   font-style: italic;
   flex-shrink: 0;
@@ -8851,7 +8864,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .slash-desc {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   margin-left: auto;
   text-align: right;
@@ -8873,42 +8886,42 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .search-container {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-light);
-  border-radius: 6px;
-  padding: 2px 6px;
-  margin-right: 8px;
+  border-radius: 0.375rem;
+  padding: 0.125rem 0.375rem;
+  margin-right: 0.5rem;
 }
 
 .search-input {
   background: transparent;
   border: none;
   color: var(--text-primary);
-  font-size: 13px;
-  width: 260px;
+  font-size: 0.8125rem;
+  width: 16.25rem;
   outline: none;
-  padding: 4px 2px;
+  padding: 0.25rem 0.125rem;
 }
 
 .search-input::placeholder {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: 0.6875rem;
 }
 
 .search-filter-tags {
   display: flex;
-  gap: 4px;
+  gap: 0.25rem;
   flex-wrap: wrap;
-  margin-top: 4px;
+  margin-top: 0.25rem;
 }
 .search-filter-tag {
   display: inline-block;
   background: var(--accent);
   color: #fff;
-  font-size: 11px;
-  padding: 2px 6px;
-  border-radius: 4px;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
   font-weight: 600;
 }
 
@@ -8916,7 +8929,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   top: 0;
   right: 0;
-  width: 340px;
+  width: 21.25rem;
   max-height: 100%;
   background: var(--bg-card);
   border-left: 1px solid var(--border-light);
@@ -8931,12 +8944,12 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  padding: 10px 14px;
+  padding: 0.625rem 0.875rem;
   border-bottom: 1px solid var(--border-light);
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-primary);
-  gap: 8px;
+  gap: 0.5rem;
 }
 
 .search-results-list {
@@ -8945,7 +8958,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .search-result-item {
-  padding: 10px 14px;
+  padding: 0.625rem 0.875rem;
   border-bottom: 1px solid var(--border-light);
   cursor: pointer;
   transition: background var(--transition);
@@ -8957,19 +8970,19 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 .search-result-author {
   font-weight: 600;
-  font-size: 12px;
-  margin-right: 6px;
+  font-size: 0.75rem;
+  margin-right: 0.375rem;
 }
 
 .search-result-time {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
 }
 
 .search-result-content {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
-  margin-top: 4px;
+  margin-top: 0.25rem;
   word-break: break-word;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -8981,8 +8994,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .search-result-content mark {
   background: rgba(250, 166, 26, 0.35);
   color: inherit;
-  padding: 0 2px;
-  border-radius: 2px;
+  padding: 0 0.125rem;
+  border-radius: 0.125rem;
 }
 
 /* Highlight flash on message when clicking search result */
@@ -8999,8 +9012,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .new-messages-divider {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 4px 16px;
+  gap: 0.625rem;
+  padding: 0.25rem 1rem;
   user-select: none;
   pointer-events: none;
 }
@@ -9008,7 +9021,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .new-messages-divider::after {
   content: '';
   flex: 1;
-  height: 1px;
+  height: 0.0625rem;
   background: var(--accent, #5865f2);
   opacity: 0.6;
 }
@@ -9026,16 +9039,16 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .edited-tag {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
-  margin-left: 6px;
+  margin-left: 0.375rem;
   font-style: italic;
   cursor: default;
   user-select: none;
 }
 
 .e2e-tag {
-  font-size: 10px;
+  font-size: 0.625rem;
   opacity: 0.4;
   cursor: default;
   user-select: none;
@@ -9043,14 +9056,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 .message.message-has-status .message-body,
 .message-compact.message-has-status .message-body {
-  padding-right: 44px;
+  padding-right: 2.75rem;
 }
 .message-inline-status {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
   flex-direction: row-reverse;
-  gap: 6px;
+  gap: 0.375rem;
   margin-left: 0;
   white-space: nowrap;
   position: absolute;
@@ -9076,53 +9089,53 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 #e2e-recovery-banner {
   background: var(--bg-tertiary);
   border-bottom: 2px solid var(--accent);
-  padding: 8px 16px;
+  padding: 0.5rem 1rem;
   z-index: 50;
   flex-shrink: 0;
 }
 .e2e-recovery-inner {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 13px;
+  gap: 0.625rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   flex-wrap: wrap;
 }
 #e2e-recovery-pw {
-  padding: 4px 8px;
+  padding: 0.25rem 0.5rem;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 13px;
-  width: 180px;
+  font-size: 0.8125rem;
+  width: 11.25rem;
 }
 #e2e-recovery-dismiss {
   background: none;
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 6px;
+  font-size: 0.875rem;
+  padding: 0.125rem 0.375rem;
 }
 #e2e-recovery-dismiss:hover { color: var(--text-primary); }
 
 /* ── E2E Key Reset Confirmation Modal ─── */
 .e2e-reset-modal {
-  max-width: 460px;
+  max-width: 28.75rem;
   text-align: center;
 }
 .e2e-reset-modal h3 {
   color: var(--danger, #f44);
-  margin-bottom: 12px;
+  margin-bottom: 0.75rem;
 }
 .e2e-reset-warning {
   background: rgba(255, 68, 68, 0.08);
   border: 1px solid rgba(255, 68, 68, 0.25);
   border-radius: var(--radius-md);
-  padding: 16px;
-  margin: 12px 0;
-  font-size: 13px;
+  padding: 1rem;
+  margin: 0.75rem 0;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   text-align: left;
   line-height: 1.6;
@@ -9131,40 +9144,40 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   color: var(--danger, #f44);
 }
 .e2e-reset-warning ul {
-  margin: 8px 0 0 16px;
+  margin: 0.5rem 0 0 1rem;
   padding: 0;
 }
 .e2e-reset-warning ul li {
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
 }
 .e2e-confirm-type {
-  margin: 16px 0 12px;
+  margin: 1rem 0 0.75rem;
 }
 .e2e-confirm-type input {
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   width: 100%;
-  max-width: 260px;
+  max-width: 16.25rem;
   text-align: center;
 }
 .e2e-reset-actions {
   display: flex;
-  gap: 8px;
+  gap: 0.5rem;
   justify-content: center;
-  margin-top: 16px;
+  margin-top: 1rem;
 }
 .btn-danger {
   background: var(--danger, #f44);
   color: #fff;
   border: none;
-  padding: 6px 18px;
+  padding: 0.375rem 1.125rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 13px;
+  font-size: 0.8125rem;
   transition: opacity 0.15s;
 }
 .btn-danger:hover {
@@ -9196,18 +9209,18 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   box-shadow: 0 8px 24px rgba(0,0,0,0.4);
-  min-width: 210px;
-  padding: 6px 0;
-  margin-top: 4px;
+  min-width: 13.125rem;
+  padding: 0.375rem 0;
+  margin-top: 0.25rem;
 }
 .e2e-dropdown-item {
   display: block;
   width: 100%;
-  padding: 8px 14px;
+  padding: 0.5rem 0.875rem;
   border: none;
   background: none;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
   text-align: left;
   transition: background 0.12s;
@@ -9224,29 +9237,29 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 /* ── E2E Password Prompt Modal ─── */
 .e2e-password-modal {
-  max-width: 380px;
+  max-width: 23.75rem;
   text-align: center;
 }
 .e2e-password-modal h3 {
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 .e2e-pw-desc {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-muted);
-  margin-bottom: 16px;
+  margin-bottom: 1rem;
   line-height: 1.5;
 }
 .e2e-pw-field {
-  margin-bottom: 12px;
+  margin-bottom: 0.75rem;
 }
 .e2e-pw-field input {
   width: 100%;
-  padding: 10px 14px;
+  padding: 0.625rem 0.875rem;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 0.875rem;
   text-align: center;
   letter-spacing: 2px;
 }
@@ -9256,17 +9269,17 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 .e2e-pw-error {
   color: var(--danger, #f44);
-  font-size: 12px;
-  margin-bottom: 10px;
-  padding: 6px 10px;
+  font-size: 0.75rem;
+  margin-bottom: 0.625rem;
+  padding: 0.375rem 0.625rem;
   background: rgba(255, 68, 68, 0.08);
   border-radius: var(--radius-sm);
 }
 .e2e-pw-actions {
   display: flex;
-  gap: 8px;
+  gap: 0.5rem;
   justify-content: center;
-  margin-top: 8px;
+  margin-top: 0.5rem;
 }
 .e2e-pw-actions .btn-accent:disabled {
   opacity: 0.4;
@@ -9277,8 +9290,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .system-message.e2e-notice {
   color: var(--text-muted);
   font-style: italic;
-  font-size: 12px;
-  padding: 4px 16px;
+  font-size: 0.75rem;
+  padding: 0.25rem 1rem;
   opacity: 0.7;
   text-align: center;
 }
@@ -9290,29 +9303,29 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 .edit-textarea {
   width: 100%;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   background: var(--bg-input);
   border: 1px solid var(--accent);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-family: inherit;
   resize: none;
-  max-height: 120px;
+  max-height: 7.5rem;
   line-height: 1.4;
   outline: none;
 }
 
 .edit-actions {
   display: flex;
-  gap: 6px;
-  margin-top: 4px;
+  gap: 0.375rem;
+  margin-top: 0.25rem;
 }
 
 .edit-save-btn, .edit-cancel-btn {
-  padding: 3px 10px;
+  padding: 0.1875rem 0.625rem;
   border-radius: var(--radius-sm);
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 600;
   cursor: pointer;
   border: none;
@@ -9334,9 +9347,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .edit-cancel-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 .edit-emoji-btn {
-  padding: 3px 8px;
+  padding: 0.1875rem 0.5rem;
   border-radius: var(--radius-sm);
-  font-size: 14px;
+  font-size: 0.875rem;
   cursor: pointer;
   border: none;
   background: var(--bg-tertiary);
@@ -9353,8 +9366,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .spoiler {
   background: var(--text-muted);
   color: transparent;
-  border-radius: 3px;
-  padding: 0 4px;
+  border-radius: 0.1875rem;
+  padding: 0 0.25rem;
   cursor: pointer;
   transition: all 0.2s ease;
   user-select: none;
@@ -9371,7 +9384,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .spoiler-media {
   position: relative;
   display: inline-block;
-  margin-top: 4px;
+  margin-top: 0.25rem;
   border-radius: var(--radius);
   overflow: hidden;
   cursor: pointer;
@@ -9394,11 +9407,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   z-index: 2;
   background: rgba(0, 0, 0, 0.72);
   color: #fff;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.02em;
-  padding: 5px 12px;
-  border-radius: 999px;
+  padding: 0.3125rem 0.75rem;
+  border-radius: 62.4375rem;
   white-space: nowrap;
   pointer-events: none;
 }
@@ -9422,14 +9435,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .hidden-image {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  margin-top: 4px;
-  padding: 6px 12px;
+  gap: 0.375rem;
+  margin-top: 0.25rem;
+  padding: 0.375rem 0.75rem;
   border: 1px dashed var(--border);
   border-radius: var(--radius);
   background: var(--bg-tertiary);
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
   user-select: none;
   transition: border-color 0.15s ease, color 0.15s ease;
@@ -9444,13 +9457,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   bottom: 2px;
   left: 2px;
-  width: 18px;
-  height: 18px;
+  width: 1.125rem;
+  height: 1.125rem;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
   border: none;
   border-radius: 50%;
-  font-size: 11px;
+  font-size: 0.6875rem;
   line-height: 1;
   cursor: pointer;
   display: flex;
@@ -9492,8 +9505,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .inline-code {
   background: var(--bg-tertiary);
   color: var(--accent);
-  padding: 1px 5px;
-  border-radius: 3px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   font-family: var(--font-mono);
   font-size: 0.9em;
 }
@@ -9506,7 +9519,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .admin-settings {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 0.625rem;
 }
 
 /* Admin save bar — fixed at bottom of settings modal */
@@ -9514,7 +9527,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 12px 24px 16px;
+  padding: 0.75rem 1.5rem 1rem;
   background: var(--bg-card);
   border-top: 1px solid var(--border);
   z-index: 10;
@@ -9522,8 +9535,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 .btn-admin-save {
   width: 100%;
-  padding: 10px 20px;
-  font-size: 14px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
   font-weight: 700;
   border: none;
   border-radius: var(--radius-sm);
@@ -9551,14 +9564,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .notif-divider {
-  height: 1px;
+  height: 0.0625rem;
   background: var(--border);
-  margin: 4px 0;
+  margin: 0.25rem 0;
 }
 
 .user-admin-actions {
   display: none;
-  gap: 2px;
+  gap: 0.125rem;
   margin-left: auto;
   flex-shrink: 0;
 }
@@ -9568,12 +9581,12 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .user-action-btn {
-  width: 22px;
-  height: 22px;
+  width: 1.375rem;
+  height: 1.375rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
   background: none;
@@ -9590,12 +9603,12 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .user-gear-menu {
   position: fixed;
   z-index: 10002;
-  min-width: 160px;
+  min-width: 10rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: 0 6px 24px rgba(0,0,0,0.5);
-  padding: 4px;
+  padding: 0.25rem;
   display: flex;
   flex-direction: column;
   animation: gear-menu-in 0.12s ease-out;
@@ -9607,9 +9620,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .gear-menu-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
-  font-size: 13px;
+  gap: 0.5rem;
+  padding: 0.4375rem 0.625rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   background: none;
   border: none;
@@ -9626,7 +9639,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 .gear-menu-danger { color: var(--danger); }
 .gear-menu-danger:hover { background: rgba(233,69,96,0.12); color: var(--danger); }
-.gear-menu-divider { height: 1px; background: var(--border); margin: 4px 2px; }
+.gear-menu-divider { height: 0.0625rem; background: var(--border); margin: 0.25rem 0.125rem; }
 
 /* ── Context menu scroll fallback (#5286) ──
    Floating menus (right-click, gear, channel, image, etc.) get capped to the
@@ -9638,33 +9651,33 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .channel-ctx-menu,
 .image-context-menu,
 .channel-functions-panel {
-  max-height: calc(100vh - 16px);
+  max-height: calc(100vh - 1rem);
   overflow-y: auto;
   overscroll-behavior: contain;
 }
 
 /* ── Transfer Admin Modal ────────────────── */
 .transfer-admin-modal {
-  max-width: 420px;
+  max-width: 26.25rem;
   width: 90vw;
 }
 .transfer-admin-warning {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
-  padding: 14px;
+  gap: 0.75rem;
+  padding: 0.875rem;
   background: rgba(233,69,96,0.08);
   border: 1px solid rgba(233,69,96,0.2);
   border-radius: var(--radius);
-  margin-bottom: 16px;
+  margin-bottom: 1rem;
 }
 .transfer-admin-warning-icon {
-  font-size: 24px;
+  font-size: 1.5rem;
   flex-shrink: 0;
   line-height: 1;
 }
 .transfer-admin-warning-text {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -9672,32 +9685,32 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   color: var(--text-primary);
 }
 .transfer-admin-note {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--danger);
   font-weight: 600;
-  margin-bottom: 16px;
+  margin-bottom: 1rem;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 .transfer-admin-error {
   color: var(--danger);
-  font-size: 12px;
+  font-size: 0.75rem;
   display: none;
-  margin-top: 8px;
-  padding: 6px 10px;
+  margin-top: 0.5rem;
+  padding: 0.375rem 0.625rem;
   background: rgba(233,69,96,0.08);
   border-radius: var(--radius-sm);
 }
 
 .user-item.offline { opacity: 0.5; }
-.user-dot.away { background: var(--text-muted); border-radius: 2px 2px 50% 50%; }
+.user-dot.away { background: var(--text-muted); border-radius: 0.125rem 0.125rem 50% 50%; }
 
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
    BANS MODAL
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
-.modal-wide { max-width: 720px; width: 95vw; }
+.modal-wide { max-width: 45rem; width: 95vw; }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
    SETTINGS POPOUT MODAL
@@ -9706,8 +9719,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .settings-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 20px 24px 12px;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem 0.75rem;
   position: sticky;
   top: 0;
   background: var(--bg-card);
@@ -9717,13 +9730,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 .settings-tab-bar {
   display: flex;
-  gap: 4px;
+  gap: 0.25rem;
   margin-left: auto;
-  margin-right: 8px;
+  margin-right: 0.5rem;
 }
 .settings-tab {
-  padding: 5px 14px;
-  font-size: 12px;
+  padding: 0.3125rem 0.875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
@@ -9744,7 +9757,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .settings-close-btn { margin-left: 0; }
 
 .settings-header h3 {
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 700;
   color: var(--text-primary);
   font-family: var(--font-heading);
@@ -9752,12 +9765,12 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .settings-close-btn {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
+  font-size: 1.25rem;
   background: none;
   border: none;
   color: var(--text-muted);
@@ -9779,31 +9792,31 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .settings-nav {
-  width: 172px;
-  min-width: 172px;
-  padding: 8px 0 8px 8px;
+  width: 10.75rem;      /* 172px at Normal; scales so labels don't wrap when the font grows */
+  min-width: 10.75rem;
+  padding: 0.5rem 0 0.5rem 0.5rem;
   overflow-y: auto;
   border-right: 1px solid var(--border);
   flex-shrink: 0;
 }
 
 .settings-nav-group {
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--text-muted);
-  padding: 10px 10px 4px;
+  padding: 0.625rem 0.625rem 0.25rem;
   user-select: none;
 }
 
 .settings-nav-item {
-  padding: 5px 10px;
-  font-size: 12px;
+  padding: 0.3125rem 0.625rem;
+  font-size: 0.75rem;
   color: var(--text-secondary);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  margin-bottom: 1px;
+  margin-bottom: 0.0625rem;
   /* Wrap rather than truncate. The nav is a fixed width the user can't drag,
      so an ellipsis here is unrecoverable — there is no way to reveal the rest
      of the label. Two short lines beat "Activity & Conne…".
@@ -9812,7 +9825,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   white-space: normal;
   overflow-wrap: break-word;
   line-height: 1.3;
-  padding-left: 26px;
+  padding-left: 1.625rem;
   text-indent: -16px;
   transition: background 0.15s, color 0.15s;
 }
@@ -9825,17 +9838,17 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 /* Section headers in the settings nav. Not clickable — they exist so ~20 flat
    entries read as five short groups instead of one long list. */
 .settings-nav-group-label {
-  font-size: 9px;
+  font-size: 0.5625rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--text-muted);
-  padding: 10px 10px 3px;
-  margin-top: 2px;
+  padding: 0.625rem 0.625rem 0.1875rem;
+  margin-top: 0.125rem;
   user-select: none;
   pointer-events: none;
 }
-.settings-nav-group-label:first-child { margin-top: 0; padding-top: 2px; }
+.settings-nav-group-label:first-child { margin-top: 0; padding-top: 0.125rem; }
 
 .settings-nav-item.active {
   background: var(--accent);
@@ -9843,8 +9856,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .settings-nav-group.settings-nav-admin {
-  margin-top: 4px;
-  padding-top: 8px;
+  margin-top: 0.25rem;
+  padding-top: 0.5rem;
   border-top: 2px solid var(--accent);
   color: var(--accent);
 }
@@ -9861,11 +9874,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
      max-width is what actually caps it — it used to be 640px too, so dragging
      stopped dead at the default size. Raising only max-width keeps the
      familiar default while letting the handle go somewhere. */
-  width: min(640px, 92vw);
+  width: min(40rem, 92vw);       /* 640px at Normal; scales with the font setting */
   max-width: min(1200px, 95vw);
-  min-width: 420px;
+  min-width: 26.25rem;           /* 420px at Normal */
   max-height: 85vh;
-  min-height: 320px;
+  min-height: 20rem;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -9875,7 +9888,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 /* ── Activities / Games Launcher ──────────────────────── */
 .modal-activities {
-  max-width: 520px;
+  max-width: 32.5rem;
   max-height: 80vh;
   overflow-y: auto;
   padding: 0;
@@ -9884,7 +9897,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 24px 12px;
+  padding: 1.25rem 1.5rem 0.75rem;
   position: sticky;
   top: 0;
   background: var(--bg-card);
@@ -9892,7 +9905,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   border-bottom: 1px solid var(--border);
 }
 .activities-header h3 {
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 700;
   color: var(--text-primary);
   margin: 0;
@@ -9900,16 +9913,16 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .activities-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 12px;
-  padding: 16px 24px 24px;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem 1.5rem;
 }
 .activity-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 16px 10px;
-  border-radius: 8px;
+  gap: 0.5rem;
+  padding: 1rem 0.625rem;
+  border-radius: 0.5rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   cursor: pointer;
@@ -9923,16 +9936,16 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   box-shadow: 0 4px 12px rgba(0,0,0,0.15);
 }
 .activity-card-icon {
-  font-size: 36px;
+  font-size: 2.25rem;
   line-height: 1;
 }
 .activity-card-name {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 .activity-card-desc {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   line-height: 1.3;
 }
@@ -9946,12 +9959,12 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 10px 16px;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
 }
 .flash-install-banner .btn-sm { pointer-events: auto; flex-shrink: 0; }
@@ -9969,19 +9982,19 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 16px;
+  padding: 0.5rem 1rem;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 .game-iframe-title {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 700;
   color: var(--text-primary);
 }
 .game-iframe-actions {
   display: flex;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .game-iframe {
   flex: 1;
@@ -9992,15 +10005,15 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 /* Win95 overrides for activities */
 [data-theme="win95"] .modal-activities { background: #bfbfbf; border: 3px outset #fff; border-radius: 0; }
-[data-theme="win95"] .activities-header { background: linear-gradient(90deg, #000080, #1084d0); padding: 4px 8px; border-bottom: none; }
-[data-theme="win95"] .activities-header h3 { color: #fff; font-size: 12px; font-weight: 700; margin: 0; background: none; font-family: "MS Sans Serif","Microsoft Sans Serif",Tahoma,Arial,sans-serif; }
+[data-theme="win95"] .activities-header { background: linear-gradient(90deg, #000080, #1084d0); padding: 0.25rem 0.5rem; border-bottom: none; }
+[data-theme="win95"] .activities-header h3 { color: #fff; font-size: 0.75rem; font-weight: 700; margin: 0; background: none; font-family: "MS Sans Serif","Microsoft Sans Serif",Tahoma,Arial,sans-serif; }
 [data-theme="win95"] .activity-card { background: #bfbfbf; border: 3px outset #fff; border-radius: 0; }
 [data-theme="win95"] .activity-card:hover { border: 3px inset #808080; transform: none; box-shadow: none; }
 [data-theme="win95"] .game-iframe-header { background: linear-gradient(90deg, #000080, #1084d0); border-bottom: 2px solid #808080; }
-[data-theme="win95"] .game-iframe-title { color: #fff; font-family: "MS Sans Serif","Microsoft Sans Serif",Tahoma,Arial,sans-serif; font-size: 12px; }
+[data-theme="win95"] .game-iframe-title { color: #fff; font-family: "MS Sans Serif","Microsoft Sans Serif",Tahoma,Arial,sans-serif; font-size: 0.75rem; }
 
 .settings-section {
-  padding: 16px 24px;
+  padding: 1rem 1.5rem;
   border-bottom: 1px solid var(--border);
 }
 .settings-section:last-child { border-bottom: none; }
@@ -10009,16 +10022,16 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .admin-section-divider {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin: 8px 0 16px;
+  gap: 0.75rem;
+  margin: 0.5rem 0 1rem;
 }
 .admin-divider-line {
   flex: 1;
-  height: 2px;
+  height: 0.125rem;
   background: linear-gradient(90deg, transparent, var(--accent), transparent);
 }
 .admin-divider-label {
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1.5px;
@@ -10028,35 +10041,35 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .admin-save-notice {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   background: rgba(var(--accent-rgb, 124,58,237), 0.12);
   border: 1px solid rgba(var(--accent-rgb, 124,58,237), 0.3);
-  border-radius: 8px;
-  padding: 8px 14px;
-  margin-bottom: 16px;
-  font-size: 12px;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  margin-bottom: 1rem;
+  font-size: 0.75rem;
   color: var(--text-secondary);
   line-height: 1.4;
 }
 
 .settings-section-title {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1px;
   color: var(--text-secondary);
-  margin-bottom: 14px;
-  padding-bottom: 8px;
+  margin-bottom: 0.875rem;
+  padding-bottom: 0.5rem;
   border-bottom: 2px solid var(--border);
 }
 
 .settings-section-subtitle {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-secondary);
-  margin-bottom: 10px;
-  margin-top: 16px;
-  padding-bottom: 6px;
+  margin-bottom: 0.625rem;
+  margin-top: 1rem;
+  padding-bottom: 0.375rem;
   border-bottom: 1px solid var(--border);
 }
 
@@ -10064,60 +10077,60 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .plugin-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.375rem;
 }
 .plugin-card {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 12px;
+  padding: 0.625rem 0.75rem;
   background: var(--bg-tertiary, rgba(255,255,255,0.04));
   border: 1px solid var(--border, rgba(255,255,255,0.08));
-  border-radius: 8px;
+  border-radius: 0.5rem;
   transition: background 0.15s;
 }
 .plugin-card:hover { background: var(--bg-hover, rgba(255,255,255,0.06)); }
 .plugin-card-info { flex: 1; min-width: 0; }
 .plugin-card-name {
   font-weight: 600;
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .plugin-card-desc {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-secondary);
-  margin-top: 2px;
+  margin-top: 0.125rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .plugin-card-meta {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 .plugin-empty {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
-  padding: 8px 0;
+  padding: 0.5rem 0;
 }
 .plugin-empty code {
   background: var(--bg-tertiary);
-  padding: 1px 4px;
-  border-radius: 3px;
-  font-size: 11px;
+  padding: 0.0625rem 0.25rem;
+  border-radius: 0.1875rem;
+  font-size: 0.6875rem;
 }
 /* Toggle switch */
 .plugin-toggle {
   position: relative;
   display: inline-block;
-  width: 40px;
-  height: 22px;
+  width: 2.5rem;
+  height: 1.375rem;
   flex-shrink: 0;
-  margin-left: 12px;
+  margin-left: 0.75rem;
 }
 .plugin-toggle input { opacity: 0; width: 0; height: 0; }
 .plugin-toggle-slider {
@@ -10125,14 +10138,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   cursor: pointer;
   top: 0; left: 0; right: 0; bottom: 0;
   background: var(--bg-tertiary, #333);
-  border-radius: 11px;
+  border-radius: 0.6875rem;
   transition: background 0.2s;
 }
 .plugin-toggle-slider::before {
   content: '';
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: 1rem;
+  height: 1rem;
   left: 3px;
   bottom: 3px;
   background: #fff;
@@ -10147,18 +10160,18 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .settings-number-input {
-  width: 70px;
-  padding: 4px 6px;
+  width: 4.375rem;
+  padding: 0.25rem 0.375rem;
   background: var(--bg-input);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 .settings-hint {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: 0.625rem;
   display: block;
   /* Was -2px, which tucked the hint up into the row above. That was invisible
      next to a 16px checkbox but collides with a 20px switch. */
@@ -10177,56 +10190,56 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .settings-hint.error { color: #e94560; }
 .settings-hint.success { color: #43b581; }
 .settings-desc {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-secondary);
-  margin-bottom: 14px;
+  margin-bottom: 0.875rem;
   line-height: 1.45;
 }
 
 /* ── Desktop Shortcuts table ──────────────────────────── */
-.shortcut-table { display: flex; flex-direction: column; gap: 4px; margin-top: 10px; }
+.shortcut-table { display: flex; flex-direction: column; gap: 0.25rem; margin-top: 0.625rem; }
 .shortcut-row {
-  display: flex; align-items: center; gap: 10px;
-  padding: 6px 8px; border-radius: var(--radius-sm);
+  display: flex; align-items: center; gap: 0.625rem;
+  padding: 0.375rem 0.5rem; border-radius: var(--radius-sm);
   background: var(--bg-tertiary); border: 1px solid var(--border-color);
 }
 .shortcut-row.recording {
   border-color: var(--accent); background: rgba(107,79,219,.1);
 }
-.shortcut-label { flex: 1; font-size: 12px; color: var(--text-primary); }
+.shortcut-label { flex: 1; font-size: 0.75rem; color: var(--text-primary); }
 .shortcut-key {
-  min-width: 140px; font-size: 11px; font-family: var(--font-mono, monospace);
+  min-width: 8.75rem; font-size: 0.6875rem; font-family: var(--font-mono, monospace);
   background: var(--bg-secondary); border: 1px solid var(--border);
-  border-radius: 3px; padding: 2px 8px; color: var(--text-secondary);
+  border-radius: 0.1875rem; padding: 0.125rem 0.5rem; color: var(--text-secondary);
   text-align: center;
 }
 .shortcut-key.recording-label {
   color: var(--accent); border-color: var(--accent); animation: shortcut-pulse 1s ease infinite;
 }
 @keyframes shortcut-pulse { 0%,100%{opacity:1} 50%{opacity:.5} }
-.shortcut-btns { display: flex; gap: 4px; }
+.shortcut-btns { display: flex; gap: 0.25rem; }
 
 /* ── Desktop App preference rows ─── */
-.desktop-pref-row { margin-bottom: 12px; }
-.desktop-pref-row .toggle-row { justify-content: flex-start; gap: 10px; font-size: 13px; color: var(--text-primary); cursor: pointer; }
-.desktop-pref-row .settings-hint { margin: 2px 0 0 26px; font-size: 11px; }
+.desktop-pref-row { margin-bottom: 0.75rem; }
+.desktop-pref-row .toggle-row { justify-content: flex-start; gap: 0.625rem; font-size: 0.8125rem; color: var(--text-primary); cursor: pointer; }
+.desktop-pref-row .settings-hint { margin: 0.125rem 0 0 1.625rem; font-size: 0.6875rem; }
 
 .password-change-form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .password-change-form .form-group.compact {
   margin: 0;
 }
 .password-change-form input {
   width: 100%;
-  padding: 7px 10px;
+  padding: 0.4375rem 0.625rem;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   outline: none;
 }
 .password-change-form input:focus {
@@ -10237,21 +10250,21 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   flex-shrink: 0;
   border-top: 1px solid var(--border);
   border-bottom: none;
-  padding: 10px 16px;
+  padding: 0.625rem 1rem;
 }
 
 .btn-settings-popout {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   width: 100%;
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   cursor: pointer;
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 500;
   transition: all 0.15s ease;
 }
@@ -10274,17 +10287,17 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 10px;
+  padding: 0.5rem 0.625rem;
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
-  gap: 10px;
+  gap: 0.625rem;
 }
 .aml-member-row:hover { background: var(--bg-hover); }
 
 .aml-member-left {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 0.625rem;
   min-width: 0;
   flex: 1;
 }
@@ -10292,13 +10305,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .aml-avatar-wrap {
   position: relative;
   flex-shrink: 0;
-  width: 34px;
-  height: 34px;
+  width: 2.125rem;
+  height: 2.125rem;
 }
 
 .aml-avatar {
-  width: 34px;
-  height: 34px;
+  width: 2.125rem;
+  height: 2.125rem;
   object-fit: cover;
 }
 
@@ -10308,7 +10321,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   justify-content: center;
   background: var(--bg-secondary);
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
 }
 
@@ -10316,8 +10329,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   bottom: -1px;
   right: -1px;
-  width: 10px;
-  height: 10px;
+  width: 0.625rem;
+  height: 0.625rem;
   border-radius: 50%;
   border: 2px solid var(--bg-tertiary);
 }
@@ -10327,39 +10340,39 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .aml-member-info {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 0.1875rem;
   min-width: 0;
 }
 
 .aml-member-name {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 500;
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 0.3125rem;
   flex-wrap: wrap;
 }
 
 .aml-login-name {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   font-weight: 400;
 }
 
 .aml-admin-badge {
-  font-size: 10px;
-  padding: 1px 5px;
-  border-radius: 3px;
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   background: var(--danger);
   color: #fff;
   font-weight: 600;
 }
 
 .aml-banned-badge {
-  font-size: 10px;
-  padding: 1px 5px;
-  border-radius: 3px;
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   background: var(--text-muted);
   color: #fff;
   font-weight: 500;
@@ -10367,9 +10380,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .aml-new-badge {
-  font-size: 10px;
-  padding: 1px 5px;
-  border-radius: 3px;
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   background: var(--accent);
   color: #fff;
   font-weight: 500;
@@ -10378,52 +10391,52 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .aml-member-meta {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   flex-wrap: wrap;
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
 }
 
 .aml-role-badge {
-  font-size: 10px;
-  padding: 1px 6px;
-  border-radius: 9px;
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.5625rem;
   border: 1px solid;
   font-weight: 500;
 }
 
 .aml-member-joined {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
 }
 
 .aml-member-channels {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
   opacity: 0.7;
 }
 
 /* ── Channel Picker (Add/Remove user from channels) ── */
 .aml-ch-picker {
-  max-width: 420px;
+  max-width: 26.25rem;
   width: 100%;
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  padding: 16px;
-  gap: 10px;
+  padding: 1rem;
+  gap: 0.625rem;
 }
 .aml-ch-picker-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding-bottom: 8px;
+  gap: 0.75rem;
+  padding-bottom: 0.5rem;
   border-bottom: 1px solid var(--border-color, rgba(255,255,255,0.06));
 }
 .aml-ch-picker-title {
   margin: 0;
-  font-size: 15px;
+  font-size: 0.9375rem;
   font-weight: 600;
   flex: 1;
   min-width: 0;
@@ -10434,8 +10447,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .aml-ch-picker-selectall {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 12px;
+  gap: 0.375rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
   cursor: pointer;
   user-select: none;
@@ -10448,10 +10461,10 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .aml-ch-picker-subtitle {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .aml-ch-picker-count {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
@@ -10459,11 +10472,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .aml-ch-picker-search {
   flex: 1;
   min-width: 0;
-  padding: 6px 10px;
-  font-size: 12px;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
   background: var(--bg-input, rgba(0,0,0,0.25));
   border: 1px solid var(--border-color, rgba(255,255,255,0.08));
-  border-radius: var(--radius-sm, 6px);
+  border-radius: var(--radius-sm, 0.375rem);
   color: var(--text);
   outline: none;
 }
@@ -10473,19 +10486,19 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .aml-channel-list {
   overflow-y: auto;
   flex: 1;
-  min-height: 80px;
+  min-height: 5rem;
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  padding: 2px;
-  margin: 0 -2px;
+  gap: 0.0625rem;
+  padding: 0.125rem;
+  margin: 0 -0.125rem;
 }
 .aml-channel-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
-  border-radius: var(--radius-sm, 6px);
+  gap: 0.5rem;
+  padding: 0.4375rem 0.625rem;
+  border-radius: var(--radius-sm, 0.375rem);
   cursor: pointer;
   transition: background 0.12s ease;
 }
@@ -10499,11 +10512,11 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 .aml-ch-hash {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 500;
 }
 .aml-ch-name {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -10516,17 +10529,17 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   font-weight: 500;
 }
 .aml-ch-picker-actions {
-  margin-top: 4px;
+  margin-top: 0.25rem;
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 0.5rem;
 }
 
 /* ── Member List Action Buttons ── */
 .aml-actions {
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 0.1875rem;
   flex-shrink: 0;
   opacity: 0;
   transition: opacity 0.15s;
@@ -10534,8 +10547,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .aml-member-row:hover .aml-actions { opacity: 1; }
 
 .aml-action-btn {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -10543,7 +10556,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   background: transparent;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 14px;
+  font-size: 0.875rem;
   padding: 0;
   transition: background 0.12s;
 }
@@ -10559,20 +10572,20 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .bans-list {
-  max-height: 300px;
+  max-height: 18.75rem;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .ban-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  padding: 8px 10px;
+  gap: 0.625rem;
+  padding: 0.5rem 0.625rem;
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
 }
@@ -10580,18 +10593,18 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .ban-info {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
   min-width: 0;
   flex: 1;
 }
 
 .ban-info strong {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-primary);
 }
 
 .ban-reason {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -10599,7 +10612,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .ban-date {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
 }
 
@@ -10613,7 +10626,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 .ban-actions {
   display: flex;
-  gap: 4px;
+  gap: 0.25rem;
   flex-shrink: 0;
   align-items: center;
 }
@@ -10622,8 +10635,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   flex-shrink: 0;
   background: var(--danger) !important;
   color: white !important;
-  font-size: 12px;
-  padding: 4px 8px !important;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem !important;
 }
 
 .btn-delete-user:hover { opacity: 0.85; }
@@ -10646,13 +10659,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .ban-appeal-label {
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 600;
   color: var(--accent);
 }
 
 .ban-appeal-text {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-primary);
   white-space: pre-wrap;
   word-break: break-word;
@@ -10660,7 +10673,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 .btn-dismiss-appeal {
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: 0.75rem;
   padding: 4px 8px !important;
 }
 
@@ -10677,14 +10690,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .collapsible-section-toggle {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .collapse-toggle-arrow {
-  font-size: 10px;
+  font-size: 0.625rem;
   transition: transform 0.2s ease;
   color: var(--text-muted);
-  width: 12px;
+  width: 0.75rem;
   text-align: center;
   flex-shrink: 0;
 }
@@ -10696,7 +10709,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .collapsible-section-body {
   overflow: hidden;
   transition: max-height 0.25s ease, opacity 0.2s ease, margin 0.25s ease;
-  max-height: 300px;
+  max-height: 18.75rem;
   opacity: 1;
 }
 
@@ -10719,17 +10732,17 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .mobile-servers-toggle {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .mobile-servers-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 0;
+  gap: 0.375rem;
+  padding: 0.375rem 0;
   overflow: hidden;
   transition: max-height 0.25s ease, opacity 0.2s ease;
-  max-height: 60px;
+  max-height: 3.75rem;
 }
 
 .mobile-servers-row.collapsed {
@@ -10742,21 +10755,21 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .mobile-servers-scroll {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   overflow-x: auto;
   overflow-y: hidden;
   flex: 1;
   min-width: 0;
   scrollbar-width: none;
   -ms-overflow-style: none;
-  padding: 2px 0;
+  padding: 0.125rem 0;
 }
 
 .mobile-servers-scroll::-webkit-scrollbar { display: none; }
 
 .mobile-srv-bubble {
-  width: 38px;
-  height: 38px;
+  width: 2.375rem;
+  height: 2.375rem;
   border-radius: 50%;
   background: var(--bg-tertiary);
   display: flex;
@@ -10769,13 +10782,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   border: none;
   padding: 0;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
   text-decoration: none;
 }
 
 .mobile-srv-bubble:hover {
-  border-radius: 12px;
+  border-radius: 0.75rem;
   background: var(--accent);
 }
 
@@ -10790,8 +10803,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   position: absolute;
   bottom: -1px;
   right: -1px;
-  width: 10px;
-  height: 10px;
+  width: 0.625rem;
+  height: 0.625rem;
   border-radius: 50%;
   border: 2px solid var(--bg-secondary);
 }
@@ -10801,13 +10814,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .mobile-srv-bubble .msrv-status.unknown { background: var(--text-muted, #666); }
 
 .mobile-srv-add-btn {
-  width: 38px;
-  height: 38px;
+  width: 2.375rem;
+  height: 2.375rem;
   border-radius: 50%;
   background: var(--bg-tertiary);
   border: 2px dashed var(--border-light);
   color: var(--accent);
-  font-size: 20px;
+  font-size: 1.25rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -10823,9 +10836,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 
 .mobile-servers-empty {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
-  padding: 4px 0;
+  padding: 0.25rem 0;
   white-space: nowrap;
 }
 
@@ -10838,7 +10851,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .mobile-users-btn {
   display: none;  /* hidden on desktop */
   width: 40px;
-  height: 40px;
+  height: 2.5rem;
   background: transparent;
   color: var(--text-secondary);
   border: none;
@@ -10867,46 +10880,46 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .mobile-server-dropdown { display: none; position: relative; }
 .mobile-server-btn {
   background: transparent; border: none; color: var(--accent, #7c5cfc);
-  font-size: 20px; cursor: pointer; padding: 4px 6px; border-radius: 4px;
+  font-size: 1.25rem; cursor: pointer; padding: 0.25rem 0.375rem; border-radius: 0.25rem;
   line-height: 1; -webkit-tap-highlight-color: transparent;
 }
 .mobile-server-btn:hover { background: var(--bg-hover); }
 .mobile-server-menu {
   display: none; position: absolute; top: 100%; left: 0; z-index: 200;
   background: var(--bg-secondary, #1e1e2e); border: 1px solid var(--border, #444);
-  border-radius: 8px; padding: 6px; min-width: 200px; max-height: 60vh; overflow-y: auto;
+  border-radius: 0.5rem; padding: 0.375rem; min-width: 12.5rem; max-height: 60vh; overflow-y: auto;
   box-shadow: 0 8px 24px rgba(0,0,0,0.5);
 }
 .mobile-server-menu.open { display: block; }
 .mobile-server-menu-header {
-  font-size: 11px; font-weight: 600; color: var(--text-muted);
+  font-size: 0.6875rem; font-weight: 600; color: var(--text-muted);
   text-transform: uppercase; letter-spacing: 0.5px;
-  padding: 4px 8px 6px; border-bottom: 1px solid var(--border, #444); margin-bottom: 4px;
+  padding: 0.25rem 0.5rem 0.375rem; border-bottom: 1px solid var(--border, #444); margin-bottom: 0.25rem;
 }
 .mobile-server-item {
-  display: flex; align-items: center; gap: 8px; padding: 8px 10px;
-  border-radius: 6px; cursor: pointer; color: var(--text-primary, #eee); font-size: 13px;
+  display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.625rem;
+  border-radius: 0.375rem; cursor: pointer; color: var(--text-primary, #eee); font-size: 0.8125rem;
   text-decoration: none; transition: background 0.15s;
 }
 .mobile-server-item:hover { background: var(--bg-hover, rgba(255,255,255,0.06)); }
 .mobile-server-item .msrv-dot {
-  width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+  width: 0.5rem; height: 0.5rem; border-radius: 50%; flex-shrink: 0;
 }
 .mobile-server-item .msrv-dot.online { background: var(--success, #43b581); }
 .mobile-server-item .msrv-dot.offline { background: var(--danger, #f04747); }
 .mobile-server-item .msrv-dot.unknown { background: var(--text-dim, #666); }
 .mobile-server-item .msrv-icon {
-  width: 24px; height: 24px; border-radius: 50%; object-fit: cover; flex-shrink: 0;
+  width: 1.5rem; height: 1.5rem; border-radius: 50%; object-fit: cover; flex-shrink: 0;
 }
 .mobile-server-item .msrv-initial {
-  width: 24px; height: 24px; border-radius: 50%; background: var(--bg-tertiary, #2a2a3a);
+  width: 1.5rem; height: 1.5rem; border-radius: 50%; background: var(--bg-tertiary, #2a2a3a);
   display: flex; align-items: center; justify-content: center;
-  font-size: 11px; font-weight: 600; color: var(--text-muted); flex-shrink: 0;
+  font-size: 0.6875rem; font-weight: 600; color: var(--text-muted); flex-shrink: 0;
 }
 .mobile-server-add {
   display: block; width: 100%; background: none; border: none; cursor: pointer;
-  color: var(--accent, #7c5cfc); font-size: 13px; padding: 8px 10px;
-  text-align: left; border-radius: 6px; margin-top: 2px;
+  color: var(--accent, #7c5cfc); font-size: 0.8125rem; padding: 0.5rem 0.625rem;
+  text-align: left; border-radius: 0.375rem; margin-top: 0.125rem;
 }
 .mobile-server-add:hover { background: rgba(124,92,252,0.1); }
 
@@ -10930,13 +10943,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .mobile-panel-close {
   display: none;
   z-index: 110;
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   border: none;
   border-radius: 50%;
   background: rgba(255,255,255,0.1);
   color: var(--text-primary, #eee);
-  font-size: 20px;
+  font-size: 1.25rem;
   line-height: 1;
   cursor: pointer;
   align-items: center;
@@ -10973,8 +10986,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     right: 0;
     top: 0;
     bottom: 0;
-    width: 260px;
-    min-width: 260px;
+    width: 16.25rem;
+    min-width: 16.25rem;
     /* 100000 sits above .message-input-area (99995) and below .modal-overlay
        (100001). Was 1100, which left the dock hidden behind the composer on
        769-900px (#5384). Keep in sync with the mobile-overlay (99996) band. */
@@ -10983,7 +10996,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     transition: transform 0.25s ease;
     box-shadow: -4px 0 24px rgba(0, 0, 0, 0.4);
     padding-top: env(safe-area-inset-top, 0px);
-    padding-bottom: max(env(safe-area-inset-bottom, 0px), 16px);
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 1rem);
   }
   #app-body.mobile-right-open .right-sidebar { transform: translateX(0); }
   .sidebar-collapse-btn { display: none; }
@@ -11027,7 +11040,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
   /* Welcome screen centered properly */
   .welcome-screen { width: 100%; justify-content: center; align-items: center; }
-  .welcome-content { max-width: 90vw; padding: 0 16px; }
+  .welcome-content { max-width: 90vw; padding: 0 1rem; }
 
   /* Left sidebar — slide out as overlay (! overrides theme [data-theme] .sidebar { position: relative }) */
   .sidebar {
@@ -11035,8 +11048,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     left: 0;
     top: 0;
     bottom: 0;
-    width: 280px;
-    min-width: 280px;
+    width: 17.5rem;
+    min-width: 17.5rem;
     /* Above .message-input-area (99995), below .modal-overlay (100001). #5384. */
     z-index: 100000;
     transform: translateX(-100%);
@@ -11045,7 +11058,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     /* Safe area for notched phones + Android gesture bar */
     padding-top: constant(safe-area-inset-top); /* iOS 11.0-11.1 */
     padding-top: env(safe-area-inset-top, 0px);
-    padding-bottom: max(env(safe-area-inset-bottom, 0px), 28px);
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 1.75rem);
   }
 
   #app-body.mobile-sidebar-open .sidebar {
@@ -11066,8 +11079,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     right: 0;
     top: 0;
     bottom: 0;
-    width: 260px;
-    min-width: 260px;
+    width: 16.25rem;
+    min-width: 16.25rem;
     /* Above .message-input-area (99995), below .modal-overlay (100001). #5384. */
     z-index: 100000;
     transform: translateX(100%);
@@ -11075,7 +11088,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     box-shadow: -4px 0 24px rgba(0, 0, 0, 0.4);
     /* iOS status bar + Android nav bar safe areas */
     padding-top: env(safe-area-inset-top, 0px);
-    padding-bottom: max(env(safe-area-inset-bottom, 0px), 16px);
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 1rem);
   }
 
   #app-body.mobile-right-open .right-sidebar {
@@ -11085,14 +11098,14 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   /* Channel header adjustments — safe-area-inset-top prevents
      underlapping the iOS status bar / Dynamic Island */
   .channel-header {
-    padding: calc(8px + constant(safe-area-inset-top)) 12px 8px; /* iOS 11.0-11.1 */
+    padding: calc(0.5rem + constant(safe-area-inset-top)) 0.75rem 0.5rem; /* iOS 11.0-11.1 */
     padding: calc(8px + env(safe-area-inset-top, 0px)) 12px 8px;
-    min-height: calc(48px + env(safe-area-inset-top, 0px));
-    gap: 8px;
+    min-height: calc(3rem + env(safe-area-inset-top, 0px));
+    gap: 0.5rem;
   }
 
-  .channel-info h3 { font-size: 14px; }
-  .channel-code-tag { font-size: 10px; padding: 1px 6px; }
+  .channel-info h3 { font-size: 0.875rem; }
+  .channel-code-tag { font-size: 0.625rem; padding: 0.0625rem 0.375rem; }
 
   /* Hide header clutter — search/pin/delete tucked into long-press or sidebar */
   #delete-channel-btn,
@@ -11107,28 +11120,28 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   /* Toolbar touch overrides are in the (hover: none) query below */
 
   /* Messages area */
-  .messages { padding: 12px; }
-  .message-input-area { padding: 8px 12px calc(12px + env(safe-area-inset-bottom, 0px)); gap: 6px; }
+  .messages { padding: 0.75rem; }
+  .message-input-area { padding: 0.5rem 0.75rem calc(0.75rem + env(safe-area-inset-bottom, 0px)); gap: 0.375rem; }
   .message-content { word-break: break-word; overflow-wrap: break-word; }
   .message-header { flex-wrap: wrap; }
   .reply-banner { max-width: 100%; flex-wrap: wrap; }
   .reply-preview { white-space: normal; word-break: break-word; }
 
   /* GIF picker — constrained on tablet */
-  .gif-picker { max-width: 360px; }
+  .gif-picker { max-width: 22.5rem; }
 
   /* Screen share — constrained */
   .screen-share-container { max-height: 40vh; }
   /* Webcam — constrained */
-  .webcam-container { max-height: 160px; }
-  .webcam-tile { width: 120px; height: 90px; }
+  .webcam-container { max-height: 10rem; }
+  .webcam-tile { width: 7.5rem; height: 5.625rem; }
 
   /* Status bar — condense on small tablets but keep visible */
   .status-bar .status-item:nth-child(n+5) { display: none; }
 
   /* Server banner — smaller on mobile */
-  .server-banner-display { height: 120px; }
-  .server-banner-display::after { height: 50px; }
+  .server-banner-display { height: 7.5rem; }
+  .server-banner-display::after { height: 3.125rem; }
 }
 
 
@@ -11147,9 +11160,9 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
   /* Channel header — tight, prevent overflow, safe-area top */
   .channel-header {
-    padding: calc(6px + env(safe-area-inset-top, 0px)) 8px 6px;
-    min-height: calc(44px + env(safe-area-inset-top, 0px));
-    gap: 4px;
+    padding: calc(0.375rem + env(safe-area-inset-top, 0px)) 0.5rem 0.375rem;
+    min-height: calc(2.75rem + env(safe-area-inset-top, 0px));
+    gap: 0.25rem;
     overflow: hidden;
   }
 
@@ -11158,15 +11171,15 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     min-width: 0;
     overflow: hidden;
   }
-  .channel-info h3 { font-size: 13px; max-width: none; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .channel-info h3 { font-size: 0.8125rem; max-width: none; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .channel-code-tag { display: none !important; }
 
   /* Android beta banner — hide on phone, it eats header space */
   .android-beta-banner { display: none !important; }
 
   /* Update banner — compact on phone */
-  .update-banner { padding: 3px 8px; font-size: 11px; }
-  .update-pulse { width: 6px; height: 6px; }
+  .update-banner { padding: 0.1875rem 0.5rem; font-size: 0.6875rem; }
+  .update-pulse { width: 0.375rem; height: 0.375rem; }
 
   /* Desktop app banner — hide on mobile (they have Haven-Android) */
   .desktop-app-banner { display: none !important; }
@@ -11177,17 +11190,17 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   }
 
   /* Messages */
-  .messages { padding: 8px; }
-  .message-row { gap: 8px; padding: 4px; }
-  .message-avatar { width: 30px; height: 30px; font-size: 12px; }
-  .message-avatar-img { width: 30px; height: 30px; }
-  .user-item-avatar, .user-item-avatar-img { width: 20px; height: 20px; font-size: 9px; }
-  .user-avatar-wrapper { width: 20px; height: 20px; }
-  .user-status-dot { width: 8px; height: 8px; bottom: -2px; right: -2px; }
-  .message-author { font-size: 13px; }
-  .message-content { font-size: 14px; line-height: 1.45; word-break: break-word; overflow-wrap: break-word; }
-  .message-time { font-size: 10px; }
-  .message-compact { padding-left: 46px; }
+  .messages { padding: 0.5rem; }
+  .message-row { gap: 0.5rem; padding: 0.25rem; }
+  .message-avatar { width: 1.875rem; height: 1.875rem; font-size: 0.75rem; }
+  .message-avatar-img { width: 1.875rem; height: 1.875rem; }
+  .user-item-avatar, .user-item-avatar-img { width: 1.25rem; height: 1.25rem; font-size: 0.5625rem; }
+  .user-avatar-wrapper { width: 1.25rem; height: 1.25rem; }
+  .user-status-dot { width: 0.5rem; height: 0.5rem; bottom: -2px; right: -2px; }
+  .message-author { font-size: 0.8125rem; }
+  .message-content { font-size: 0.875rem; line-height: 1.45; word-break: break-word; overflow-wrap: break-word; }
+  .message-time { font-size: 0.625rem; }
+  .message-compact { padding-left: 2.875rem; }
   .message-header { flex-wrap: wrap; }
 
   /* Reply banners — allow wrapping on mobile */
@@ -11195,23 +11208,23 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   .reply-preview { white-space: normal; word-break: break-word; }
 
   /* Chat images — scale down for mobile, preserve aspect ratio */
-  .chat-image { display: block; max-width: min(80%, 280px); max-height: 300px; object-fit: contain; width: auto; height: auto; }
-  .image-mode-full .chat-image { max-width: 100%; max-height: 280px; }
-  .message-compact .chat-image { margin-top: 4px; }
+  .chat-image { display: block; max-width: min(80%, 17.5rem); max-height: 18.75rem; object-fit: contain; width: auto; height: auto; }
+  .image-mode-full .chat-image { max-width: 100%; max-height: 17.5rem; }
+  .message-compact .chat-image { margin-top: 0.25rem; }
 
   /* Input area — single-row inline layout */
   .message-input-area {
-    padding: 6px 8px calc(6px + env(safe-area-inset-bottom, 0px));
-    gap: 4px;
+    padding: 0.375rem 0.5rem calc(0.375rem + env(safe-area-inset-bottom, 0px));
+    gap: 0.25rem;
     flex-wrap: nowrap;
     align-items: flex-end;
   }
 
   /* Media buttons — compact inline, not a separate row */
   .input-actions-box {
-    border-radius: 16px;
-    padding: 2px 2px;
-    gap: 1px;
+    border-radius: 1rem;
+    padding: 0.125rem 0.125rem;
+    gap: 0.0625rem;
     flex-shrink: 0;
     order: 0;
     border: none;
@@ -11223,39 +11236,39 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   .input-actions-box .btn-emoji,
   .input-actions-box .btn-gif,
   .input-actions-box .btn-poll {
-    width: 28px;
-    height: 28px;
-    min-width: 28px;
-    min-height: 28px;
-    font-size: 14px;
+    width: 1.75rem;
+    height: 1.75rem;
+    min-width: 1.75rem;
+    min-height: 1.75rem;
+    font-size: 0.875rem;
     border-radius: 50%;
     flex-shrink: 0;
   }
   .input-actions-box .btn-gif {
     width: auto;
-    padding: 0 5px;
+    padding: 0 0.3125rem;
     border-radius: var(--radius-sm);
-    height: 22px;
-    min-height: 22px;
-    font-size: 11px;
+    height: 1.375rem;
+    min-height: 1.375rem;
+    font-size: 0.6875rem;
   }
 
   /* Textarea fills remaining space inline */
   .message-input-area textarea {
-    padding: 6px 10px;
-    font-size: 16px; /* prevents iOS zoom on focus */
+    padding: 0.375rem 0.625rem;
+    font-size: 1rem; /* prevents iOS zoom on focus */
     border-radius: 20px;
-    min-height: 34px;
+    min-height: 2.125rem;
     flex: 1 1 0;
     min-width: 0;
     order: 1;
   }
 
   .message-input-area .btn-send {
-    width: 34px;
-    height: 34px;
-    min-width: 34px;
-    min-height: 34px;
+    width: 2.125rem;
+    height: 2.125rem;
+    min-width: 2.125rem;
+    min-height: 2.125rem;
     border-radius: 50%;
     flex-shrink: 0;
     order: 2;
@@ -11286,8 +11299,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     margin-bottom: 0;
   }
 
-  .emoji-grid { max-height: min(200px, 30vh); }
-  .emoji-item { width: 40px; height: 40px; font-size: 22px; }
+  .emoji-grid { max-height: min(12.5rem, 30vh); }
+  .emoji-item { width: 2.5rem; height: 2.5rem; font-size: 1.375rem; }
 
   /* Mention dropdown — wider */
   .mention-dropdown {
@@ -11297,38 +11310,38 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
     min-width: 0;
   }
 
-  .mention-item { padding: 12px 14px; font-size: 14px; }
+  .mention-item { padding: 0.75rem 0.875rem; font-size: 0.875rem; }
 
   /* Reply bar */
-  .reply-bar { padding: 6px 8px; font-size: 12px; }
-  .reply-banner { padding: 4px 8px; font-size: 0.75em; max-width: 100%; flex-wrap: wrap; }
+  .reply-bar { padding: 0.375rem 0.5rem; font-size: 0.75rem; }
+  .reply-banner { padding: 0.25rem 0.5rem; font-size: 0.75em; max-width: 100%; flex-wrap: wrap; }
   .reply-preview { white-space: normal; word-break: break-word; }
 
   /* Reaction badges — touch-friendly */
-  .reaction-badge { padding: 4px 10px; font-size: 14px; }
-  .reaction-picker { gap: 4px; padding: 6px 8px; }
-  .reaction-pick-btn { width: 38px; height: 38px; font-size: 20px; }
-  .reaction-full-picker { width: calc(100vw - 32px); max-width: 320px; right: 0; }
+  .reaction-badge { padding: 0.25rem 0.625rem; font-size: 0.875rem; }
+  .reaction-picker { gap: 0.25rem; padding: 0.375rem 0.5rem; }
+  .reaction-pick-btn { width: 2.375rem; height: 2.375rem; font-size: 1.25rem; }
+  .reaction-full-picker { width: calc(100vw - 2rem); max-width: 20rem; right: 0; }
 
   /* Toolbar touch overrides are in the (hover: none) query below */
 
   /* Screen share — smaller on phone */
-  .screen-share-container { max-height: 35vh; min-height: 120px; }
+  .screen-share-container { max-height: 35vh; min-height: 7.5rem; }
   /* Webcam — smaller on phone */
-  .webcam-container { max-height: 130px; }
-  .webcam-tile { width: 100px; height: 75px; }
+  .webcam-container { max-height: 8.125rem; }
+  .webcam-tile { width: 6.25rem; height: 4.6875rem; }
 
   /* Status bar — condense on phones */
   .status-bar .status-item:nth-child(n+3) { display: none; }
 
   /* Welcome screen */
-  .welcome-icon { font-size: 48px; }
-  .welcome-content h2 { font-size: 18px; }
-  .welcome-content p { font-size: 13px; }
+  .welcome-icon { font-size: 3rem; }
+  .welcome-content h2 { font-size: 1.125rem; }
+  .welcome-content p { font-size: 0.8125rem; }
 
   /* Modal — wider on phone */
-  .modal { padding: 20px; width: 95%; max-height: 85vh; overflow-y: auto; }
-  .modal h3 { font-size: 18px; }
+  .modal { padding: 1.25rem; width: 95%; max-height: 85vh; overflow-y: auto; }
+  .modal h3 { font-size: 1.125rem; }
 
   /* Settings modal — scrollable on phone, hide nav */
   .modal-settings { max-height: 80vh; }
@@ -11340,15 +11353,15 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   .toast { max-width: none; }
 
   /* Typing indicator */
-  .typing-indicator { padding: 0 8px; font-size: 11px; }
+  .typing-indicator { padding: 0 0.5rem; font-size: 0.6875rem; }
 
   /* Search container */
   .search-container { flex: 1; }
-  .search-input { font-size: 14px; }
+  .search-input { font-size: 0.875rem; }
 
   /* Stream audio controls — always visible on touch */
   .stream-audio-controls { opacity: 1; }
-  .stream-vol-slider { width: 50px; }
+  .stream-vol-slider { width: 3.125rem; }
 }
 
 
@@ -11357,16 +11370,16 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 @media (max-width: 360px) {
-  .channel-info h3 { font-size: 12px; max-width: 90px; }
-  .message-avatar { width: 26px; height: 26px; font-size: 11px; }
-  .message-avatar-img { width: 26px; height: 26px; }
-  .user-item-avatar, .user-item-avatar-img { width: 18px; height: 18px; font-size: 8px; }
-  .user-avatar-wrapper { width: 18px; height: 18px; }
-  .user-status-dot { width: 7px; height: 7px; bottom: -2px; right: -2px; }
-  .message-compact { padding-left: 40px; }
-  .message-row { gap: 6px; }
-  .message-content { font-size: 13px; }
-  .chat-image { max-width: min(90%, 240px); }
+  .channel-info h3 { font-size: 0.75rem; max-width: 5.625rem; }
+  .message-avatar { width: 1.625rem; height: 1.625rem; font-size: 0.6875rem; }
+  .message-avatar-img { width: 1.625rem; height: 1.625rem; }
+  .user-item-avatar, .user-item-avatar-img { width: 1.125rem; height: 1.125rem; font-size: 0.5rem; }
+  .user-avatar-wrapper { width: 1.125rem; height: 1.125rem; }
+  .user-status-dot { width: 0.4375rem; height: 0.4375rem; bottom: -2px; right: -2px; }
+  .message-compact { padding-left: 2.5rem; }
+  .message-row { gap: 0.375rem; }
+  .message-content { font-size: 0.8125rem; }
+  .chat-image { max-width: min(90%, 15rem); }
 
   /* Hide non-critical status items */
   .status-bar .status-item:nth-child(n+3) { display: none; }
@@ -11387,7 +11400,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .ios-keyboard-open .message-input-area {
-  padding-bottom: 6px !important;
+  padding-bottom: 0.375rem !important;
 }
 
 /* When iOS keyboard is open, constrain emoji/gif pickers to the visible area */
@@ -11413,8 +11426,8 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   /* Header: use JS-measured safe-top when available, falling back to env() */
   body.is-ios .channel-header,
   body.is-android .channel-header {
-    padding-top: calc(8px + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
-    min-height: calc(48px + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
+    padding-top: calc(0.5rem + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
+    min-height: calc(3rem + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
   }
 
   /* Left sidebar overlay */
@@ -11432,13 +11445,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   /* Server bar */
   body.is-ios .server-bar,
   body.is-android .server-bar {
-    padding-top: calc(8px + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
+    padding-top: calc(0.5rem + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
   }
 
   /* Message input — bottom safe area */
   body.is-ios .message-input-area,
   body.is-android .message-input-area {
-    padding-bottom: calc(8px + var(--safe-bottom, env(safe-area-inset-bottom, 0px))) !important;
+    padding-bottom: calc(0.5rem + var(--safe-bottom, env(safe-area-inset-bottom, 0px))) !important;
   }
 
   /* Toasts */
@@ -11451,20 +11464,20 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 @media (max-width: 480px) {
   body.is-ios .channel-header,
   body.is-android .channel-header {
-    padding-top: calc(6px + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
-    min-height: calc(44px + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
+    padding-top: calc(0.375rem + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
+    min-height: calc(2.75rem + var(--safe-top, env(safe-area-inset-top, 0px))) !important;
   }
 
   body.is-ios .message-input-area,
   body.is-android .message-input-area {
-    padding-bottom: calc(6px + var(--safe-bottom, env(safe-area-inset-bottom, 0px))) !important;
+    padding-bottom: calc(0.375rem + var(--safe-bottom, env(safe-area-inset-bottom, 0px))) !important;
   }
 }
 
 /* Remove safe-top padding when iOS keyboard is open (bottom padding already
    handled by .ios-keyboard-open rule above) */
 body.is-ios.ios-keyboard-open .message-input-area {
-  padding-bottom: 6px !important;
+  padding-bottom: 0.375rem !important;
 }
 
 
@@ -11510,12 +11523,12 @@ body.is-ios.ios-keyboard-open .message-input-area {
   }
 
   /* Touch devices — larger tap targets */
-  .channel-item { padding: 12px 16px; min-height: 44px; }
-  .btn-sm { min-height: 44px; padding: 10px 14px; }
-  .icon-btn { min-width: 40px; min-height: 40px; font-size: 18px; }
-  .theme-btn { width: 36px; height: 36px; }
-  .toggle-row input[type="checkbox"] { width: 20px; height: 20px; }
-  .server-icon { width: 44px; height: 44px; }
+  .channel-item { padding: 0.75rem 1rem; min-height: 2.75rem; }
+  .btn-sm { min-height: 2.75rem; padding: 0.625rem 0.875rem; }
+  .icon-btn { min-width: 2.5rem; min-height: 2.5rem; font-size: 1.125rem; }
+  .theme-btn { width: 2.25rem; height: 2.25rem; }
+  .toggle-row input[type="checkbox"] { width: 1.25rem; height: 1.25rem; }
+  .server-icon { width: 2.75rem; height: 2.75rem; }
   /* Disable hover-only interactions on touch */
   .message:hover, .message-compact:hover { background: transparent; }
   .message-compact:hover .compact-time { display: none !important; }
@@ -11547,9 +11560,9 @@ body.is-ios.ios-keyboard-open .message-input-area {
   .msg-toolbar button {
     background: var(--bg-tertiary);
     border-radius: var(--radius);
-    min-width: 34px;
-    min-height: 34px;
-    font-size: 16px;
+    min-width: 2.125rem;
+    min-height: 2.125rem;
+    font-size: 1rem;
   }
 
   /* Compact timestamp — always hidden on touch (no real hover exists) */
@@ -11583,13 +11596,13 @@ body.is-ios.ios-keyboard-open .message-input-area {
 
 @media (max-height: 500px) and (orientation: landscape) {
   .status-bar .status-item:nth-child(n+3) { display: none; }
-  .channel-header { min-height: 40px; padding: 4px 8px; }
-  .messages { padding: 4px 8px; }
-  .message-input-area { padding: 4px 8px 6px; }
-  .welcome-icon { font-size: 36px; }
-  .welcome-content h2 { font-size: 16px; }
-  .server-banner-display { height: 80px; }
-  .server-banner-display::after { height: 30px; }
+  .channel-header { min-height: 2.5rem; padding: 0.25rem 0.5rem; }
+  .messages { padding: 0.25rem 0.5rem; }
+  .message-input-area { padding: 0.25rem 0.5rem 0.375rem; }
+  .welcome-icon { font-size: 2.25rem; }
+  .welcome-content h2 { font-size: 1rem; }
+  .server-banner-display { height: 5rem; }
+  .server-banner-display::after { height: 1.875rem; }
 }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -11597,27 +11610,27 @@ body.is-ios.ios-keyboard-open .message-input-area {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .user-group-label {
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.6px;
   color: var(--text-muted);
-  padding: 8px 6px 4px;
+  padding: 0.5rem 0.375rem 0.25rem;
   user-select: none;
 }
 
 .user-group-label.offline-label {
-  margin-top: 8px;
+  margin-top: 0.5rem;
   border-top: 1px solid var(--border);
-  padding-top: 10px;
+  padding-top: 0.625rem;
 }
 
 .user-score-badge {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--accent);
   background: var(--bg-tertiary);
-  padding: 1px 6px;
-  border-radius: 8px;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.5rem;
   margin-left: auto;
   flex-shrink: 0;
   font-weight: 600;
@@ -11629,8 +11642,8 @@ body.is-ios.ios-keyboard-open .message-input-area {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .eula-notice {
-  margin-top: 16px;
-  padding: 12px 14px;
+  margin-top: 1rem;
+  padding: 0.75rem 0.875rem;
   background: var(--bg-primary);
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
@@ -11639,19 +11652,19 @@ body.is-ios.ios-keyboard-open .message-input-area {
 .eula-check-row {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
-  font-size: 13px;
+  gap: 0.625rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   cursor: pointer;
 }
 
-.eula-check-row + .eula-check-row { margin-top: 10px; }
+.eula-check-row + .eula-check-row { margin-top: 0.625rem; }
 
 .eula-check-row input[type="checkbox"] {
-  margin-top: 2px;
+  margin-top: 0.125rem;
   accent-color: var(--accent);
-  width: 16px;
-  height: 16px;
+  width: 1rem;
+  height: 1rem;
   flex-shrink: 0;
 }
 
@@ -11665,7 +11678,7 @@ body.is-ios.ios-keyboard-open .message-input-area {
 }
 
 .eula-modal {
-  max-width: 700px;
+  max-width: 43.75rem;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
@@ -11674,24 +11687,24 @@ body.is-ios.ios-keyboard-open .message-input-area {
 .eula-content {
   overflow-y: auto;
   max-height: 55vh;
-  padding: 16px;
+  padding: 1rem;
   background: var(--bg-primary);
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
-  margin: 12px 0;
-  font-size: 13px;
+  margin: 0.75rem 0;
+  font-size: 0.8125rem;
   line-height: 1.7;
   color: var(--text-secondary);
 }
 
-.eula-content p { margin: 8px 0; }
-.eula-content ol { padding-left: 20px; }
-.eula-content ol li { margin: 10px 0; }
-.eula-content ul { padding-left: 20px; margin: 6px 0; }
-.eula-content ul li { margin: 4px 0; list-style: disc; }
+.eula-content p { margin: 0.5rem 0; }
+.eula-content ol { padding-left: 1.25rem; }
+.eula-content ol li { margin: 0.625rem 0; }
+.eula-content ul { padding-left: 1.25rem; margin: 0.375rem 0; }
+.eula-content ul li { margin: 0.25rem 0; list-style: disc; }
 .eula-content h4 {
-  margin: 18px 0 6px;
-  font-size: 14px;
+  margin: 1.125rem 0 0.375rem;
+  font-size: 0.875rem;
   font-weight: 700;
   color: var(--text-primary);
   letter-spacing: 0.3px;
@@ -11700,8 +11713,8 @@ body.is-ios.ios-keyboard-open .message-input-area {
 .eula-content em { color: var(--text-muted); }
 
 .eula-footer {
-  margin-top: 12px;
-  padding-top: 10px;
+  margin-top: 0.75rem;
+  padding-top: 0.625rem;
   border-top: 1px solid var(--border);
   text-align: center;
   color: var(--danger);
@@ -11712,13 +11725,13 @@ body.is-ios.ios-keyboard-open .message-input-area {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .btn-game {
-  margin-top: 20px;
-  padding: 10px 24px;
+  margin-top: 1.25rem;
+  padding: 0.625rem 1.5rem;
   background: var(--bg-hover);
   color: var(--text-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
   transition: all var(--transition);
@@ -11735,9 +11748,9 @@ body.is-ios.ios-keyboard-open .message-input-area {
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .tts-tag {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--accent);
-  margin-left: 6px;
+  margin-left: 0.375rem;
   opacity: 0.7;
 }
 
@@ -11750,15 +11763,15 @@ body.is-ios.ios-keyboard-open .message-input-area {
   background: color-mix(in srgb, var(--bg-primary) 90%, #000);
   border-bottom: 2px solid var(--accent);
   max-height: 25vh;
-  min-height: 100px;
+  min-height: 6.25rem;
   position: relative;
 }
 .webcam-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 4px 10px;
-  font-size: 12px;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--text-secondary);
   background: color-mix(in srgb, var(--bg-secondary) 60%, transparent);
@@ -11766,16 +11779,16 @@ body.is-ios.ios-keyboard-open .message-input-area {
 .webcam-header-controls {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
 }
 .webcam-header .icon-btn.small {
-  font-size: 11px;
-  padding: 2px 6px;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
   background: none;
   border: none;
   color: var(--text-secondary);
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: 0.25rem;
 }
 .webcam-header .icon-btn.small:hover {
   background: var(--bg-hover);
@@ -11785,21 +11798,21 @@ body.is-ios.ios-keyboard-open .message-input-area {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 4px;
-  padding: 4px;
+  gap: 0.25rem;
+  padding: 0.25rem;
   overflow-y: auto;
-  max-height: calc(25vh - 32px);
+  max-height: calc(25vh - 2rem);
 }
 .webcam-tile {
   position: relative;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   overflow: hidden;
   background: #111;
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   cursor: pointer;
   max-width: 25vw;
-  min-width: 120px;
+  min-width: 7.5rem;
   flex-shrink: 0;
 }
 .webcam-tile:hover {
@@ -11817,8 +11830,8 @@ body.is-ios.ios-keyboard-open .message-input-area {
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 3px 8px;
-  font-size: 10px;
+  padding: 0.1875rem 0.5rem;
+  font-size: 0.625rem;
   font-weight: 600;
   color: #fff;
   background: linear-gradient(transparent, rgba(0,0,0,0.7));
@@ -11834,9 +11847,9 @@ body.is-ios.ios-keyboard-open .message-input-area {
   background: rgba(0,0,0,0.6);
   color: #fff;
   border: none;
-  border-radius: 4px;
-  font-size: 13px;
-  padding: 2px 6px;
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+  padding: 0.125rem 0.375rem;
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.15s ease;
@@ -11855,8 +11868,8 @@ body.is-ios.ios-keyboard-open .message-input-area {
 
 /* Webcam layout modes (reuse screen-share layout classes) */
 .webcam-grid.layout-vertical    { flex-direction: column; align-items: center; }
-.webcam-grid.layout-side-by-side .webcam-tile { flex: 0 1 calc(50% - 4px); max-width: calc(50% - 4px); }
-.webcam-grid.layout-grid-2x2 .webcam-tile    { flex: 0 1 calc(50% - 4px); max-width: calc(50% - 4px); }
+.webcam-grid.layout-side-by-side .webcam-tile { flex: 0 1 calc(50% - 4px); max-width: calc(50% - 0.25rem); }
+.webcam-grid.layout-grid-2x2 .webcam-tile    { flex: 0 1 calc(50% - 4px); max-width: calc(50% - 0.25rem); }
 
 /* Webcam focus mode (double-click to expand) */
 .webcam-container.webcam-focus-mode {
@@ -11889,18 +11902,18 @@ body.is-ios.ios-keyboard-open .message-input-area {
 
 /* Webcam popped-out tile (mirrors screen-share) */
 .webcam-tile.webcam-popped-out {
-  height: 28px !important; min-height: 0;
+  height: 1.75rem !important; min-height: 0;
   overflow: hidden; opacity: 0.5;
 }
 .webcam-tile.webcam-popped-out video { display: none; }
 .webcam-tile.webcam-popped-out::after {
   content: '⧉ Popped out'; display: flex; align-items: center; justify-content: center;
-  height: 100%; font-size: 11px; color: var(--text-muted);
+  height: 100%; font-size: 0.6875rem; color: var(--text-muted);
 }
 
 /* Webcam PiP overlay */
 .webcam-pip-overlay {
-  width: 320px; min-height: 240px;
+  width: 20rem; min-height: 15rem;
 }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -11913,22 +11926,22 @@ body.is-ios.ios-keyboard-open .message-input-area {
   background: #000;
   border-bottom: 2px solid var(--accent);
   max-height: 50vh;
-  min-height: 180px;
+  min-height: 11.25rem;
   position: relative;
 }
 
 .screen-share-indicator {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 10px;
-  font-size: 11px;
-  border-radius: 12px;
+  gap: 0.25rem;
+  padding: 0.1875rem 0.625rem;
+  font-size: 0.6875rem;
+  border-radius: 0.75rem;
   background: var(--accent);
   color: #fff;
   border: none;
   cursor: pointer;
-  margin-left: 8px;
+  margin-left: 0.5rem;
   animation: pulse-glow 2s ease-in-out infinite;
   white-space: nowrap;
 }
@@ -11942,9 +11955,9 @@ body.is-ios.ios-keyboard-open .message-input-area {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 12px;
+  padding: 0.375rem 0.75rem;
   background: var(--bg-tertiary);
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--text-secondary);
 }
@@ -11956,45 +11969,45 @@ body.is-ios.ios-keyboard-open .message-input-area {
 .screen-share-header-controls {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 }
 
 .stream-size-slider {
-  width: 100px;
-  height: 18px;
+  width: 6.25rem;
+  height: 1.125rem;
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
-  border-radius: 2px;
+  border-radius: 0.125rem;
   cursor: pointer;
   vertical-align: middle;
   outline: none;
 }
 .stream-size-slider::-webkit-slider-runnable-track {
   background: rgba(255,255,255,0.3);
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   border: 1px solid rgba(255,255,255,0.2);
 }
 .stream-size-slider::-moz-range-track {
   background: rgba(255,255,255,0.3);
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   border: 1px solid rgba(255,255,255,0.2);
 }
 .stream-size-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
-  margin-top: -4px;
+  margin-top: -0.25rem;
   box-shadow: 0 0 6px var(--accent-glow, rgba(124,92,252,0.4));
 }
 .stream-size-slider::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   border-radius: 50%;
   background: var(--accent);
   cursor: pointer;
@@ -12003,8 +12016,8 @@ body.is-ios.ios-keyboard-open .message-input-area {
 .stream-size-label {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 11px;
+  gap: 0.375rem;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   user-select: none;
   white-space: nowrap;
@@ -12012,8 +12025,8 @@ body.is-ios.ios-keyboard-open .message-input-area {
 .screen-share-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2px;
-  max-height: calc(50vh - 32px);
+  gap: 0.125rem;
+  max-height: calc(50vh - 2rem);
   overflow-y: auto;
   background: #000;
 }
@@ -12026,19 +12039,19 @@ body.is-ios.ios-keyboard-open .message-input-area {
 .stream-layout-picker { position: relative; }
 .stream-layout-btn {
   background: none; border: none; color: var(--text-muted, #aaa); cursor: pointer;
-  font-size: 16px; padding: 2px 6px; border-radius: 4px; line-height: 1;
+  font-size: 1rem; padding: 0.125rem 0.375rem; border-radius: 0.25rem; line-height: 1;
 }
 .stream-layout-btn:hover { background: rgba(255,255,255,0.1); color: #fff; }
 .stream-layout-menu {
   display: none; position: absolute; top: 100%; right: 0; z-index: 50;
   background: var(--bg-tertiary, #2a2a3a); border: 1px solid var(--border, #444);
-  border-radius: 6px; padding: 4px; min-width: 110px;
+  border-radius: 0.375rem; padding: 0.25rem; min-width: 6.875rem;
   box-shadow: 0 4px 16px rgba(0,0,0,0.4);
 }
-.stream-layout-menu.open { display: flex; flex-direction: column; gap: 2px; }
+.stream-layout-menu.open { display: flex; flex-direction: column; gap: 0.125rem; }
 .stream-layout-opt {
   background: none; border: none; color: var(--text-secondary, #bbb); cursor: pointer;
-  padding: 5px 10px; border-radius: 4px; text-align: left; font-size: 12px; white-space: nowrap;
+  padding: 0.3125rem 0.625rem; border-radius: 0.25rem; text-align: left; font-size: 0.75rem; white-space: nowrap;
 }
 .stream-layout-opt:hover { background: rgba(255,255,255,0.08); color: #fff; }
 .stream-layout-opt.active { background: var(--accent, #7c5cfc); color: #fff; }
@@ -12092,9 +12105,9 @@ video:-webkit-full-screen {
   left: 6px;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 4px;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
   pointer-events: none;
 }
 
@@ -12106,10 +12119,10 @@ video:-webkit-full-screen {
   right: 6px;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   background: rgba(0, 0, 0, 0.75);
-  padding: 3px 8px;
-  border-radius: 6px;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 0.375rem;
   opacity: 0;
   transition: opacity 0.2s;
   z-index: 2;
@@ -12121,9 +12134,9 @@ video:-webkit-full-screen {
   border: none;
   color: #fff;
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 4px;
-  border-radius: 4px;
+  font-size: 0.875rem;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
   line-height: 1;
 }
 .stream-mute-btn:hover { background: rgba(255,255,255,0.15); }
@@ -12131,39 +12144,39 @@ video:-webkit-full-screen {
 
 .stream-vol-slider {
   --track-bg: rgba(255,255,255,0.2);
-  width: 60px;
-  height: 14px;
+  width: 3.75rem;
+  height: 0.875rem;
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
-  border-radius: 2px;
+  border-radius: 0.125rem;
   cursor: pointer;
   outline: none;
   vertical-align: middle;
 }
 .stream-vol-slider::-webkit-slider-runnable-track {
   background: rgba(255,255,255,0.3);
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   border: 1px solid rgba(255,255,255,0.15);
 }
 .stream-vol-slider::-moz-range-track {
   background: rgba(255,255,255,0.3);
-  height: 6px;
-  border-radius: 3px;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
   border: 1px solid rgba(255,255,255,0.15);
 }
 .stream-vol-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 14px; height: 14px;
+  width: 0.875rem; height: 0.875rem;
   border-radius: 50%;
   background: var(--accent, #7c5cfc);
   cursor: pointer;
-  margin-top: -5px;
+  margin-top: -0.3125rem;
   box-shadow: 0 0 4px rgba(124,92,252,0.4);
 }
 .stream-vol-slider::-moz-range-thumb {
-  width: 14px; height: 14px;
+  width: 0.875rem; height: 0.875rem;
   border-radius: 50%;
   background: var(--accent, #7c5cfc);
   cursor: pointer;
@@ -12171,8 +12184,8 @@ video:-webkit-full-screen {
 }
 .stream-vol-pct {
   color: rgba(255,255,255,0.7);
-  font-size: 10px;
-  min-width: 28px;
+  font-size: 0.625rem;
+  min-width: 1.75rem;
   text-align: center;
   user-select: none;
 }
@@ -12183,13 +12196,13 @@ video:-webkit-full-screen {
   right: 6px;
   background: rgba(0,0,0,0.65);
   color: var(--accent, #7c5cfc);
-  font-size: 10px;
-  padding: 2px 6px;
-  border-radius: 4px;
+  font-size: 0.625rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
   pointer-events: none;
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 0.1875rem;
 }
 
 .stream-no-audio-badge {
@@ -12198,13 +12211,13 @@ video:-webkit-full-screen {
   right: 6px;
   background: rgba(0,0,0,0.75);
   color: var(--text-muted, #888);
-  font-size: 10px;
-  padding: 2px 8px;
-  border-radius: 4px;
+  font-size: 0.625rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
   pointer-events: none;
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 0.1875rem;
   opacity: 0.85;
 }
 
@@ -12224,18 +12237,18 @@ video:-webkit-full-screen {
   right: 6px;
   background: rgba(0,0,0,0.7);
   color: #fff;
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 10px;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.625rem;
   pointer-events: none;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   z-index: 5;
   backdrop-filter: blur(4px);
 }
 .stream-viewer-badge .viewer-eye {
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 /* ── Stream Focus Mode (double-click to expand) ──────── */
@@ -12282,9 +12295,9 @@ video:-webkit-full-screen {
   color: #fff;
   border: none;
   cursor: pointer;
-  font-size: 16px;
-  padding: 2px 6px;
-  border-radius: 4px;
+  font-size: 1rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
   opacity: 0;
   transition: opacity 0.2s;
   z-index: 3;
@@ -12303,9 +12316,9 @@ video:-webkit-full-screen {
   color: #fff;
   border: none;
   cursor: pointer;
-  font-size: 16px;
-  padding: 2px 6px;
-  border-radius: 4px;
+  font-size: 1rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
   opacity: 0;
   transition: opacity 0.2s;
   z-index: 3;
@@ -12324,9 +12337,9 @@ video:-webkit-full-screen {
   color: #fff;
   border: none;
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 6px;
-  border-radius: 4px;
+  font-size: 0.875rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
   opacity: 0;
   transition: opacity 0.2s;
   z-index: 3;
@@ -12345,9 +12358,9 @@ video:-webkit-full-screen {
   color: #fff;
   border: none;
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 6px;
-  border-radius: 4px;
+  font-size: 0.875rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
   opacity: 0;
   transition: opacity 0.2s;
   z-index: 3;
@@ -12358,7 +12371,7 @@ video:-webkit-full-screen {
 
 /* Collapse tile when popped out — free up Haven space */
 .screen-share-tile.stream-popped-out {
-  height: 28px !important;
+  height: 1.75rem !important;
   min-height: 0 !important;
   overflow: hidden;
   flex: none !important;
@@ -12372,9 +12385,9 @@ video:-webkit-full-screen {
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 28px;
+  height: 1.75rem;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 500;
   background: var(--bg-tertiary);
 }
@@ -12391,14 +12404,14 @@ video:-webkit-full-screen {
 
 /* ── Stream PiP Overlay ─────────────────────────────────── */
 .stream-pip-overlay {
-  width: 480px;
-  min-height: 320px;
+  width: 30rem;
+  min-height: 20rem;
 }
 .stream-pip-overlay .stream-pip-video {
   flex: 1;
   overflow: hidden;
   background: #000;
-  min-height: 240px;
+  min-height: 15rem;
 }
 .stream-pip-overlay video {
   width: 100%;
@@ -12424,7 +12437,7 @@ video:-webkit-full-screen {
 
 @media (max-width: 768px) {
   .stream-pip-overlay {
-    width: 280px;
+    width: 17.5rem;
     bottom: 12px;
     right: 12px;
   }
@@ -12435,39 +12448,39 @@ video:-webkit-full-screen {
   position: fixed;
   bottom: 24px;
   right: 24px;
-  width: 400px;
+  width: 25rem;
   z-index: 10000;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 0.75rem;
   box-shadow: 0 8px 32px rgba(0,0,0,0.45);
   overflow: hidden;
   display: flex;
   flex-direction: column;
   resize: both;
-  min-width: 260px;
-  min-height: 220px;
+  min-width: 16.25rem;
+  min-height: 13.75rem;
 }
 .sb-pip-body {
   flex: 1;
   overflow: hidden;
-  padding: 8px 10px;
+  padding: 0.5rem 0.625rem;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
   min-height: 0;
 }
 .sb-pip-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
-  gap: 6px;
+  gap: 0.375rem;
   overflow-y: auto;
   flex: 1;
-  min-height: 80px;
+  min-height: 5rem;
 }
 @media (max-width: 768px) {
   .sb-pip-overlay {
-    width: 280px;
+    width: 17.5rem;
     bottom: 12px;
     right: 12px;
   }
@@ -12475,9 +12488,9 @@ video:-webkit-full-screen {
 
 /* ── Soundboard Sidebar (twin panel, sits directly LEFT of voice/users sidebar) ── */
 .sb-sidebar-panel {
-  width: 220px;
-  min-width: 220px;
-  max-width: 420px;
+  width: 13.75rem;
+  min-width: 13.75rem;
+  max-width: 26.25rem;
   background: var(--bg-secondary);
   border-left: 1px solid var(--border);
   display: flex;
@@ -12501,7 +12514,7 @@ video:-webkit-full-screen {
   position: absolute;
   top: 0;
   left: -3px;
-  width: 6px;
+  width: 0.375rem;
   height: 100%;
   cursor: col-resize;
   z-index: 10;
@@ -12514,9 +12527,9 @@ video:-webkit-full-screen {
   opacity: 0.5;
 }
 .sb-sidebar-header {
-  padding: 10px 12px;
+  padding: 0.625rem 0.75rem;
   border-bottom: 1px solid var(--border);
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.8px;
@@ -12530,8 +12543,8 @@ video:-webkit-full-screen {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 8px;
+  gap: 0.5rem;
+  padding: 0.5rem;
   min-height: 0;
 }
 .sb-sidebar-body .soundboard-grid.sidebar-mode {
@@ -12540,7 +12553,7 @@ video:-webkit-full-screen {
   overflow-y: auto;
 }
 /* Collapsible category groups inside the soundboard sidebar */
-.sb-sidebar-group { margin-bottom: 6px; }
+.sb-sidebar-group { margin-bottom: 0.375rem; }
 .sb-sidebar-group-label {
   cursor: pointer;
   user-select: none;
@@ -12548,16 +12561,16 @@ video:-webkit-full-screen {
   text-transform: uppercase;
   letter-spacing: .06em;
   color: var(--text-muted);
-  padding: 4px 2px;
+  padding: 0.25rem 0.125rem;
   list-style: none;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
 }
 .sb-sidebar-group-label::-webkit-details-marker { display: none; }
 .sb-sidebar-group-label::before {
   content: '\25BE'; /* small down triangle */
-  font-size: 9px;
+  font-size: 0.5625rem;
   transition: transform 0.15s;
   display: inline-block;
 }
@@ -12573,8 +12586,8 @@ video:-webkit-full-screen {
 .sb-sidebar-group-body {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding-top: 2px;
+  gap: 0.25rem;
+  padding-top: 0.125rem;
 }
 /* Soundboard sidebar toggle button — fixed; sits at the LEFT edge of the
    soundboard panel (which is directly LEFT of the voice/users panel).
@@ -12584,16 +12597,16 @@ video:-webkit-full-screen {
   right: 0;           /* JS recalculates on mount + resize/collapse events */
   top: 114px;         /* staggered below the voice/users collapse btn at 72px */
   transform: none;
-  width: 20px;
-  height: 36px;
+  width: 1.25rem;
+  height: 2.25rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 0.6875rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-right: none;
-  border-radius: 6px 0 0 6px;
+  border-radius: 0.375rem 0 0 0.375rem;
   color: var(--text-muted);
   cursor: pointer;
   padding: 0;
@@ -12616,8 +12629,8 @@ video:-webkit-full-screen {
 
 .whitelist-add-row {
   display: flex;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: 0.375rem;
+  margin-bottom: 0.5rem;
 }
 
 .whitelist-add-row input {
@@ -12626,12 +12639,12 @@ video:-webkit-full-screen {
 }
 
 .settings-text-input {
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 
 .settings-text-input:focus {
@@ -12640,21 +12653,21 @@ video:-webkit-full-screen {
 }
 
 .whitelist-list {
-  max-height: 200px;
+  max-height: 12.5rem;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .whitelist-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   background: var(--bg-primary);
   border-radius: var(--radius-sm);
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 
 .whitelist-username {
@@ -12663,8 +12676,8 @@ video:-webkit-full-screen {
 }
 
 .btn-danger-sm {
-  padding: 2px 8px !important;
-  font-size: 11px;
+  padding: 0.125rem 0.5rem !important;
+  font-size: 0.6875rem;
   background: var(--danger) !important;
   color: #fff !important;
   border-radius: var(--radius-sm);
@@ -12686,8 +12699,8 @@ video:-webkit-full-screen {
 }
 
 .pinned-tag {
-  font-size: 11px;
-  margin-left: 4px;
+  font-size: 0.6875rem;
+  margin-left: 0.25rem;
   opacity: 0.7;
   cursor: default;
 }
@@ -12703,18 +12716,18 @@ video:-webkit-full-screen {
 }
 
 .archived-tag {
-  font-size: 11px;
-  margin-left: 4px;
+  font-size: 0.6875rem;
+  margin-left: 0.25rem;
   opacity: 0.7;
   cursor: default;
 }
 
 .ephemeral-tag {
   display: inline-block;
-  margin-right: 6px;
-  padding: 1px 6px;
-  border-radius: 999px;
-  font-size: 10px;
+  margin-right: 0.375rem;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 62.4375rem;
+  font-size: 0.625rem;
   font-weight: 600;
   color: #6b4f00;
   background: rgba(212, 160, 23, 0.2);
@@ -12740,7 +12753,7 @@ video:-webkit-full-screen {
 .pinned-panel {
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
-  max-height: 300px;
+  max-height: 18.75rem;
   overflow-y: auto;
 }
 
@@ -12748,8 +12761,8 @@ video:-webkit-full-screen {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
-  font-size: 13px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-secondary);
   border-bottom: 1px solid var(--border-color);
@@ -12758,10 +12771,10 @@ video:-webkit-full-screen {
   background: var(--bg-secondary);
 }
 
-.pinned-list { padding: 4px 0; }
+.pinned-list { padding: 0.25rem 0; }
 
 .pinned-item {
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   cursor: pointer;
   border-bottom: 1px solid rgba(255,255,255,0.03);
   transition: background var(--transition);
@@ -12772,23 +12785,23 @@ video:-webkit-full-screen {
 .pinned-item-header {
   display: flex;
   align-items: baseline;
-  gap: 8px;
-  margin-bottom: 2px;
+  gap: 0.5rem;
+  margin-bottom: 0.125rem;
 }
 
-.pinned-item-author { font-weight: 600; font-size: 13px; }
-.pinned-item-time { font-size: 11px; color: var(--text-muted); }
+.pinned-item-author { font-weight: 600; font-size: 0.8125rem; }
+.pinned-item-time { font-size: 0.6875rem; color: var(--text-muted); }
 
 .pinned-item-content {
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-primary);
   line-height: 1.4;
 }
 
 .pinned-item-footer {
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
-  margin-top: 4px;
+  margin-top: 0.25rem;
 }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -12799,16 +12812,16 @@ video:-webkit-full-screen {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  margin: 6px 0;
+  margin: 0.375rem 0;
   position: relative;
   overflow: hidden;
 }
 
 .code-block pre {
   margin: 0;
-  padding: 10px 12px;
+  padding: 0.625rem 0.75rem;
   overflow-x: auto;
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.5;
 }
 
@@ -12823,7 +12836,7 @@ video:-webkit-full-screen {
   position: absolute;
   top: 4px;
   right: 8px;
-  font-size: 10px;
+  font-size: 0.625rem;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -12832,41 +12845,41 @@ video:-webkit-full-screen {
 .inline-code {
   font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
   background: var(--bg-tertiary);
-  padding: 1px 5px;
-  border-radius: 3px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   font-size: 0.9em;
   color: var(--accent);
 }
 
 .chat-blockquote {
   border-left: 3px solid var(--text-muted);
-  padding: 4px 10px;
-  margin: 1px 0;
+  padding: 0.25rem 0.625rem;
+  margin: 0.0625rem 0;
   color: var(--text-secondary);
   font-style: italic;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   max-width: fit-content;
 }
 
 /* ── Markdown tables ────────────────────────────────── */
 .chat-table-wrap {
-  margin: 4px 0;
+  margin: 0.25rem 0;
   overflow-x: auto;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   border: 1px solid var(--border-color, rgba(255,255,255,0.08));
   max-width: 100%;
 }
 .chat-table {
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: 0.8125rem;
   width: auto;
-  min-width: 200px;
+  min-width: 12.5rem;
   background: var(--bg-tertiary, rgba(0,0,0,0.15));
 }
 .chat-table th,
 .chat-table td {
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   text-align: left;
   border-bottom: 1px solid var(--border-color, rgba(255,255,255,0.06));
   border-right: 1px solid var(--border-color, rgba(255,255,255,0.04));
@@ -12887,7 +12900,7 @@ video:-webkit-full-screen {
   font-style: normal;
   font-weight: 600;
   color: var(--text-muted);
-  margin-bottom: 1px;
+  margin-bottom: 0.0625rem;
 }
 .chat-blockquote-body {
   line-height: 1.35;
@@ -12897,14 +12910,14 @@ video:-webkit-full-screen {
 .chat-highlight {
   background: rgba(250, 200, 50, 0.25);
   color: inherit;
-  padding: 1px 4px;
-  border-radius: 3px;
+  padding: 0.0625rem 0.25rem;
+  border-radius: 0.1875rem;
 }
 
 /* ── Chat Markdown: Headings ───────────────────────────── */
 .chat-heading {
   font-weight: 700;
-  margin: 4px 0 2px;
+  margin: 0.25rem 0 0.125rem;
   line-height: 1.3;
   color: var(--text-primary);
 }
@@ -12916,16 +12929,16 @@ video:-webkit-full-screen {
 .chat-hr {
   border: none;
   border-top: 1px solid var(--border-color);
-  margin: 6px 0;
+  margin: 0.375rem 0;
 }
 
 /* ── Chat Markdown: Lists ──────────────────────────────── */
 .chat-list {
-  margin: 4px 0;
-  padding-left: 22px;
+  margin: 0.25rem 0;
+  padding-left: 1.375rem;
 }
 .chat-list li {
-  margin: 1px 0;
+  margin: 0.0625rem 0;
   line-height: 1.45;
 }
 ol.chat-list { list-style-type: decimal; }
@@ -12937,16 +12950,16 @@ ul.chat-list { list-style-type: disc; }
 
 .link-preview {
   display: flex;
-  gap: 10px;
-  margin-top: 6px;
-  padding: 10px;
+  gap: 0.625rem;
+  margin-top: 0.375rem;
+  padding: 0.625rem;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
   border-left: 3px solid var(--accent);
   border-radius: var(--radius-sm);
   text-decoration: none;
   color: inherit;
-  max-width: 480px;
+  max-width: 30rem;
   overflow: hidden;
   transition: background var(--transition);
 }
@@ -12956,30 +12969,30 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .link-preview-image {
-  width: 80px;
-  height: 80px;
+  width: 5rem;
+  height: 5rem;
   object-fit: cover;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   flex-shrink: 0;
 }
 
 .link-preview-text {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
   min-width: 0;
   overflow: hidden;
 }
 
 .link-preview-site {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }
 
 .link-preview-title {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-link);
   white-space: nowrap;
@@ -12988,7 +13001,7 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .link-preview-desc {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-secondary);
   line-height: 1.4;
   display: -webkit-box;
@@ -13000,15 +13013,15 @@ ul.chat-list { list-style-type: disc; }
 /* ── Multi-image gallery embed (2×2 grid, Discord-style) ─ */
 .link-preview--gallery {
   flex-direction: column;
-  max-width: 400px;
-  gap: 6px;
+  max-width: 25rem;
+  gap: 0.375rem;
 }
 
 .link-preview-gallery {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 2px;
-  border-radius: 4px;
+  gap: 0.125rem;
+  border-radius: 0.25rem;
   overflow: hidden;
   width: 100%;
 }
@@ -13028,8 +13041,8 @@ ul.chat-list { list-style-type: disc; }
 
 /* ── Inline YouTube embed in chat messages ────────────── */
 .link-preview-yt {
-  margin-top: 6px;
-  max-width: 480px;
+  margin-top: 0.375rem;
+  max-width: 30rem;
   border-radius: var(--radius-sm);
   overflow: hidden;
   border: 1px solid var(--border-color);
@@ -13047,21 +13060,21 @@ ul.chat-list { list-style-type: disc; }
 /* ── Rich embed card (Bluesky / X / generic) — mobile-parity layout ───── */
 .link-preview--rich {
   flex-direction: column;
-  gap: 6px;
+  gap: 0.375rem;
   align-items: stretch;
-  max-width: 480px;
-  padding: 8px 10px;
+  max-width: 30rem;
+  padding: 0.5rem 0.625rem;
   border-left-color: var(--lp-accent, var(--accent));
 }
 .lp-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .lp-site {
   flex: 1 1 auto;
   min-width: 0;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.3px;
@@ -13077,11 +13090,11 @@ ul.chat-list { list-style-type: disc; }
   border: 0;
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   line-height: 1;
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
 }
 .lp-size:hover,
 .lp-collapse:hover {
@@ -13091,14 +13104,14 @@ ul.chat-list { list-style-type: disc; }
 .lp-content {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.375rem;
   min-width: 0;
 }
 .link-preview.lp-collapsed .lp-content { display: none; }
 .lp-meta {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
   min-width: 0;
   text-decoration: none;
   color: inherit;
@@ -13106,18 +13119,18 @@ ul.chat-list { list-style-type: disc; }
 .lp-author {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   min-width: 0;
 }
 .lp-avatar {
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
   border-radius: 50%;
   object-fit: cover;
   flex: 0 0 auto;
 }
 .lp-author-name {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 700;
   color: var(--text-primary);
   white-space: nowrap;
@@ -13125,12 +13138,12 @@ ul.chat-list { list-style-type: disc; }
   text-overflow: ellipsis;
 }
 .lp-handle {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
   white-space: nowrap;
 }
 .lp-text {
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.45;
   color: var(--text-primary);
   white-space: pre-wrap;
@@ -13144,7 +13157,7 @@ ul.chat-list { list-style-type: disc; }
   position: relative;
   display: block;
   line-height: 0;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   overflow: hidden;
   max-width: 100%;
 }
@@ -13154,8 +13167,8 @@ ul.chat-list { list-style-type: disc; }
   width: auto;
   max-width: 100%;
   height: auto;
-  max-height: 520px;
-  border-radius: 8px;
+  max-height: 32.5rem;
+  border-radius: 0.5rem;
   background: #000;
   object-fit: contain;
 }
@@ -13163,8 +13176,8 @@ ul.chat-list { list-style-type: disc; }
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 52px;
-  height: 52px;
+  width: 3.25rem;
+  height: 3.25rem;
   transform: translate(-50%, -50%);
   background: rgba(0, 0, 0, 0.55);
   border-radius: 50%;
@@ -13183,22 +13196,22 @@ ul.chat-list { list-style-type: disc; }
 .lp-stats {
   display: flex;
   flex-wrap: wrap;
-  gap: 14px;
-  font-size: 12px;
+  gap: 0.875rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 .lp-stats span { white-space: nowrap; }
 /* YouTube card reuses the shared chrome; neutralise the legacy inner styling */
 .link-preview--yt {
   flex-direction: column;
-  gap: 6px;
-  padding: 8px 10px;
+  gap: 0.375rem;
+  padding: 0.5rem 0.625rem;
 }
 .link-preview--yt .link-preview-yt {
   margin-top: 0;
   border: 0;
-  border-radius: 6px;
-  max-width: 480px;
+  border-radius: 0.375rem;
+  max-width: 30rem;
   width: 100%;
 }
 
@@ -13208,8 +13221,8 @@ ul.chat-list { list-style-type: disc; }
 
 .dm-cleanup-notice {
   display: none;
-  padding: 4px 16px;
-  font-size: 12px;
+  padding: 0.25rem 1rem;
+  font-size: 0.75rem;
   color: var(--text-secondary);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
@@ -13224,15 +13237,15 @@ ul.chat-list { list-style-type: disc; }
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .channel-topic-bar {
-  padding: 4px 16px;
-  font-size: 12px;
+  padding: 0.25rem 1rem;
+  font-size: 0.75rem;
   color: var(--text-secondary);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  min-height: 24px;
+  min-height: 1.5rem;
   line-height: 24px;
 }
 
@@ -13248,14 +13261,14 @@ ul.chat-list { list-style-type: disc; }
 .user-dot.dnd {
   background-color: var(--danger) !important;
   box-shadow: 0 0 4px var(--danger);
-  border-radius: 2px;
+  border-radius: 0.125rem;
 }
 
 /* Away: half-circle dome */
 .user-dot.away {
   background-color: #faa61a !important;
   box-shadow: 0 0 4px rgba(250, 166, 26, 0.4);
-  border-radius: 2px 2px 50% 50%;
+  border-radius: 0.125rem 0.125rem 50% 50%;
 }
 
 /* Invisible: hollow circle */
@@ -13267,10 +13280,10 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .user-status-text {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
-  margin-left: 4px;
-  max-width: 100px;
+  margin-left: 0.25rem;
+  max-width: 6.25rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -13329,21 +13342,21 @@ ul.chat-list { list-style-type: disc; }
   bottom: auto;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 6px 0;
-  min-width: 200px;
-  width: 220px;
+  border-radius: 0.5rem;
+  padding: 0.375rem 0;
+  min-width: 12.5rem;
+  width: 13.75rem;
   z-index: 600;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .status-option {
-  padding: 6px 12px;
+  padding: 0.375rem 0.75rem;
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
   color: var(--text-primary);
 }
 
@@ -13357,20 +13370,20 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .status-text-row {
-  padding: 6px 12px;
+  padding: 0.375rem 0.75rem;
   border-top: 1px solid var(--border);
-  margin-top: 4px;
-  padding-top: 8px;
+  margin-top: 0.25rem;
+  padding-top: 0.5rem;
 }
 
 .status-text-row input {
   width: 100%;
   background: var(--bg-input);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: 0.75rem;
   outline: none;
 }
 
@@ -13540,13 +13553,13 @@ ul.chat-list { list-style-type: disc; }
 
 .dm-section-label {
   margin-top: 0 !important;
-  padding-top: 4px;
+  padding-top: 0.25rem;
 }
 
 .dm-toggle {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   width: 100%;
   user-select: none;
   transition: color 0.15s;
@@ -13559,7 +13572,7 @@ ul.chat-list { list-style-type: disc; }
 .dm-toggle-arrow {
   display: inline-block;
   transition: transform 0.2s ease;
-  font-size: 10px;
+  font-size: 0.625rem;
 }
 
 .dm-toggle-arrow.collapsed {
@@ -13567,12 +13580,12 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .dm-unread-count {
-  font-size: 9px;
+  font-size: 0.5625rem;
   font-weight: 700;
   background: var(--accent);
   color: #fff;
-  padding: 1px 5px;
-  border-radius: 8px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.5rem;
   margin-left: auto;
 }
 
@@ -13584,9 +13597,9 @@ ul.chat-list { list-style-type: disc; }
 .dm-category-header {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 10px 2px;
-  font-size: 10px;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem 0.125rem;
+  font-size: 0.625rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -13601,14 +13614,14 @@ ul.chat-list { list-style-type: disc; }
 .dm-category-arrow {
   display: inline-block;
   transition: transform 0.2s ease;
-  font-size: 9px;
+  font-size: 0.5625rem;
 }
 .dm-category-arrow.collapsed {
   transform: rotate(-90deg);
 }
 
 .user-dm-btn {
-  font-size: 12px !important;
+  font-size: 0.75rem !important;
   opacity: 0;
   transition: opacity 0.15s;
 }
@@ -13629,13 +13642,13 @@ ul.chat-list { list-style-type: disc; }
 /* Sidebar: one compact line, truncated. Deliberately quiet — it sits next to
    every name in the member list, so it must never out-shout the username. */
 .user-activity {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   opacity: 0.85;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 130px;
+  max-width: 8.125rem;
   flex-shrink: 1;
   min-width: 0;
 }
@@ -13645,35 +13658,35 @@ ul.chat-list { list-style-type: disc; }
 .profile-popup-activity {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin: 4px 0 8px;
+  gap: 0.5rem;
+  margin: 0.25rem 0 0.5rem;
 }
 
 .profile-activity-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   min-width: 0;
 }
 
 .profile-activity-art {
-  width: 38px;
-  height: 38px;
-  border-radius: 4px;
+  width: 2.375rem;
+  height: 2.375rem;
+  border-radius: 0.25rem;
   object-fit: cover;
   flex-shrink: 0;
   background: var(--bg-tertiary);
 }
 
 .profile-activity-icon {
-  width: 38px;
-  height: 38px;
-  border-radius: 4px;
+  width: 2.375rem;
+  height: 2.375rem;
+  border-radius: 0.25rem;
   background: var(--bg-tertiary);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
+  font-size: 1.125rem;
   flex-shrink: 0;
 }
 
@@ -13685,14 +13698,14 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .profile-activity-verb {
-  font-size: 10px;
+  font-size: 0.625rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-muted);
 }
 
 .profile-activity-name {
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-primary);
   overflow: hidden;
@@ -13701,7 +13714,7 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .profile-activity-details {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -13712,15 +13725,15 @@ ul.chat-list { list-style-type: disc; }
 .connection-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
+  gap: 0.625rem;
+  padding: 0.625rem 0.75rem;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  margin-bottom: 8px;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
   background: var(--bg-tertiary);
 }
 
-.connection-row .connection-icon { font-size: 20px; flex-shrink: 0; }
+.connection-row .connection-icon { font-size: 1.25rem; flex-shrink: 0; }
 /* Name and status must stack, not flow inline. As plain inline spans they
    wrapped as one paragraph, so "Not set up yet" ran on from the provider name
    and the wrapped remainder started underneath the icon. */
@@ -13729,11 +13742,11 @@ ul.chat-list { list-style-type: disc; }
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 0.0625rem;
 }
-.connection-row .connection-name { font-size: 13px; font-weight: 600; }
+.connection-row .connection-name { font-size: 0.8125rem; font-weight: 600; }
 .connection-row .connection-sub {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   /* Setup hints name env vars and URLs — let them wrap rather than truncating
      the one piece of information the admin actually needs. */
@@ -13742,10 +13755,10 @@ ul.chat-list { list-style-type: disc; }
 }
 .connection-row .connection-sub code {
   font-family: var(--font-mono, monospace);
-  font-size: 10px;
+  font-size: 0.625rem;
   background: var(--bg-secondary);
-  border-radius: 3px;
-  padding: 1px 4px;
+  border-radius: 0.1875rem;
+  padding: 0.0625rem 0.25rem;
 }
 .connection-row.is-unavailable { opacity: 0.55; }
 
@@ -13758,8 +13771,8 @@ ul.chat-list { list-style-type: disc; }
   background: var(--bg-secondary);
   border: 1px solid var(--border-light);
   color: var(--text-primary);
-  font-size: 12px;
-  padding: 6px 14px;
+  font-size: 0.75rem;
+  padding: 0.375rem 0.875rem;
   flex-shrink: 0;
 }
 .connection-row .btn-sm:hover {
@@ -13770,8 +13783,8 @@ ul.chat-list { list-style-type: disc; }
   background: var(--accent);
   border-color: var(--accent);
   color: #fff;
-  font-size: 12px;
-  padding: 6px 14px;
+  font-size: 0.75rem;
+  padding: 0.375rem 0.875rem;
   line-height: normal;
 }
 .connection-row .btn-sm.btn-accent:hover { background: var(--accent-hover); }
@@ -13779,27 +13792,27 @@ ul.chat-list { list-style-type: disc; }
 /* Same treatment inside the setup form so Save/Cancel read as buttons too. */
 .connection-setup-actions .btn-sm {
   border: 1px solid var(--border-light);
-  font-size: 12px;
-  padding: 6px 14px;
+  font-size: 0.75rem;
+  padding: 0.375rem 0.875rem;
   line-height: normal;
 }
 .connection-setup-actions .btn-sm.btn-accent {
   border-color: var(--accent);
   color: #fff;
 }
-.connection-block { margin-bottom: 8px; }
+.connection-block { margin-bottom: 0.5rem; }
 .connection-block .connection-row { margin-bottom: 0; }
 
 /* Inline credential entry (admins only, collapsed by default) */
 .connection-setup-form {
   border: 1px solid var(--border);
   border-top: none;
-  border-radius: 0 0 8px 8px;
+  border-radius: 0 0 0.5rem 0.5rem;
   background: var(--bg-secondary);
-  padding: 10px 12px;
+  padding: 0.625rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .connection-setup-form[hidden] { display: none; }
 
@@ -13807,37 +13820,37 @@ ul.chat-list { list-style-type: disc; }
 .connection-username-form {
   border: 1px solid var(--border);
   border-top: none;
-  border-radius: 0 0 8px 8px;
+  border-radius: 0 0 0.5rem 0.5rem;
   background: var(--bg-secondary);
-  padding: 10px 12px;
+  padding: 0.625rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .connection-username-form[hidden] { display: none; }
 
 /* "Other options" — keeps the harder, more limited providers out of the way
    without hiding them outright. */
-.connection-advanced { margin-top: 4px; }
+.connection-advanced { margin-top: 0.25rem; }
 .connection-advanced > summary {
   cursor: pointer;
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
-  padding: 4px 2px;
+  padding: 0.25rem 0.125rem;
   list-style: revert;
   user-select: none;
 }
 .connection-advanced > summary:hover { color: var(--text-secondary); }
-.connection-advanced[open] > summary { margin-bottom: 6px; }
+.connection-advanced[open] > summary { margin-bottom: 0.375rem; }
 
 /* The Last.fm blurb is a real sentence, not a status line — let it breathe. */
 .connection-row .connection-sub { line-height: 1.45; }
-.connection-username-form input { font-family: inherit; font-size: 12px; }
+.connection-username-form input { font-family: inherit; font-size: 0.75rem; }
 /* The scrobbling note is multi-line with bullets, not a one-liner hint. */
 .connection-username-form .settings-hint { line-height: 1.7; }
 
 .connection-help {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--accent);
   text-decoration: none;
 }
@@ -13846,18 +13859,18 @@ ul.chat-list { list-style-type: disc; }
 .connection-field {
   display: flex;
   flex-direction: column;
-  gap: 3px;
-  font-size: 11px;
+  gap: 0.1875rem;
+  font-size: 0.6875rem;
   color: var(--text-secondary);
 }
 .connection-field input {
   background: var(--bg-primary);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 6px 8px;
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.5rem;
   color: var(--text-primary);
   font-family: var(--font-mono, monospace);
-  font-size: 11px;
+  font-size: 0.6875rem;
   width: 100%;
 }
 .connection-field input:focus {
@@ -13865,23 +13878,23 @@ ul.chat-list { list-style-type: disc; }
   border-color: var(--accent);
 }
 
-.connection-setup-actions { display: flex; gap: 6px; }
+.connection-setup-actions { display: flex; gap: 0.375rem; }
 
 .connection-steps {
   margin: 0;
-  padding-left: 18px;
-  font-size: 11px;
+  padding-left: 1.125rem;
+  font-size: 0.6875rem;
   line-height: 1.6;
   color: var(--text-secondary);
 }
-.connection-steps li { margin-bottom: 3px; }
+.connection-steps li { margin-bottom: 0.1875rem; }
 .connection-steps code {
   font-family: var(--font-mono, monospace);
-  font-size: 10px;
+  font-size: 0.625rem;
   background: var(--bg-primary);
   border: 1px solid var(--border);
-  border-radius: 3px;
-  padding: 1px 4px;
+  border-radius: 0.1875rem;
+  padding: 0.0625rem 0.25rem;
   word-break: break-all;
   user-select: all;
 }
@@ -13891,13 +13904,13 @@ ul.chat-list { list-style-type: disc; }
    full-width block under the instruction that introduces it. */
 .connection-steps code.setup-uri {
   display: block;
-  margin-top: 4px;
-  padding: 6px 8px;
-  font-size: 10px;
+  margin-top: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.625rem;
   line-height: 1.5;
   background: var(--bg-primary);
   border: 1px solid var(--accent);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   color: var(--text-primary);
 }
 
@@ -13906,24 +13919,24 @@ ul.chat-list { list-style-type: disc; }
    Windows renders Unicode flag emoji as bare letter pairs ("GB", "RU"). */
 .lang-select-hidden { display: none !important; }
 
-.lang-picker { position: relative; min-width: 190px; }
+.lang-picker { position: relative; min-width: 11.875rem; }
 
 .lang-picker-btn {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   width: 100%;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
   text-align: left;
 }
 .lang-picker-btn:hover { border-color: var(--accent); }
-.lang-caret { margin-left: auto; opacity: 0.6; font-size: 10px; }
+.lang-caret { margin-left: auto; opacity: 0.6; font-size: 0.625rem; }
 
 .lang-picker-list {
   position: absolute;
@@ -13933,10 +13946,10 @@ ul.chat-list { list-style-type: disc; }
   z-index: 60;
   background: var(--bg-card);
   border: 1px solid var(--border-light);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   box-shadow: 0 8px 24px rgba(0,0,0,0.45);
-  padding: 4px;
-  max-height: 260px;
+  padding: 0.25rem;
+  max-height: 16.25rem;
   overflow-y: auto;
 }
 .lang-picker-list[hidden] { display: none; }
@@ -13944,24 +13957,24 @@ ul.chat-list { list-style-type: disc; }
 .lang-picker-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   width: 100%;
-  padding: 6px 8px;
+  padding: 0.375rem 0.5rem;
   background: none;
   border: none;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
   text-align: left;
 }
 .lang-picker-item:hover { background: var(--bg-tertiary); }
 
 .lang-flag {
-  width: 20px;
-  height: 15px;
+  width: 1.25rem;
+  height: 0.9375rem;
   object-fit: cover;
-  border-radius: 2px;
+  border-radius: 0.125rem;
   flex-shrink: 0;
   box-shadow: 0 0 0 1px rgba(255,255,255,0.08);
 }
@@ -13970,7 +13983,7 @@ ul.chat-list { list-style-type: disc; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 9px;
+  font-size: 0.5625rem;
   font-weight: 700;
   background: var(--bg-secondary);
   color: var(--text-muted);
@@ -13979,16 +13992,16 @@ ul.chat-list { list-style-type: disc; }
 .file-attachment {
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 14px;
-  max-width: 400px;
-  margin: 4px 0;
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  max-width: 25rem;
+  margin: 0.25rem 0;
 }
 
 .file-download-link {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   text-decoration: none;
   color: var(--text-primary);
   transition: color 0.15s;
@@ -13999,7 +14012,7 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .file-icon {
-  font-size: 24px;
+  font-size: 1.5rem;
   flex-shrink: 0;
 }
 
@@ -14010,13 +14023,13 @@ ul.chat-list { list-style-type: disc; }
 
 .file-size {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 0.75rem;
   flex-shrink: 0;
 }
 
 .file-download-arrow {
   margin-left: auto;
-  font-size: 16px;
+  font-size: 1rem;
   opacity: 0.5;
 }
 
@@ -14027,21 +14040,21 @@ ul.chat-list { list-style-type: disc; }
 .file-info {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 6px;
-  font-size: 13px;
+  gap: 0.375rem;
+  margin-bottom: 0.375rem;
+  font-size: 0.8125rem;
 }
 
 .file-attachment audio {
   width: 100%;
-  height: 32px;
+  height: 2rem;
 }
 
 .file-video {
   max-width: 100%;
-  max-height: 300px;
-  border-radius: 4px;
-  margin-top: 4px;
+  max-height: 18.75rem;
+  border-radius: 0.25rem;
+  margin-top: 0.25rem;
   background: #0a0a0a;
   object-fit: contain;
 }
@@ -14073,61 +14086,61 @@ ul.chat-list { list-style-type: disc; }
 .risky-download-modal {
   background: var(--bg-secondary, #2b2d31);
   border: 1px solid var(--border, #3a3c42);
-  border-radius: 12px;
-  padding: 28px 32px;
-  max-width: 420px;
+  border-radius: 0.75rem;
+  padding: 1.75rem 2rem;
+  max-width: 26.25rem;
   width: 90%;
   text-align: center;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 }
 .risky-download-icon {
-  font-size: 48px;
-  margin-bottom: 8px;
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
 }
 .risky-download-modal h3 {
-  margin: 0 0 12px;
+  margin: 0 0 0.75rem;
   color: var(--error, #e74c3c);
-  font-size: 18px;
+  font-size: 1.125rem;
 }
 .risky-download-modal p {
-  margin: 0 0 8px;
+  margin: 0 0 0.5rem;
   color: var(--text-primary, #dbdee1);
-  font-size: 14px;
+  font-size: 0.875rem;
   word-break: break-all;
 }
 .risky-download-desc {
   color: var(--text-muted, #949ba4) !important;
-  font-size: 13px !important;
+  font-size: 0.8125rem !important;
   line-height: 1.5;
   word-break: normal !important;
 }
 .risky-download-actions {
   display: flex;
-  gap: 10px;
+  gap: 0.625rem;
   justify-content: center;
-  margin-top: 20px;
+  margin-top: 1.25rem;
 }
 .risky-download-cancel {
-  padding: 8px 20px;
-  border-radius: 6px;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.375rem;
   border: 1px solid var(--border, #3a3c42);
   background: var(--bg-tertiary, #232428);
   color: var(--text-primary, #dbdee1);
   cursor: pointer;
-  font-size: 14px;
+  font-size: 0.875rem;
   transition: background 0.15s;
 }
 .risky-download-cancel:hover {
   background: var(--bg-primary, #1e1f22);
 }
 .risky-download-confirm {
-  padding: 8px 20px;
-  border-radius: 6px;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.375rem;
   border: none;
   background: var(--error, #e74c3c);
   color: #fff;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
   transition: filter 0.15s;
 }
@@ -14179,18 +14192,18 @@ ul.chat-list { list-style-type: disc; }
   --track-h: 6px;
   --track-r: 0;
   --track-border: 1px solid #3a3a3a;
-  height: 6px;
+  height: 0.375rem;
   border-radius: 0;
   border: 1px solid #3a3a3a;
 }
 [data-theme="minecraft"] .slider-sm::-webkit-slider-thumb,
 [data-theme="minecraft"] .ns-slider::-webkit-slider-thumb {
-  border-radius: 2px;
+  border-radius: 0.125rem;
   box-shadow: 2px 2px 0 #2a5a2a;
 }
 [data-theme="minecraft"] .slider-sm::-moz-range-thumb,
 [data-theme="minecraft"] .ns-slider::-moz-range-thumb {
-  border-radius: 2px;
+  border-radius: 0.125rem;
 }
 
 /* Final Fantasy X — blue mana bar */
@@ -14198,7 +14211,7 @@ ul.chat-list { list-style-type: disc; }
 [data-theme="ffx"] .ns-slider {
   --track-bg: #101a30;
   --track-h: 5px;
-  height: 5px;
+  height: 0.3125rem;
 }
 [data-theme="ffx"] .slider-sm::-webkit-slider-thumb,
 [data-theme="ffx"] .ns-slider::-webkit-slider-thumb {
@@ -14210,7 +14223,7 @@ ul.chat-list { list-style-type: disc; }
 [data-theme="zelda"] .ns-slider {
   --track-bg: #142014;
   --track-h: 5px;
-  height: 5px;
+  height: 0.3125rem;
 }
 [data-theme="zelda"] .slider-sm::-webkit-slider-thumb,
 [data-theme="zelda"] .ns-slider::-webkit-slider-thumb {
@@ -14289,14 +14302,14 @@ ul.chat-list { list-style-type: disc; }
 
 /* ── Sub-channel styling ─────────────────────────────── */
 .sub-channel-item {
-  padding: 3px 16px 3px 38px !important;
+  padding: 0.1875rem 1rem 0.1875rem 2.375rem !important;
 }
 .sub-channel-item .channel-hash {
-  font-size: 12px;
+  font-size: 0.75rem;
   opacity: 0.55;
 }
 .sub-channel-item .channel-name {
-  font-size: 12px;
+  font-size: 0.75rem;
   opacity: 0.8;
 }
 
@@ -14306,12 +14319,12 @@ ul.chat-list { list-style-type: disc; }
   font-style: italic;
 }
 .private-channel .channel-hash {
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 /* ── Sub-channel Subscriptions Panel ─────────────────── */
 .sub-panel-parent-section {
-  margin-bottom: 16px;
+  margin-bottom: 1rem;
 }
 .sub-panel-parent-section:last-child {
   margin-bottom: 0;
@@ -14321,7 +14334,7 @@ ul.chat-list { list-style-type: disc; }
   text-transform: uppercase;
   letter-spacing: 0.05em;
   opacity: 0.5;
-  margin: 0 0 8px;
+  margin: 0 0 0.5rem;
   font-weight: 600;
 }
 .sub-panel-group-label {
@@ -14329,7 +14342,7 @@ ul.chat-list { list-style-type: disc; }
   text-transform: uppercase;
   letter-spacing: 0.04em;
   opacity: 0.4;
-  margin: 8px 0 4px;
+  margin: 0.5rem 0 0.25rem;
   font-weight: 600;
   color: var(--accent, #7289da);
 }
@@ -14339,14 +14352,14 @@ ul.chat-list { list-style-type: disc; }
 .sub-panel-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 0.375rem;
 }
 .sub-panel-tile {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  border-radius: 6px;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.375rem;
   background: rgba(255,255,255,0.04);
   cursor: pointer;
   transition: background 0.15s, opacity 0.15s;
@@ -14375,7 +14388,7 @@ ul.chat-list { list-style-type: disc; }
 .sub-panel-toggle {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   cursor: pointer;
   flex-shrink: 0;
 }
@@ -14391,56 +14404,56 @@ ul.chat-list { list-style-type: disc; }
   font-weight: 700;
   background: var(--accent, #7289da);
   color: #fff;
-  padding: 1px 5px;
-  border-radius: 8px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.5rem;
   flex-shrink: 0;
-  min-width: 16px;
+  min-width: 1rem;
   text-align: center;
 }
 
 /* ── Role badge (user list & messages) ───────────────── */
 .user-role-badge {
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  padding: 1px 5px;
-  border-radius: 3px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   background: rgba(255,255,255,0.06);
-  margin-left: 4px;
+  margin-left: 0.25rem;
   white-space: nowrap;
   flex-shrink: 0;
   /* Hidden in sidebar user list — role shown via dot + tooltip instead */
   display: none;
 }
 .msg-role-badge {
-  font-size: 9px;
+  font-size: 0.5625rem;
   vertical-align: middle;
-  margin-left: 4px;
+  margin-left: 0.25rem;
   /* Always show in messages */
   display: inline;
 }
 /* Multi-role: small "+N" appended to the badge when the user holds extra
    roles. Hover the badge to see the full list (native title tooltip). */
 .msg-role-extra-count {
-  font-size: 8px;
+  font-size: 0.5rem;
   font-weight: 600;
   opacity: 0.75;
-  margin-left: 2px;
+  margin-left: 0.125rem;
 }
 
 /* ── BOT badge for webhook messages ───────────────── */
 .bot-badge {
   display: inline-block;
-  font-size: 9px;
+  font-size: 0.5625rem;
   font-weight: 700;
   letter-spacing: 0.5px;
-  padding: 1px 5px;
-  border-radius: 3px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   background: var(--accent-color, #5865f2);
   color: #fff;
   vertical-align: middle;
-  margin-left: 4px;
+  margin-left: 0.25rem;
 }
 .webhook-message .message-avatar {
   border: 2px solid var(--accent-color, #5865f2);
@@ -14450,30 +14463,30 @@ ul.chat-list { list-style-type: disc; }
 .webhook-item {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 10px;
-  margin-bottom: 8px;
+  border-radius: 0.375rem;
+  padding: 0.625rem;
+  margin-bottom: 0.5rem;
 }
 .webhook-item-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
 }
 .webhook-item-name {
   font-weight: 600;
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--text-primary);
 }
 .webhook-item-channel {
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--text-muted);
   background: var(--bg-tertiary);
-  padding: 1px 6px;
-  border-radius: 4px;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.25rem;
 }
 .webhook-item-status {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 600;
   margin-left: auto;
 }
@@ -14482,16 +14495,16 @@ ul.chat-list { list-style-type: disc; }
 .webhook-item-url {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 6px;
+  gap: 0.375rem;
+  margin-bottom: 0.375rem;
 }
 .webhook-url-text {
-  font-size: 10px;
+  font-size: 0.625rem;
   font-family: monospace;
   color: var(--text-muted);
   background: var(--bg-primary);
-  padding: 3px 6px;
-  border-radius: 4px;
+  padding: 0.1875rem 0.375rem;
+  border-radius: 0.25rem;
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -14500,12 +14513,12 @@ ul.chat-list { list-style-type: disc; }
 }
 .webhook-item-actions {
   display: flex;
-  gap: 6px;
+  gap: 0.375rem;
 }
 .btn-xs {
-  padding: 2px 8px;
-  font-size: 11px;
-  border-radius: 4px;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  border-radius: 0.25rem;
   border: 1px solid var(--border);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
@@ -14528,9 +14541,9 @@ ul.chat-list { list-style-type: disc; }
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
-  font-size: 10px;
+  width: 1rem;
+  height: 1rem;
+  font-size: 0.625rem;
   color: var(--text-muted);
   cursor: pointer;
   user-select: none;
@@ -14553,9 +14566,9 @@ ul.chat-list { list-style-type: disc; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 14px;
-  height: 14px;
-  font-size: 10px;
+  width: 0.875rem;
+  height: 0.875rem;
+  font-size: 0.625rem;
   color: inherit;
   transition: transform 0.15s ease;
   flex-shrink: 0;
@@ -14570,11 +14583,11 @@ ul.chat-list { list-style-type: disc; }
 .role-management-modal {
   display: flex;
   flex-direction: column;
-  width: min(95vw, 720px);
+  width: min(95vw, 45rem);
   max-width: 95vw;
-  height: min(85vh, 640px);
-  min-height: 360px;
-  padding-bottom: 18px;
+  height: min(85vh, 40rem);
+  min-height: 22.5rem;
+  padding-bottom: 1.125rem;
 }
 .role-management-modal > .role-editor-layout {
   flex: 1 1 auto;
@@ -14583,37 +14596,37 @@ ul.chat-list { list-style-type: disc; }
 }
 .role-management-modal > .modal-actions {
   flex-shrink: 0;
-  margin-top: 12px;
+  margin-top: 0.75rem;
 }
 .role-editor-layout {
   display: flex;
-  gap: 16px;
-  min-height: 280px;
+  gap: 1rem;
+  min-height: 17.5rem;
   max-height: 60vh;
-  margin: 12px 0;
+  margin: 0.75rem 0;
 }
 .role-sidebar {
-  width: 180px;
+  width: 11.25rem;
   border-right: 1px solid var(--border, #333);
-  padding-right: 12px;
+  padding-right: 0.75rem;
   flex-shrink: 0;
   overflow-y: auto;
 }
 .role-list-sidebar {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
   max-height: 100%;
   overflow-y: auto;
 }
 .role-sidebar-item {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
-  border-radius: 4px;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 0.8125rem;
   transition: background 0.15s;
 }
 .role-sidebar-item:hover {
@@ -14624,8 +14637,8 @@ ul.chat-list { list-style-type: disc; }
   color: #fff;
 }
 .role-color-dot {
-  width: 10px;
-  height: 10px;
+  width: 0.625rem;
+  height: 0.625rem;
   border-radius: 50%;
   flex-shrink: 0;
 }
@@ -14633,24 +14646,24 @@ ul.chat-list { list-style-type: disc; }
   flex: 1;
   min-width: 0;
   overflow-y: auto;
-  padding-right: 14px;
+  padding-right: 0.875rem;
 }
 .role-detail-form {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
 }
 .role-detail-form .settings-label {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 600;
   text-transform: uppercase;
   color: var(--text-muted, #888);
-  margin-top: 4px;
+  margin-top: 0.25rem;
 }
 .role-detail-form .toggle-row {
-  font-size: 13px;
-  padding: 5px 8px;
-  border-radius: var(--radius-sm, 4px);
+  font-size: 0.8125rem;
+  padding: 0.3125rem 0.5rem;
+  border-radius: var(--radius-sm, 0.25rem);
   transition: background 0.15s;
 }
 .role-detail-form .toggle-row:hover {
@@ -14664,9 +14677,9 @@ ul.chat-list { list-style-type: disc; }
 .role-preview-item {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 0;
-  font-size: 13px;
+  gap: 0.375rem;
+  padding: 0.25rem 0;
+  font-size: 0.8125rem;
 }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -14695,12 +14708,12 @@ ul.chat-list { list-style-type: disc; }
 
 .donors-modal-box {
   position: relative;
-  max-width: 500px;
+  max-width: 31.25rem;
   width: 92%;
   max-height: 80vh;
-  padding: 36px 32px 28px;
+  padding: 2.25rem 2rem 1.75rem;
   text-align: center;
-  border-radius: 16px;
+  border-radius: 1rem;
   background: var(--bg-secondary, #2b2d31);
   box-shadow: 0 8px 32px rgba(0,0,0,.45);
   animation: donorsSlideIn .3s ease;
@@ -14725,10 +14738,10 @@ ul.chat-list { list-style-type: disc; }
   background: none;
   border: none;
   color: var(--text-muted, #888);
-  font-size: 22px;
+  font-size: 1.375rem;
   cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
   line-height: 1;
   transition: color .15s, background .15s;
 }
@@ -14738,8 +14751,8 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .donors-heart-icon {
-  font-size: 48px;
-  margin-bottom: 8px;
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
   animation: donorsPulse 1.5s ease-in-out infinite;
 }
 
@@ -14749,25 +14762,25 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .donors-title {
-  font-size: 26px;
+  font-size: 1.625rem;
   font-weight: 700;
   color: var(--text-primary, #fff);
-  margin: 0 0 8px;
+  margin: 0 0 0.5rem;
 }
 
 .donors-subtitle {
   color: var(--text-muted, #aaa);
-  font-size: 13.5px;
+  font-size: 0.84375rem;
   line-height: 1.5;
-  margin: 0 0 20px;
-  padding: 0 8px;
+  margin: 0 0 1.25rem;
+  padding: 0 0.5rem;
 }
 
 .donors-tiers {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-bottom: 4px;
+  gap: 1.25rem;
+  margin-bottom: 0.25rem;
   /* Owns the modal's scroll: the rest of the modal (heart, title, sort
      toggle, note, Ko-fi button) stays put while only the tier lists
      scroll. min-height:0 lets this child actually shrink inside the flex
@@ -14790,8 +14803,8 @@ ul.chat-list { list-style-type: disc; }
 .donors-tier-title {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 13px;
+  gap: 0.625rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   letter-spacing: .6px;
   text-transform: uppercase;
@@ -14804,7 +14817,7 @@ ul.chat-list { list-style-type: disc; }
 .donors-tier-title::after {
   content: '';
   flex: 1;
-  height: 1px;
+  height: 0.0625rem;
   background: rgba(255,255,255,.1);
 }
 .donors-sponsor-title { color: #f8c53a; }
@@ -14818,12 +14831,12 @@ ul.chat-list { list-style-type: disc; }
   flex-wrap: wrap;
   justify-content: center;
   align-content: flex-start;
-  gap: 8px;
+  gap: 0.5rem;
   background: rgba(255,255,255,.04);
   border: 1px solid rgba(255,255,255,.07);
-  border-radius: 10px;
-  padding: 14px 14px;
-  max-height: 140px;
+  border-radius: 0.625rem;
+  padding: 0.875rem 0.875rem;
+  max-height: 8.75rem;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: rgba(255,255,255,.15) transparent;
@@ -14831,9 +14844,9 @@ ul.chat-list { list-style-type: disc; }
 
 .donor-chip {
   background: rgba(255,255,255,.06);
-  padding: 5px 14px;
-  border-radius: 20px;
-  font-size: 13px;
+  padding: 0.3125rem 0.875rem;
+  border-radius: 1.25rem;
+  font-size: 0.8125rem;
   color: var(--text-primary, #ddd);
   border: 1px solid rgba(255,255,255,.08);
   transition: background .15s, border-color .15s;
@@ -14851,8 +14864,8 @@ ul.chat-list { list-style-type: disc; }
 
 .donors-note {
   color: var(--text-muted, #777);
-  font-size: 11.5px;
-  margin: 14px 0 18px;
+  font-size: 0.71875rem;
+  margin: 0.875rem 0 1.125rem;
   font-style: italic;
   flex-shrink: 0;
 }
@@ -14860,16 +14873,16 @@ ul.chat-list { list-style-type: disc; }
 .donors-sort-toggle {
   display: flex;
   justify-content: center;
-  gap: 4px;
-  margin: 10px 0 6px;
+  gap: 0.25rem;
+  margin: 0.625rem 0 0.375rem;
 }
 .donors-sort-btn {
-  padding: 5px 14px;
-  border-radius: 8px;
+  padding: 0.3125rem 0.875rem;
+  border-radius: 0.5rem;
   border: 1px solid var(--border-color, #444);
   background: transparent;
   color: var(--text-muted, #999);
-  font-size: 12px;
+  font-size: 0.75rem;
   cursor: pointer;
   transition: background .15s, color .15s;
 }
@@ -14885,12 +14898,12 @@ ul.chat-list { list-style-type: disc; }
 .donors-kofi-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 10px 24px;
-  border-radius: 10px;
+  gap: 0.375rem;
+  padding: 0.625rem 1.5rem;
+  border-radius: 0.625rem;
   background: linear-gradient(135deg, #ff5e5b 0%, #e24444 100%);
   color: #fff;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
   text-decoration: none;
   transition: transform .15s, box-shadow .15s;
@@ -14911,8 +14924,8 @@ ul.chat-list { list-style-type: disc; }
 
 .density-picker {
   display: flex;
-  gap: 8px;
-  padding: 8px 0;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
 }
 
 .density-btn {
@@ -14920,15 +14933,15 @@ ul.chat-list { list-style-type: disc; }
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 10px 8px;
+  gap: 0.25rem;
+  padding: 0.625rem 0.5rem;
   background: var(--bg-primary);
   border: 2px solid var(--border);
   border-radius: var(--radius);
   color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.2s;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 .density-btn:hover {
   background: var(--bg-hover);
@@ -14939,53 +14952,56 @@ ul.chat-list { list-style-type: disc; }
   color: var(--text-primary);
   background: var(--bg-hover);
 }
-.density-icon { font-size: 18px; }
+.density-icon { font-size: 1.125rem; }
 .density-label { font-weight: 600; }
 
-/* ── Compact density ─────────────────────────────────── */
+/* ── Compact density ─────────────────────────────────────
+   Density adjusts spacing and message text size. Values are in rem so the
+   rows/avatars scale with the interface Zoom too; at the default 1rem = 16px
+   each tier is pixel-identical to the previous px-based rules. */
 [data-density="compact"] .message-row {
-  padding: 2px 8px;
-  gap: 8px;
+  padding: 0.125rem 0.5rem;   /* 2px 8px */
+  gap: 0.5rem;                /* 8px */
 }
 [data-density="compact"] .message-avatar,
 [data-density="compact"] .message-avatar-img {
-  width: 28px;
-  height: 28px;
-  font-size: 11px;
+  width: 1.75rem;             /* 28px */
+  height: 1.75rem;
+  font-size: 0.6875rem;       /* 11px */
 }
 [data-density="compact"] .message-compact {
-  padding-left: 44px;
+  padding-left: 2.75rem;      /* 44px */
 }
 [data-density="compact"] .message-compact .compact-time {
-  font-size: 9px;
+  font-size: 0.5625rem;       /* 9px */
 }
 [data-density="compact"] .message-content {
-  font-size: 13px;
+  font-size: 0.8125rem;       /* 13px */
 }
 [data-density="compact"] .message-author {
-  font-size: 12px;
+  font-size: 0.75rem;         /* 12px */
 }
 [data-density="compact"] .message-time {
-  font-size: 10px;
+  font-size: 0.625rem;        /* 10px */
 }
 
 /* ── Spacious density ────────────────────────────────── */
 [data-density="spacious"] .message-row {
-  padding: 8px 12px;
-  gap: 14px;
+  padding: 0.5rem 0.75rem;    /* 8px 12px */
+  gap: 0.875rem;              /* 14px */
 }
 [data-density="spacious"] .message-avatar,
 [data-density="spacious"] .message-avatar-img {
-  width: 44px;
-  height: 44px;
-  font-size: 17px;
+  width: 2.75rem;             /* 44px */
+  height: 2.75rem;
+  font-size: 1.0625rem;       /* 17px */
 }
 [data-density="spacious"] .message-content {
-  font-size: 15px;
+  font-size: 0.9375rem;       /* 15px */
   line-height: 1.5;
 }
 [data-density="spacious"] .message-author {
-  font-size: 14px;
+  font-size: 0.875rem;        /* 14px */
 }
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -14994,172 +15010,59 @@ ul.chat-list { list-style-type: disc; }
 
 .font-size-picker {
   display: flex;
-  gap: 8px;
-  padding: 8px 0;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
 }
 
-/* Small — 11 px base (noticeably smaller) */
-[data-fontsize="small"] .message-content     { font-size: 11px; line-height: 1.35; }
-[data-fontsize="small"] .message-author      { font-size: 11px; }
-[data-fontsize="small"] .message-time        { font-size: 8.5px; }
-[data-fontsize="small"] .message-input       { font-size: 11px; }
-[data-fontsize="small"] .channel-item span,
-[data-fontsize="small"] .ch-name             { font-size: 11px; }
-[data-fontsize="small"] .user-list-item span { font-size: 11px; }
-[data-fontsize="small"] .sidebar-title       { font-size: 9px; }
-[data-fontsize="small"] .user-item-name      { font-size: 11px; }
-[data-fontsize="small"] .section-label        { font-size: 9px; }
-[data-fontsize="small"] .panel-title          { font-size: 9px; }
-[data-fontsize="small"] .current-user         { font-size: 11px; }
-[data-fontsize="small"] .login-name           { font-size: 8.5px; }
-[data-fontsize="small"] .settings-section-title { font-size: 11px; }
-[data-fontsize="small"] .settings-section-subtitle { font-size: 10.5px; }
-[data-fontsize="small"] .muted-text           { font-size: 10px; }
-[data-fontsize="small"] .channel-info         { font-size: 11px; }
-[data-fontsize="small"] .density-label        { font-size: 10px; }
-[data-fontsize="small"] .modal-body,
-[data-fontsize="small"] .modal-title          { font-size: 11px; }
-[data-fontsize="small"] .toast                { font-size: 11px; }
-[data-fontsize="small"] .inline-code,
-[data-fontsize="small"] code                  { font-size: 10.5px; }
-[data-fontsize="small"] .compact-time         { font-size: 8px; }
-/* Channel ID tag, header action icons, and voice-channel user list (#5450) */
-[data-fontsize="small"] .channel-code-tag     { font-size: 9px; }
-[data-fontsize="small"] .header-actions-box .icon-btn { font-size: 11px; }
-[data-fontsize="small"] .channel-voice-user   { font-size: 11px; }
-/* .message-compact .message-content intentionally not overridden — inherits same size
-   as full messages so all message text stays uniform across grouped and root messages. */
+/* ── Zoom slider (interface scale) ── */
+.zoom-control {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0;
+}
+.zoom-control .zoom-slider {
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+}
+.zoom-step {
+  width: 1.625rem;
+  height: 1.625rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  line-height: 1;
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.zoom-step:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+.zoom-value {
+  min-width: 3.4em;
+  text-align: right;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
 
-/* Normal — 14 px base (default, no overrides needed) */
-
-/* Large — 18 px base (clearly bigger) */
-[data-fontsize="large"] .message-content     { font-size: 18px; line-height: 1.55; }
-[data-fontsize="large"] .message-author      { font-size: 16px; }
-[data-fontsize="large"] .message-time        { font-size: 12.5px; }
-[data-fontsize="large"] .message-input       { font-size: 17px; }
-[data-fontsize="large"] .channel-item span,
-[data-fontsize="large"] .ch-name             { font-size: 16px; }
-[data-fontsize="large"] .user-list-item span { font-size: 16px; }
-[data-fontsize="large"] .sidebar-title       { font-size: 13px; }
-[data-fontsize="large"] .user-item-name      { font-size: 16px; }
-[data-fontsize="large"] .section-label        { font-size: 13px; }
-[data-fontsize="large"] .panel-title          { font-size: 13px; }
-[data-fontsize="large"] .current-user         { font-size: 16px; }
-[data-fontsize="large"] .login-name           { font-size: 12px; }
-[data-fontsize="large"] .settings-section-title { font-size: 17px; }
-[data-fontsize="large"] .settings-section-subtitle { font-size: 15px; }
-[data-fontsize="large"] .muted-text           { font-size: 15px; }
-[data-fontsize="large"] .channel-info         { font-size: 16px; }
-[data-fontsize="large"] .density-label        { font-size: 14px; }
-[data-fontsize="large"] .modal-body,
-[data-fontsize="large"] .modal-title          { font-size: 17px; }
-[data-fontsize="large"] .toast                { font-size: 16px; }
-[data-fontsize="large"] .inline-code,
-[data-fontsize="large"] code                  { font-size: 16px; }
-[data-fontsize="large"] .message-input-area   { min-height: 48px; }
-[data-fontsize="large"] .compact-time         { font-size: 11px; }
-/* Channel ID tag, header action icons, and voice-channel user list (#5450) */
-[data-fontsize="large"] .channel-code-tag     { font-size: 14px; }
-[data-fontsize="large"] .header-actions-box .icon-btn { font-size: 16px; }
-[data-fontsize="large"] .channel-voice-user   { font-size: 16px; }
-
-
-/* X-Large — 22 px base (very large, high visibility) */
-[data-fontsize="x-large"] .message-content     { font-size: 22px; line-height: 1.6; }
-[data-fontsize="x-large"] .message-author      { font-size: 19px; }
-[data-fontsize="x-large"] .message-time        { font-size: 14px; }
-[data-fontsize="x-large"] .message-input       { font-size: 21px; }
-[data-fontsize="x-large"] .channel-item span,
-[data-fontsize="x-large"] .ch-name             { font-size: 19px; }
-[data-fontsize="x-large"] .user-list-item span { font-size: 19px; }
-[data-fontsize="x-large"] .sidebar-title       { font-size: 15px; }
-[data-fontsize="x-large"] .message-input-area  { min-height: 56px; }
-[data-fontsize="x-large"] .user-item-name      { font-size: 19px; }
-[data-fontsize="x-large"] .section-label        { font-size: 15px; }
-[data-fontsize="x-large"] .panel-title          { font-size: 15px; }
-[data-fontsize="x-large"] .current-user         { font-size: 19px; }
-[data-fontsize="x-large"] .login-name           { font-size: 14px; }
-[data-fontsize="x-large"] .settings-section-title { font-size: 20px; }
-[data-fontsize="x-large"] .settings-section-subtitle { font-size: 18px; }
-[data-fontsize="x-large"] .muted-text           { font-size: 17px; }
-[data-fontsize="x-large"] .channel-info         { font-size: 19px; }
-[data-fontsize="x-large"] .density-label        { font-size: 16px; }
-[data-fontsize="x-large"] .modal-body,
-[data-fontsize="x-large"] .modal-title          { font-size: 21px; }
-[data-fontsize="x-large"] .toast                { font-size: 19px; }
-[data-fontsize="x-large"] .inline-code,
-[data-fontsize="x-large"] code                  { font-size: 19px; }
-[data-fontsize="x-large"] .compact-time         { font-size: 12.5px; }
-/* Channel ID tag, header action icons, and voice-channel user list (#5450) */
-[data-fontsize="x-large"] .channel-code-tag     { font-size: 16px; }
-[data-fontsize="x-large"] .header-actions-box .icon-btn { font-size: 19px; }
-[data-fontsize="x-large"] .channel-voice-user   { font-size: 19px; }
-
-
-/* ── Font Size: Settings / Sub-menus ─────────────────────── */
-
-/* Small */
-[data-fontsize="small"] .settings-hint          { font-size: 8.5px; }
-[data-fontsize="small"] .settings-nav-item      { font-size: 10px; }
-[data-fontsize="small"] .settings-nav-group     { font-size: 8.5px; }
-[data-fontsize="small"] .btn-sm                 { font-size: 10px; }
-[data-fontsize="small"] .btn-sm.btn-accent,
-[data-fontsize="small"] .btn-sm.btn-danger      { font-size: 13px; }
-[data-fontsize="small"] .toggle-row,
-[data-fontsize="small"] .volume-row,
-[data-fontsize="small"] .select-row             { font-size: 10px; }
-[data-fontsize="small"] .select-row select      { font-size: 9.5px; }
-[data-fontsize="small"] .settings-text-input    { font-size: 11px; }
-[data-fontsize="small"] .settings-number-input  { font-size: 10px; }
-[data-fontsize="small"] .custom-sound-name      { font-size: 11px; }
-[data-fontsize="small"] .password-change-form input { font-size: 11px; }
-[data-fontsize="small"] .status-bar             { font-size: 10px; }
-[data-fontsize="small"] .status-bar .label,
-[data-fontsize="small"] .status-bar .value      { font-size: 10px; }
-[data-fontsize="small"] .context-menu           { font-size: 11px; }
-[data-fontsize="small"] .online-overlay-title   { font-size: 9px; }
-
-/* Large */
-[data-fontsize="large"] .settings-hint          { font-size: 13px; }
-[data-fontsize="large"] .settings-nav-item      { font-size: 15px; }
-[data-fontsize="large"] .settings-nav-group     { font-size: 12px; }
-[data-fontsize="large"] .btn-sm                 { font-size: 15px; }
-[data-fontsize="large"] .btn-sm.btn-accent,
-[data-fontsize="large"] .btn-sm.btn-danger      { font-size: 18px; }
-[data-fontsize="large"] .toggle-row,
-[data-fontsize="large"] .volume-row,
-[data-fontsize="large"] .select-row             { font-size: 15px; }
-[data-fontsize="large"] .select-row select      { font-size: 14px; }
-[data-fontsize="large"] .settings-text-input    { font-size: 16px; }
-[data-fontsize="large"] .settings-number-input  { font-size: 15px; }
-[data-fontsize="large"] .custom-sound-name      { font-size: 16px; }
-[data-fontsize="large"] .password-change-form input { font-size: 16px; }
-[data-fontsize="large"] .status-bar             { font-size: 14px; }
-[data-fontsize="large"] .status-bar .label,
-[data-fontsize="large"] .status-bar .value      { font-size: 14px; }
-[data-fontsize="large"] .context-menu           { font-size: 16px; }
-[data-fontsize="large"] .online-overlay-title   { font-size: 14px; }
-
-/* X-Large */
-[data-fontsize="x-large"] .settings-hint          { font-size: 15px; }
-[data-fontsize="x-large"] .settings-nav-item      { font-size: 17px; }
-[data-fontsize="x-large"] .settings-nav-group     { font-size: 14px; }
-[data-fontsize="x-large"] .btn-sm                 { font-size: 17px; }
-[data-fontsize="x-large"] .btn-sm.btn-accent,
-[data-fontsize="x-large"] .btn-sm.btn-danger      { font-size: 21px; }
-[data-fontsize="x-large"] .toggle-row,
-[data-fontsize="x-large"] .volume-row,
-[data-fontsize="x-large"] .select-row             { font-size: 17px; }
-[data-fontsize="x-large"] .select-row select      { font-size: 16px; }
-[data-fontsize="x-large"] .settings-text-input    { font-size: 19px; }
-[data-fontsize="x-large"] .settings-number-input  { font-size: 17px; }
-[data-fontsize="x-large"] .custom-sound-name      { font-size: 19px; }
-[data-fontsize="x-large"] .password-change-form input { font-size: 19px; }
-[data-fontsize="x-large"] .status-bar             { font-size: 16px; }
-[data-fontsize="x-large"] .status-bar .label,
-[data-fontsize="x-large"] .status-bar .value      { font-size: 16px; }
-[data-fontsize="x-large"] .context-menu           { font-size: 19px; }
-[data-fontsize="x-large"] .online-overlay-title   { font-size: 16px; }
+/* ── Interface scale ─────────────────────────────────────
+   The Zoom slider scales the whole UI by driving the root font-size through
+   --ui-scale (a percentage; 100% = 16px root). Because every size in this file
+   — text, spacing, avatars, rails, sidebars, icons — is expressed in rem, one
+   root change rescales the entire interface crisply, and the flex layout
+   reflows instead of overflowing. JS sets --ui-scale from the slider; it is
+   also applied pre-paint in theme-init.js. The root rule lives up in `html {}`. */
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
    ONLINE OVERLAY
@@ -15167,9 +15070,9 @@ ul.chat-list { list-style-type: disc; }
 
 .status-online-trigger {
   cursor: pointer;
-  border-radius: 4px;
-  padding: 2px 6px;
-  margin: -2px -6px;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  margin: -0.125rem -0.375rem;
   transition: background 0.15s;
 }
 .status-online-trigger:hover {
@@ -15179,8 +15082,8 @@ ul.chat-list { list-style-type: disc; }
 .online-overlay {
   position: fixed;
   z-index: 9999;
-  width: 220px;
-  max-height: 350px;
+  width: 13.75rem;
+  max-height: 21.875rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -15194,11 +15097,11 @@ ul.chat-list { list-style-type: disc; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   border-bottom: 1px solid var(--border);
 }
 .online-overlay-title {
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -15207,17 +15110,17 @@ ul.chat-list { list-style-type: disc; }
 
 .online-overlay-list {
   overflow-y: auto;
-  padding: 6px 0;
-  max-height: 300px;
+  padding: 0.375rem 0;
+  max-height: 18.75rem;
 }
 
 .online-overlay-group {
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text-muted);
-  padding: 6px 12px 4px;
+  padding: 0.375rem 0.75rem 0.25rem;
 }
 .online-overlay-group.offline {
   opacity: 0.6;
@@ -15226,9 +15129,9 @@ ul.chat-list { list-style-type: disc; }
 .online-overlay-user {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 12px;
-  font-size: 13px;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8125rem;
 }
 .online-overlay-user.offline {
   opacity: 0.45;
@@ -15239,14 +15142,14 @@ ul.chat-list { list-style-type: disc; }
 
 .online-overlay-avatar,
 .online-overlay-avatar-img {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 50%;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   color: #fff;
 }
@@ -15264,8 +15167,8 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .online-overlay-status-dot {
-  width: 8px;
-  height: 8px;
+  width: 0.5rem;
+  height: 0.5rem;
   border-radius: 50%;
   flex-shrink: 0;
 }
@@ -15305,9 +15208,9 @@ ul.chat-list { list-style-type: disc; }
   position: absolute;
   left: 10px;
   right: 10px;
-  height: 2px;
+  height: 0.125rem;
   background: var(--accent);
-  border-radius: 2px;
+  border-radius: 0.125rem;
 }
 
 .mod-mode-active .mod-drop-above::before { top: 2px; }
@@ -15325,15 +15228,15 @@ ul.chat-list { list-style-type: disc; }
   position: absolute;
   top: 8px;
   right: 8px;
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
   border: 1px solid var(--border-light);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   cursor: grab;
   z-index: 40;
-  font-size: 14px;
+  font-size: 0.875rem;
   display: none;
 }
 
@@ -15358,7 +15261,7 @@ ul.chat-list { list-style-type: disc; }
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -15368,22 +15271,22 @@ ul.chat-list { list-style-type: disc; }
   background: color-mix(in srgb, var(--bg-secondary) 56%, var(--accent) 44%);
 }
 
-.mod-snap-zone.left { left: 0; top: 0; width: 80px; height: 100vh; }
-.mod-snap-zone.right { right: 0; top: 0; width: 80px; height: 100vh; }
-.mod-snap-zone.top { left: 0; top: 0; width: 100vw; height: 56px; }
-.mod-snap-zone.bottom { left: 0; bottom: 0; width: 100vw; height: 56px; }
+.mod-snap-zone.left { left: 0; top: 0; width: 5rem; height: 100vh; }
+.mod-snap-zone.right { right: 0; top: 0; width: 5rem; height: 100vh; }
+.mod-snap-zone.top { left: 0; top: 0; width: 100vw; height: 3.5rem; }
+.mod-snap-zone.bottom { left: 0; bottom: 0; width: 100vw; height: 3.5rem; }
 .mod-snap-zone.center {
-  left: 50%; top: 50%; width: 160px; height: 80px;
+  left: 50%; top: 50%; width: 10rem; height: 5rem;
   transform: translate(-50%, -50%);
-  border-radius: 12px;
+  border-radius: 0.75rem;
 }
 .mod-snap-zone.right-sidebar {
-  right: 0; top: 30%; width: 80px; height: 40vh;
-  border-radius: 8px 0 0 8px;
+  right: 0; top: 30%; width: 5rem; height: 40vh;
+  border-radius: 0.5rem 0 0 0.5rem;
 }
 .mod-snap-zone.left-sidebar {
-  left: 0; top: 30%; width: 80px; height: 40vh;
-  border-radius: 0 8px 8px 0;
+  left: 0; top: 30%; width: 5rem; height: 40vh;
+  border-radius: 0 0.5rem 0.5rem 0;
 }
 
 #app[data-status-pos="top"] #status-bar {
@@ -15435,7 +15338,7 @@ ul.chat-list { list-style-type: disc; }
 .mod-float {
   position: fixed !important;
   z-index: 500;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   border: 1px solid var(--border-light) !important;
   box-shadow: 0 8px 32px rgba(0,0,0,0.45), 0 0 0 1px rgba(255,255,255,0.04);
   resize: both;
@@ -15443,7 +15346,7 @@ ul.chat-list { list-style-type: disc; }
 }
 .right-sidebar.mod-float {
   top: 80px; right: 24px;
-  width: 280px; height: 420px;
+  width: 17.5rem; height: 26.25rem;
   max-width: 50vw; max-height: 70vh;
 }
 
@@ -15457,9 +15360,9 @@ ul.chat-list { list-style-type: disc; }
   background: var(--bg-card);
   color: var(--text-primary);
   border: 1px solid var(--border-light);
-  border-radius: 8px;
-  padding: 8px 12px;
-  font-size: 12px;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
@@ -15483,11 +15386,11 @@ ul.chat-list { list-style-type: disc; }
 /* Channels pane (top) */
 .sidebar-split .channel-section {
   flex: 1 1 60%;
-  min-height: 80px;
+  min-height: 5rem;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  padding: 8px 16px 0;
+  padding: 0.5rem 1rem 0;
   border-bottom: none;
 }
 .sidebar-split .channel-section .channel-list {
@@ -15500,7 +15403,7 @@ ul.chat-list { list-style-type: disc; }
 .channels-toggle {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   width: 100%;
   transition: color 0.15s;
 }
@@ -15514,7 +15417,7 @@ ul.chat-list { list-style-type: disc; }
 .channels-toggle-arrow {
   display: inline-block;
   transition: transform 0.2s ease;
-  font-size: 10px;
+  font-size: 0.625rem;
 }
 .channels-toggle-arrow.collapsed {
   transform: rotate(-90deg);
@@ -15528,8 +15431,8 @@ ul.chat-list { list-style-type: disc; }
   flex-shrink: 0;
   z-index: 5;
   border-top: 1px solid var(--border);
-  margin: 0 12px;
-  padding: 4px 0;
+  margin: 0 0.75rem;
+  padding: 0.25rem 0;
   box-sizing: content-box;
   transition: border-color 0.15s;
 }
@@ -15539,8 +15442,8 @@ ul.chat-list { list-style-type: disc; }
    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .btn-poll {
-  width: 34px;
-  height: 34px;
+  width: 2.125rem;
+  height: 2.125rem;
   background: transparent;
   color: var(--text-muted);
   border: none;
@@ -15556,8 +15459,8 @@ ul.chat-list { list-style-type: disc; }
 
 /* Burn-after-read input button (#5325) */
 .btn-burn {
-  width: 34px;
-  height: 34px;
+  width: 2.125rem;
+  height: 2.125rem;
   background: transparent;
   color: var(--text-muted);
   border: none;
@@ -15568,7 +15471,7 @@ ul.chat-list { list-style-type: disc; }
   transition: all var(--transition);
   flex-shrink: 0;
   cursor: pointer;
-  font-size: 18px;
+  font-size: 1.125rem;
 }
 .btn-burn:hover { color: var(--text-primary); background: var(--bg-tertiary); }
 .btn-burn.active {
@@ -15589,7 +15492,7 @@ ul.chat-list { list-style-type: disc; }
 /* Row-level flame label shown on all unstarted burn messages (#5280) */
 .burn-pending-label {
   font-size: 0.78em;
-  margin-left: 6px;
+  margin-left: 0.375rem;
   opacity: 0.85;
   cursor: default;
   vertical-align: middle;
@@ -15602,7 +15505,7 @@ ul.chat-list { list-style-type: disc; }
 }
 .message-inline-status .burn-pending-label {
   color: #ff6b35;
-  font-size: 12px;
+  font-size: 0.75rem;
   opacity: 0.85;
   cursor: default;
   user-select: none;
@@ -15613,7 +15516,7 @@ ul.chat-list { list-style-type: disc; }
   color: #ff6b35;
   border: 1px solid rgba(255, 107, 53, 0.3);
   border-radius: var(--radius);
-  padding: 6px 12px;
+  padding: 0.375rem 0.75rem;
   cursor: pointer;
   font-size: 0.875rem;
   transition: all var(--transition);
@@ -15632,21 +15535,21 @@ ul.chat-list { list-style-type: disc; }
 .poll-widget {
   background: var(--bg-secondary, #2b2d31);
   border: 1px solid var(--border, #3f4147);
-  border-radius: 8px;
-  padding: 12px;
-  margin-top: 6px;
-  max-width: 400px;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  margin-top: 0.375rem;
+  max-width: 25rem;
 }
 .poll-question {
   font-weight: 600;
   font-size: 0.95rem;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
   color: var(--text-primary, #fff);
 }
 .poll-options {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
 }
 .poll-option {
   position: relative;
@@ -15655,8 +15558,8 @@ ul.chat-list { list-style-type: disc; }
   justify-content: space-between;
   background: var(--bg-tertiary, #232428);
   border: 1px solid transparent;
-  border-radius: 6px;
-  padding: 8px 10px;
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.625rem;
   cursor: pointer;
   overflow: hidden;
   transition: border-color 0.15s, background 0.15s;
@@ -15678,7 +15581,7 @@ ul.chat-list { list-style-type: disc; }
   height: 100%;
   background: var(--accent, #5865f2);
   opacity: 0.15;
-  border-radius: 5px;
+  border-radius: 0.3125rem;
   transition: width 0.3s ease;
   pointer-events: none;
 }
@@ -15697,13 +15600,13 @@ ul.chat-list { list-style-type: disc; }
 .poll-option-count {
   position: relative;
   z-index: 1;
-  margin-left: 8px;
+  margin-left: 0.5rem;
   font-size: 0.8rem;
   color: var(--text-muted, #949ba4);
   white-space: nowrap;
 }
 .poll-footer {
-  margin-top: 8px;
+  margin-top: 0.5rem;
   font-size: 0.75rem;
   color: var(--text-muted, #949ba4);
 }
@@ -15717,19 +15620,19 @@ ul.chat-list { list-style-type: disc; }
 .poll-options-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.375rem;
 }
 .poll-option-row {
   display: flex;
-  gap: 6px;
+  gap: 0.375rem;
   align-items: center;
 }
 .poll-option-row .poll-option-input {
   flex: 1;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   background: var(--bg-tertiary, #1e1f22);
   border: 1px solid var(--border, #3f4147);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   color: var(--text-primary, #fff);
   font-size: 0.875rem;
 }
@@ -15742,9 +15645,9 @@ ul.chat-list { list-style-type: disc; }
   border: none;
   color: var(--text-muted, #949ba4);
   cursor: pointer;
-  font-size: 18px;
-  padding: 2px 6px;
-  border-radius: 4px;
+  font-size: 1.125rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
 }
 .poll-option-remove:hover {
   color: var(--danger, #ed4245);
@@ -15752,13 +15655,13 @@ ul.chat-list { list-style-type: disc; }
 }
 .poll-settings-row {
   display: flex;
-  gap: 16px;
+  gap: 1rem;
   flex-wrap: wrap;
 }
 .poll-checkbox-label {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   font-size: 0.875rem;
   color: var(--text-secondary, #b5bac1);
   cursor: pointer;
@@ -15774,11 +15677,11 @@ ul.chat-list { list-style-type: disc; }
 /* DM pane (bottom) */
 .sidebar-split .dm-section-pane {
   flex: 0 1 40%;
-  min-height: 60px;
+  min-height: 3.75rem;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  padding: 0 16px;
+  padding: 0 1rem;
   border-bottom: none;
   transition: flex 0.25s ease, min-height 0.25s ease, opacity 0.2s ease;
 }
@@ -15786,7 +15689,7 @@ ul.chat-list { list-style-type: disc; }
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 4px 0;
+  padding: 0.25rem 0;
 }
 
 /* ─── Collapse arrow positioning override ─────────────── */
@@ -15799,8 +15702,8 @@ ul.chat-list { list-style-type: disc; }
 .organize-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 12px 0 8px;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0.5rem;
 }
 .organize-toolbar-label {
   font-size: 0.85rem;
@@ -15809,8 +15712,8 @@ ul.chat-list { list-style-type: disc; }
   flex-shrink: 0;
 }
 .organize-select {
-  padding: 5px 8px;
-  border-radius: var(--radius-sm, 6px);
+  padding: 0.3125rem 0.5rem;
+  border-radius: var(--radius-sm, 0.375rem);
   border: 1px solid var(--border, rgba(255,255,255,0.12));
   background: var(--bg-input, rgba(255,255,255,0.06));
   color: var(--text-primary, #eee);
@@ -15827,17 +15730,17 @@ ul.chat-list { list-style-type: disc; }
 
 .organize-list {
   border: 1px solid var(--border, rgba(255,255,255,0.1));
-  border-radius: 8px;
-  max-height: 280px;
+  border-radius: 0.5rem;
+  max-height: 17.5rem;
   overflow-y: auto;
-  margin: 6px 0;
+  margin: 0.375rem 0;
 }
 
 .organize-tag-header {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -15858,9 +15761,9 @@ ul.chat-list { list-style-type: disc; }
 }
 .organize-tag-header .tag-sort-select {
   margin-left: auto;
-  padding: 1px 4px;
+  padding: 0.0625rem 0.25rem;
   font-size: 0.65rem;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   border: 1px solid var(--border, rgba(255,255,255,0.1));
   background: var(--bg-input, rgba(255,255,255,0.04));
   color: var(--text-muted);
@@ -15873,11 +15776,11 @@ ul.chat-list { list-style-type: disc; }
 }
 
 .organize-item {
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   border-bottom: 1px solid rgba(255,255,255,0.04);
   transition: background 0.12s;
 }
@@ -15887,8 +15790,8 @@ ul.chat-list { list-style-type: disc; }
   opacity: 0.45;
   font-size: 0.72rem;
   background: rgba(255,255,255,0.07);
-  padding: 1px 7px;
-  border-radius: 4px;
+  padding: 0.0625rem 0.4375rem;
+  border-radius: 0.25rem;
   flex-shrink: 0;
   white-space: nowrap;
 }
@@ -15897,7 +15800,7 @@ ul.chat-list { list-style-type: disc; }
   font-size: 0.65rem;
   opacity: 0.3;
   flex-shrink: 0;
-  margin-left: 2px;
+  margin-left: 0.125rem;
   transition: opacity 0.12s;
 }
 .organize-has-subs:hover .organize-drill-hint {
@@ -15912,23 +15815,23 @@ ul.chat-list { list-style-type: disc; }
 
 .organize-controls {
   display: flex;
-  gap: 6px;
+  gap: 0.375rem;
   align-items: center;
-  margin: 8px 0;
+  margin: 0.5rem 0;
   flex-wrap: wrap;
 }
-.organize-spacer { flex: 1; min-width: 8px; }
+.organize-spacer { flex: 1; min-width: 0.5rem; }
 .organize-tag-group {
   display: flex;
-  gap: 5px;
+  gap: 0.3125rem;
   align-items: center;
 }
 .organize-tag-input {
-  width: 110px;
-  height: 30px;
+  width: 6.875rem;
+  height: 1.875rem;
   font-size: 0.82rem;
-  padding: 4px 10px;
-  border-radius: var(--radius-sm, 6px);
+  padding: 0.25rem 0.625rem;
+  border-radius: var(--radius-sm, 0.375rem);
   border: 1px solid var(--border, rgba(255,255,255,0.12));
   background: var(--bg-input, rgba(255,255,255,0.06));
   color: var(--text-primary, #eee);
@@ -15938,7 +15841,7 @@ ul.chat-list { list-style-type: disc; }
 .organize-tag-input:focus { border-color: var(--accent); }
 .organize-tag-input::placeholder { color: var(--text-muted, #888); opacity: 0.5; }
 .organize-tag-btn {
-  padding: 5px 8px !important;
+  padding: 0.3125rem 0.5rem !important;
   font-size: 0.78rem !important;
 }
 .organize-tag-btn.danger { color: var(--danger, #ff4444) !important; }
@@ -15955,10 +15858,10 @@ ul.chat-list { list-style-type: disc; }
   opacity: 0.4;
 }
 .organize-drop-indicator {
-  height: 2px;
+  height: 0.125rem;
   background: var(--accent, #7c5cfc);
-  margin: 0 6px;
-  border-radius: 2px;
+  margin: 0 0.375rem;
+  border-radius: 0.125rem;
   pointer-events: none;
 }
 .organize-tag-header.org-drop-above {
@@ -15972,23 +15875,23 @@ ul.chat-list { list-style-type: disc; }
   font-size: 0.85rem;
   cursor: grab;
   user-select: none;
-  margin-right: 4px;
+  margin-right: 0.25rem;
 }
 
 /* ── Audit Log ────────────────────────────────────────── */
 .audit-log-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 8px 0;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
   flex-wrap: wrap;
 }
 .audit-log-toolbar select,
 .audit-log-toolbar input {
-  height: 30px;
+  height: 1.875rem;
   font-size: 0.82rem;
-  padding: 4px 10px;
-  border-radius: 6px;
+  padding: 0.25rem 0.625rem;
+  border-radius: 0.375rem;
   border: 1px solid var(--border, rgba(255,255,255,0.12));
   background: var(--bg-input, rgba(255,255,255,0.06));
   color: var(--text-primary, #eee);
@@ -15996,16 +15899,16 @@ ul.chat-list { list-style-type: disc; }
 }
 .audit-log-list {
   border: 1px solid var(--border, rgba(255,255,255,0.1));
-  border-radius: 8px;
-  max-height: 420px;
+  border-radius: 0.5rem;
+  max-height: 26.25rem;
   overflow-y: auto;
-  margin: 6px 0;
+  margin: 0.375rem 0;
   background: var(--bg-secondary, rgba(0,0,0,0.18));
 }
 .audit-log-row {
   display: flex;
-  gap: 10px;
-  padding: 8px 12px;
+  gap: 0.625rem;
+  padding: 0.5rem 0.75rem;
   border-bottom: 1px solid rgba(255,255,255,0.04);
   font-size: 0.85rem;
   align-items: flex-start;
@@ -16013,7 +15916,7 @@ ul.chat-list { list-style-type: disc; }
 .audit-log-row:last-child { border-bottom: none; }
 .audit-log-row .audit-icon {
   flex-shrink: 0;
-  width: 22px;
+  width: 1.375rem;
   text-align: center;
   opacity: 0.85;
 }
@@ -16035,33 +15938,33 @@ ul.chat-list { list-style-type: disc; }
 .audit-log-row .audit-meta {
   font-size: 0.72rem;
   color: var(--text-muted, #888);
-  margin-top: 2px;
+  margin-top: 0.125rem;
   white-space: nowrap;
 }
 .audit-log-row .audit-details {
   font-size: 0.75rem;
   color: var(--text-muted, #888);
-  margin-top: 3px;
+  margin-top: 0.1875rem;
   font-family: var(--font-mono, monospace);
   word-break: break-word;
 }
 .audit-log-empty {
-  padding: 24px;
+  padding: 1.5rem;
   text-align: center;
   opacity: 0.5;
   font-size: 0.9rem;
 }
 .audit-log-load-more {
   display: block;
-  margin: 8px auto;
+  margin: 0.5rem auto;
 }
 
 /* ── Channel Roles Modal ─────────────────────── */
 .channel-roles-layout {
   display: flex;
-  gap: 16px;
+  gap: 1rem;
   max-height: 62vh;
-  min-height: 280px;
+  min-height: 17.5rem;
 }
 .channel-roles-left {
   flex: 1;
@@ -16079,31 +15982,31 @@ ul.chat-list { list-style-type: disc; }
   overflow: hidden;
   min-height: 0;
   border-left: 1px solid var(--border, rgba(255,255,255,0.1));
-  padding-left: 16px;
+  padding-left: 1rem;
 }
 .channel-roles-section-title {
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.6px;
   color: var(--text-muted, #888);
-  margin: 0 0 6px;
+  margin: 0 0 0.375rem;
   font-weight: 600;
 }
 .channel-roles-member-list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
   overflow-y: auto;
   flex: 1;
   min-height: 0;
-  padding: 2px 0;
+  padding: 0.125rem 0;
 }
 .channel-roles-member {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm, 6px);
+  gap: 0.625rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: var(--radius-sm, 0.375rem);
   cursor: pointer;
   transition: background 0.12s;
   user-select: none;
@@ -16111,21 +16014,21 @@ ul.chat-list { list-style-type: disc; }
 .channel-roles-member:hover { background: rgba(255,255,255,0.06); }
 .channel-roles-member.selected { background: rgba(var(--accent-rgb, 88,101,242), 0.18); outline: 1px solid var(--accent); }
 .channel-roles-member-avatar {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   object-fit: cover;
   background: var(--bg-floating, #333);
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
-.channel-roles-member-avatar.square { border-radius: 6px; }
+.channel-roles-member-avatar.square { border-radius: 0.375rem; }
 .channel-roles-member-info {
   flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
 }
 .channel-roles-member-name {
   font-size: 0.88rem;
@@ -16147,16 +16050,16 @@ ul.chat-list { list-style-type: disc; }
 .channel-roles-member-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 3px;
+  gap: 0.25rem;
+  margin-top: 0.1875rem;
 }
 .channel-roles-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
   font-size: 0.7rem;
-  padding: 2px 8px;
-  border-radius: 9px;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.5625rem;
   background: rgba(255,255,255,0.08);
   color: var(--text-primary, #eee);
   white-space: nowrap;
@@ -16167,20 +16070,20 @@ ul.chat-list { list-style-type: disc; }
   color: #e74c3c;
 }
 .channel-roles-badge .badge-dot {
-  width: 7px;
-  height: 7px;
+  width: 0.4375rem;
+  height: 0.4375rem;
   border-radius: 50%;
   flex-shrink: 0;
 }
 .channel-roles-badge .badge-scope {
   font-size: 0.6rem;
   opacity: 0.6;
-  margin-left: 2px;
+  margin-left: 0.125rem;
 }
 .channel-roles-badge .revoke-btn {
   cursor: pointer;
   opacity: 0;
-  margin-left: 4px;
+  margin-left: 0.25rem;
   font-size: 0.7rem;
   transition: opacity 0.15s;
 }
@@ -16188,30 +16091,30 @@ ul.chat-list { list-style-type: disc; }
 .channel-roles-badge .revoke-btn:hover { opacity: 1; color: var(--danger, #ff4444); }
 .channel-roles-actions {
   border-top: 1px solid var(--border, rgba(255,255,255,0.1));
-  padding-top: 10px;
+  padding-top: 0.625rem;
 }
 .channel-roles-selected-name {
   font-size: 0.88rem;
-  margin: 0 0 6px;
+  margin: 0 0 0.375rem;
   color: var(--text-primary, #eee);
 }
 .channel-roles-current {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
-  margin-bottom: 8px;
-  min-height: 22px;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+  min-height: 1.375rem;
 }
 .channel-roles-assign-row {
   display: flex;
-  gap: 6px;
+  gap: 0.375rem;
   align-items: center;
   flex-wrap: wrap;
 }
-.channel-roles-assign-row .organize-select { flex: 1; min-width: 120px; }
+.channel-roles-assign-row .organize-select { flex: 1; min-width: 7.5rem; }
 .channel-roles-no-members {
   text-align: center;
-  padding: 24px;
+  padding: 1.5rem;
   color: var(--text-muted, #888);
   font-size: 0.88rem;
 }
@@ -16220,18 +16123,18 @@ ul.chat-list { list-style-type: disc; }
 .channel-roles-role-list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
   overflow-y: auto;
-  max-height: 150px;
+  max-height: 9.375rem;
   flex-shrink: 0;
-  padding: 2px 0;
+  padding: 0.125rem 0;
 }
 .channel-roles-role-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  border-radius: var(--radius-sm, 6px);
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: var(--radius-sm, 0.375rem);
   cursor: pointer;
   transition: background 0.12s;
   user-select: none;
@@ -16250,9 +16153,9 @@ ul.chat-list { list-style-type: disc; }
   flex-shrink: 0;
 }
 .channel-roles-role-detail {
-  margin-top: 8px;
+  margin-top: 0.5rem;
   border-top: 1px solid var(--border, rgba(255,255,255,0.1));
-  padding-top: 8px;
+  padding-top: 0.5rem;
   overflow-y: auto;
   flex: 1;
   min-height: 0;
@@ -16260,7 +16163,7 @@ ul.chat-list { list-style-type: disc; }
 .cr-role-form {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
 }
 .cr-role-label {
   font-size: 0.72rem;
@@ -16268,44 +16171,44 @@ ul.chat-list { list-style-type: disc; }
   letter-spacing: 0.5px;
   color: var(--text-muted, #888);
   font-weight: 600;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 .cr-role-inline {
   display: flex;
-  gap: 12px;
+  gap: 0.75rem;
   align-items: flex-end;
 }
-.cr-role-inline > div { display: flex; flex-direction: column; gap: 2px; }
+.cr-role-inline > div { display: flex; flex-direction: column; gap: 0.125rem; }
 .cr-role-perms {
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  max-height: 180px;
+  gap: 0.0625rem;
+  max-height: 11.25rem;
   overflow-y: auto;
-  padding: 2px 0;
+  padding: 0.125rem 0;
 }
 .cr-perm-toggle {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 3px 4px;
+  gap: 0.375rem;
+  padding: 0.1875rem 0.25rem;
   font-size: 0.78rem;
   color: var(--text-primary, #eee);
   cursor: pointer;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm, 0.25rem);
   transition: background 0.1s;
 }
 .cr-perm-toggle:hover { background: rgba(255,255,255,0.05); }
 .cr-perm-toggle input[type="checkbox"] {
   accent-color: var(--accent);
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   cursor: pointer;
 }
 .cr-role-btns {
   display: flex;
-  gap: 6px;
-  margin-top: 6px;
+  gap: 0.375rem;
+  margin-top: 0.375rem;
 }
 
 /* ── Channel Roles responsive ─────────────────── */
@@ -16318,7 +16221,7 @@ ul.chat-list { list-style-type: disc; }
     border-left: none;
     border-top: 1px solid var(--border, rgba(255,255,255,0.1));
     padding-left: 0;
-    padding-top: 12px;
+    padding-top: 0.75rem;
   }
 }
 
@@ -16330,47 +16233,47 @@ ul.chat-list { list-style-type: disc; }
   letter-spacing: 0.5px;
   color: var(--text-muted, #888);
   font-weight: 600;
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
 }
 .assign-role-hint {
   font-size: 0.75rem;
   color: var(--text-muted, #888);
-  margin: 0 0 6px;
+  margin: 0 0 0.375rem;
   opacity: 0.7;
   line-height: 1.3;
 }
 .assign-role-select {
   width: 100%;
-  padding: 8px 10px;
+  padding: 0.5rem 0.625rem;
   font-size: 0.88rem;
 }
 .assign-role-select option {
-  padding: 4px 8px;
+  padding: 0.25rem 0.5rem;
 }
 
 /* Multi-role checkbox list inside the basic Assign Role modal. */
 .assign-role-checkboxes {
-  max-height: 220px;
+  max-height: 13.75rem;
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 6px 4px;
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.25rem;
   background: var(--bg-secondary);
 }
 .assign-role-checkbox-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 8px;
+  gap: 0.5rem;
+  padding: 0.3125rem 0.5rem;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: 0.25rem;
 }
 .assign-role-checkbox-row:hover {
   background: var(--bg-tertiary);
 }
 .assign-role-checkbox-row .role-color-dot {
-  width: 10px;
-  height: 10px;
+  width: 0.625rem;
+  height: 0.625rem;
   border-radius: 50%;
   flex-shrink: 0;
 }
@@ -16387,31 +16290,31 @@ ul.chat-list { list-style-type: disc; }
 .settings-group {
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.75rem;
 }
 .settings-group-label {
   display: block;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 
 /* ── Server Icon Upload (admin settings) ─────────── */
 .server-icon-upload-area {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
-  margin-top: 8px;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
   flex-wrap: wrap;
 }
 .server-icon-preview {
-  width: 52px;
-  height: 52px;
-  border-radius: 12px;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 0.75rem;
   background: var(--bg-tertiary);
   display: flex;
   align-items: center;
@@ -16426,13 +16329,13 @@ ul.chat-list { list-style-type: disc; }
   object-fit: cover;
 }
 .server-icon-preview .server-icon-text {
-  font-size: 22px;
+  font-size: 1.375rem;
   color: var(--accent);
 }
 .server-icon-upload-controls {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
   min-width: 0;
   flex: 1 1 auto;
 }
@@ -16447,14 +16350,14 @@ ul.chat-list { list-style-type: disc; }
 .server-banner-upload-area {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: 0.75rem;
   flex-wrap: wrap;
 }
 .server-banner-preview {
-  width: 200px;
+  width: 12.5rem;
   max-width: 100%;
-  height: 60px;
-  border-radius: 8px;
+  height: 3.75rem;
+  border-radius: 0.5rem;
   background: var(--bg-tertiary);
   display: flex;
   align-items: center;
@@ -16466,7 +16369,7 @@ ul.chat-list { list-style-type: disc; }
 .server-banner-upload-controls {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
   min-width: 0;
   flex: 1 1 auto;
 }
@@ -16477,7 +16380,7 @@ ul.chat-list { list-style-type: disc; }
   top: 0;
   left: 0;
   right: 0;
-  height: 180px;
+  height: 11.25rem;
   z-index: 0;
   overflow: hidden;
   pointer-events: none;
@@ -16497,7 +16400,7 @@ ul.chat-list { list-style-type: disc; }
   bottom: 0;
   left: 0;
   right: 0;
-  height: 80px;
+  height: 5rem;
   background: linear-gradient(to bottom, transparent, var(--bg-primary));
   pointer-events: none;
 }
@@ -16552,8 +16455,8 @@ ul.chat-list { list-style-type: disc; }
 }
 .main.banner-mode-minimal .channel-info {
   background: rgba(0,0,0,0.35);
-  border-radius: 8px;
-  padding: 4px 10px;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.625rem;
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
 }
@@ -16566,16 +16469,16 @@ ul.chat-list { list-style-type: disc; }
 .main.banner-mode-minimal .btn-voice,
 .main.banner-mode-minimal .voice-active-indicator {
   background: rgba(0,0,0,0.35);
-  border-radius: 8px;
-  padding: 4px 10px;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.625rem;
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   text-shadow: none;
 }
 .main.banner-mode-minimal .channel-topic-bar {
-  margin: 0 12px;
-  border-radius: 0 0 8px 8px;
-  padding: 3px 12px;
+  margin: 0 0.75rem;
+  border-radius: 0 0 0.5rem 0.5rem;
+  padding: 0.1875rem 0.75rem;
   background: rgba(0,0,0,0.3) !important;
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
@@ -16621,42 +16524,42 @@ ul.chat-list { list-style-type: disc; }
 
 /* ── Role Icons ────────────────────────────────────── */
 .role-icon {
-  width: 16px;
-  height: 16px;
-  border-radius: 3px;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.1875rem;
   object-fit: cover;
   vertical-align: middle;
-  margin-right: 2px;
+  margin-right: 0.125rem;
   flex-shrink: 0;
 }
 .role-icon-preview {
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.25rem;
   object-fit: cover;
   border: 1px solid var(--border);
 }
 .role-icon-upload-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 8px;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 /* ── Discord Import ────────────────────────────────── */
 .import-format-info {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 8px 12px;
-  margin-bottom: 12px;
-  font-size: 12px;
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.75rem;
 }
-.import-format-row { margin: 3px 0; }
+.import-format-row { margin: 0.1875rem 0; }
 .import-dropzone {
   border: 2px dashed var(--border);
-  border-radius: 8px;
-  padding: 32px 16px;
+  border-radius: 0.5rem;
+  padding: 2rem 1rem;
   text-align: center;
   cursor: pointer;
   transition: border-color .2s, background .2s;
@@ -16666,61 +16569,61 @@ ul.chat-list { list-style-type: disc; }
   border-color: var(--accent-color, #5865f2);
   background: color-mix(in srgb, var(--accent-color, #5865f2) 8%, transparent);
 }
-.import-dropzone-content { display: flex; flex-direction: column; align-items: center; gap: 4px; }
-.import-dropzone-icon { font-size: 28px; }
+.import-dropzone-content { display: flex; flex-direction: column; align-items: center; gap: 0.25rem; }
+.import-dropzone-icon { font-size: 1.75rem; }
 .import-dropzone a { color: var(--accent-color, #5865f2); text-decoration: underline; }
 .import-progress-bar {
-  height: 6px;
+  height: 0.375rem;
   background: var(--bg-secondary);
-  border-radius: 3px;
+  border-radius: 0.1875rem;
   overflow: hidden;
-  margin-top: 10px;
+  margin-top: 0.625rem;
 }
 .import-progress-fill {
   height: 100%;
   width: 0%;
   background: var(--accent-color, #5865f2);
-  border-radius: 3px;
+  border-radius: 0.1875rem;
   transition: width .3s;
 }
 .import-info-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 13px;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
 }
 .import-format-badge {
   display: inline-block;
-  font-size: 10px;
+  font-size: 0.625rem;
   font-weight: 700;
-  padding: 2px 6px;
-  border-radius: 3px;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.1875rem;
   background: #5865f2;
   color: #fff;
   letter-spacing: .3px;
 }
 .import-format-badge.official { background: #57f287; color: #000; }
 .import-channel-list {
-  max-height: 300px;
+  max-height: 18.75rem;
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: 6px;
-  margin-top: 8px;
+  border-radius: 0.375rem;
+  margin-top: 0.5rem;
 }
 .import-channel-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
+  gap: 0.5rem;
+  padding: 0.4375rem 0.625rem;
   border-bottom: 1px solid var(--border);
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 .import-channel-row:last-child { border-bottom: none; }
-.import-channel-row label { display: flex; align-items: center; gap: 6px; flex: 1; min-width: 0; cursor: pointer; }
+.import-channel-row label { display: flex; align-items: center; gap: 0.375rem; flex: 1; min-width: 0; cursor: pointer; }
 .import-channel-row .import-ch-name {
   flex: 1;
   min-width: 0;
@@ -16730,15 +16633,15 @@ ul.chat-list { list-style-type: disc; }
 }
 .import-channel-row .import-ch-name input[type="text"] {
   width: 100%;
-  padding: 2px 6px;
-  font-size: 12px;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.75rem;
   background: var(--bg-primary);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   color: var(--text-primary);
 }
 .import-channel-row .import-ch-count {
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: var(--text-muted);
   white-space: nowrap;
 }
@@ -16746,19 +16649,19 @@ ul.chat-list { list-style-type: disc; }
 /* Import modal tabs */
 .import-tabs {
   display: flex;
-  gap: 4px;
-  margin-bottom: 12px;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
   border-bottom: 1px solid var(--border);
 }
 .import-tab {
   background: none;
   border: none;
-  padding: 6px 14px;
-  font-size: 12px;
+  padding: 0.375rem 0.875rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
   cursor: pointer;
   border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
+  margin-bottom: -0.0625rem;
   transition: color .2s, border-color .2s;
 }
 .import-tab:hover { color: var(--text-primary); }
@@ -16768,88 +16671,88 @@ ul.chat-list { list-style-type: disc; }
 }
 .import-token-input {
   flex: 1;
-  padding: 6px 10px;
-  font-size: 12px;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
   background: var(--bg-primary);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: 0.25rem;
   color: var(--text-primary);
   font-family: monospace;
 }
-.import-token-help { margin-top: 8px; font-size: 12px; }
+.import-token-help { margin-top: 0.5rem; font-size: 0.75rem; }
 .import-token-help summary {
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: 0.6875rem;
 }
 .import-token-help summary:hover { color: var(--text-primary); }
 .import-token-steps {
-  margin-top: 8px;
-  padding: 10px;
+  margin-top: 0.5rem;
+  padding: 0.625rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 11px;
+  border-radius: 0.375rem;
+  font-size: 0.6875rem;
   line-height: 1.5;
 }
-.import-token-steps ol { padding-left: 18px; margin: 4px 0; }
+.import-token-steps ol { padding-left: 1.125rem; margin: 0.25rem 0; }
 .import-token-steps kbd {
-  padding: 1px 5px;
+  padding: 0.0625rem 0.3125rem;
   border: 1px solid var(--border);
-  border-radius: 3px;
+  border-radius: 0.1875rem;
   background: var(--bg-primary);
-  font-size: 10px;
+  font-size: 0.625rem;
 }
 .import-token-snippet {
   display: block;
-  padding: 6px 8px;
+  padding: 0.375rem 0.5rem;
   background: var(--bg-primary);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  font-size: 10px;
+  border-radius: 0.25rem;
+  font-size: 0.625rem;
   word-break: break-all;
   user-select: all;
-  margin-top: 4px;
+  margin-top: 0.25rem;
 }
 .import-server-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 8px;
-  max-height: 280px;
+  gap: 0.5rem;
+  max-height: 17.5rem;
   overflow-y: auto;
 }
 .import-server-card {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   cursor: pointer;
   transition: border-color .2s, background .2s;
   text-align: left;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 .import-server-card:hover {
   border-color: var(--accent-color, #5865f2);
   background: color-mix(in srgb, var(--accent-color, #5865f2) 8%, var(--bg-secondary));
 }
 .import-server-icon {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   border-radius: 50%;
   flex-shrink: 0;
   object-fit: cover;
 }
 .import-server-icon-placeholder {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
+  font-size: 1.125rem;
   flex-shrink: 0;
 }
 .import-server-name {
@@ -16858,8 +16761,8 @@ ul.chat-list { list-style-type: disc; }
   white-space: nowrap;
 }
 .import-channel-category {
-  padding: 6px 10px 3px;
-  font-size: 10px;
+  padding: 0.375rem 0.625rem 0.1875rem;
+  font-size: 0.625rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -16867,11 +16770,11 @@ ul.chat-list { list-style-type: disc; }
   border-bottom: 1px solid var(--border);
 }
 .import-thread-row {
-  padding-left: 28px;
+  padding-left: 1.75rem;
   background: color-mix(in srgb, var(--bg-secondary) 40%, transparent);
 }
 .import-type-badge {
-  font-size: 9px;
+  font-size: 0.5625rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.3px;
@@ -16881,15 +16784,15 @@ ul.chat-list { list-style-type: disc; }
 /* DISCORD badge for imported messages */
 .discord-badge {
   display: inline-block;
-  font-size: 9px;
+  font-size: 0.5625rem;
   font-weight: 700;
   letter-spacing: 0.5px;
-  padding: 1px 5px;
-  border-radius: 3px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   background: #5865f2;
   color: #fff;
   vertical-align: middle;
-  margin-left: 4px;
+  margin-left: 0.25rem;
 }
 .imported-message .message-avatar {
   border: 2px solid #5865f2;
@@ -16908,8 +16811,8 @@ ul.chat-list { list-style-type: disc; }
   max-width: 98vw;
   height: 80vh;
   max-height: 92vh;
-  min-width: 560px;
-  min-height: 420px;
+  min-width: 35rem;
+  min-height: 26.25rem;
   display: flex;
   flex-direction: column;
   resize: both;
@@ -16917,19 +16820,19 @@ ul.chat-list { list-style-type: disc; }
 }
 .role-assign-center-subtitle {
   font-size: 0.82rem;
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 
 /* Three-pane layout */
 .rac-layout {
   display: flex;
-  gap: 1px;
+  gap: 0.0625rem;
   background: var(--border-light, #333);
   border: 1px solid var(--border-light, #333);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   overflow: hidden;
   flex: 1;
-  min-height: 340px;
+  min-height: 21.25rem;
 }
 .rac-pane {
   display: flex;
@@ -16937,16 +16840,16 @@ ul.chat-list { list-style-type: disc; }
   background: var(--bg-primary, #1a1a2e);
   overflow: hidden;
 }
-.rac-users-pane { flex: 0 0 220px; min-width: 180px; }
-.rac-channels-pane { flex: 0 0 220px; min-width: 180px; }
-.rac-config-pane { flex: 1; min-width: 240px; }
+.rac-users-pane { flex: 0 0 220px; min-width: 11.25rem; }
+.rac-channels-pane { flex: 0 0 220px; min-width: 11.25rem; }
+.rac-config-pane { flex: 1; min-width: 15rem; }
 
 .rac-pane-header {
-  padding: 8px 10px;
+  padding: 0.5rem 0.625rem;
   border-bottom: 1px solid var(--border-light, #333);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.375rem;
   flex-shrink: 0;
 }
 .rac-pane-title {
@@ -16958,9 +16861,9 @@ ul.chat-list { list-style-type: disc; }
 }
 .rac-search {
   width: 100%;
-  padding: 5px 8px;
+  padding: 0.3125rem 0.5rem;
   font-size: 0.82rem;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   border: 1px solid var(--border-light, #444);
   background: var(--bg-secondary, #16213e);
   color: var(--text-primary, #e0e0e0);
@@ -16972,10 +16875,10 @@ ul.chat-list { list-style-type: disc; }
 .rac-pane-list {
   flex: 1;
   overflow-y: auto;
-  padding: 4px 0;
+  padding: 0.25rem 0;
 }
 .rac-placeholder {
-  padding: 20px 12px;
+  padding: 1.25rem 0.75rem;
   text-align: center;
   color: var(--text-muted, #888);
   font-size: 0.82rem;
@@ -16985,8 +16888,8 @@ ul.chat-list { list-style-type: disc; }
 .rac-user-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
   cursor: pointer;
   transition: background 0.15s;
   font-size: 0.85rem;
@@ -16994,15 +16897,15 @@ ul.chat-list { list-style-type: disc; }
 .rac-user-item:hover { background: rgba(255,255,255,0.04); }
 .rac-user-item.active { background: var(--accent, #6b4fdb)22; border-left: 3px solid var(--accent, #6b4fdb); }
 .rac-user-avatar {
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #fff;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 700;
 }
 .rac-user-avatar img {
@@ -17032,8 +16935,8 @@ ul.chat-list { list-style-type: disc; }
 .rac-channel-item {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 10px;
+  gap: 0.375rem;
+  padding: 0.3125rem 0.625rem;
   cursor: pointer;
   transition: background 0.15s;
   font-size: 0.84rem;
@@ -17044,18 +16947,18 @@ ul.chat-list { list-style-type: disc; }
 .rac-channel-item.rac-server-wide {
   font-weight: 600;
   border-bottom: 1px solid var(--border-light, #333);
-  padding: 7px 10px;
+  padding: 0.4375rem 0.625rem;
 }
 .rac-channel-item.rac-sub {
-  padding-left: 26px;
+  padding-left: 1.625rem;
   font-size: 0.8rem;
 }
 .rac-channel-icon { opacity: 0.5; font-size: 0.8rem; }
 .rac-channel-current-role {
   margin-left: auto;
   font-size: 0.68rem;
-  padding: 1px 6px;
-  border-radius: 3px;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.1875rem;
   background: rgba(255,255,255,0.06);
   color: var(--text-muted, #888);
   white-space: nowrap;
@@ -17065,10 +16968,10 @@ ul.chat-list { list-style-type: disc; }
 .rac-config-body {
   flex: 1;
   overflow-y: auto;
-  padding: 14px;
+  padding: 0.875rem;
 }
 .rac-config-section {
-  margin-bottom: 14px;
+  margin-bottom: 0.875rem;
 }
 .rac-config-label {
   font-size: 0.72rem;
@@ -17076,19 +16979,19 @@ ul.chat-list { list-style-type: disc; }
   letter-spacing: 0.8px;
   font-weight: 700;
   color: var(--text-muted, #888);
-  margin-bottom: 5px;
+  margin-bottom: 0.3125rem;
 }
 .rac-config-row {
   display: flex;
-  gap: 10px;
+  gap: 0.625rem;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
 }
 .rac-level-input {
-  width: 70px;
-  padding: 5px 8px;
+  width: 4.375rem;
+  padding: 0.3125rem 0.5rem;
   font-size: 0.88rem;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   border: 1px solid var(--border-light, #444);
   background: var(--bg-secondary, #16213e);
   color: var(--text-primary, #e0e0e0);
@@ -17096,9 +16999,9 @@ ul.chat-list { list-style-type: disc; }
 }
 .rac-role-select {
   flex: 1;
-  padding: 5px 8px;
+  padding: 0.3125rem 0.5rem;
   font-size: 0.85rem;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   border: 1px solid var(--border-light, #444);
   background: var(--bg-secondary, #16213e);
   color: var(--text-primary, #e0e0e0);
@@ -17108,16 +17011,16 @@ ul.chat-list { list-style-type: disc; }
 .rac-perms-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 4px 12px;
+  gap: 0.25rem 0.75rem;
 }
 .rac-perm-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   font-size: 0.8rem;
-  padding: 3px 6px;
+  padding: 0.1875rem 0.375rem;
   color: var(--text-secondary, #ccc);
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm, 0.25rem);
   transition: background 0.15s;
 }
 .rac-perm-item:hover {
@@ -17139,25 +17042,25 @@ ul.chat-list { list-style-type: disc; }
 .rac-current-role {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 10px;
-  border-radius: 4px;
+  gap: 0.25rem;
+  padding: 0.1875rem 0.625rem;
+  border-radius: 0.25rem;
   background: rgba(255,255,255,0.06);
   font-size: 0.82rem;
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 .rac-current-role .rac-role-dot {
-  width: 8px;
-  height: 8px;
+  width: 0.5rem;
+  height: 0.5rem;
   border-radius: 50%;
 }
 .rac-changed-badge {
   font-size: 0.68rem;
-  padding: 1px 5px;
-  border-radius: 3px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.1875rem;
   background: #e67e2244;
   color: #e67e22;
-  margin-left: 6px;
+  margin-left: 0.375rem;
   font-weight: 600;
 }
 
@@ -17165,13 +17068,13 @@ ul.chat-list { list-style-type: disc; }
 .rac-roles-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .rac-role-card {
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   background: var(--bg-secondary);
-  padding: 8px 10px;
+  padding: 0.5rem 0.625rem;
 }
 .rac-role-card.rac-card-dirty {
   border-color: #e67e22;
@@ -17185,7 +17088,7 @@ ul.chat-list { list-style-type: disc; }
 .rac-card-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   flex-wrap: wrap;
   min-width: 0;
 }
@@ -17204,16 +17107,16 @@ ul.chat-list { list-style-type: disc; }
   opacity: 0.65;
 }
 .rac-card-editor {
-  margin-top: 10px;
-  padding-top: 8px;
+  margin-top: 0.625rem;
+  padding-top: 0.5rem;
   border-top: 1px dashed var(--border);
 }
 .rac-card-hint {
   font-size: 0.78rem;
   color: var(--text-muted);
-  margin: 6px 4px 12px;
-  padding: 1px 6px;
-  border-radius: 3px;
+  margin: 0.375rem 0.25rem 0.75rem;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.1875rem;
   font-weight: 600;
   white-space: normal;
   word-break: break-word;
@@ -17243,7 +17146,7 @@ ul.chat-list { list-style-type: disc; }
 }
 .rac-add-role-section {
   border-top: 1px solid var(--border);
-  padding-top: 10px;
+  padding-top: 0.625rem;
 }
 
 /* Footer */
@@ -17254,7 +17157,7 @@ ul.chat-list { list-style-type: disc; }
 }
 .rac-footer-right {
   display: flex;
-  gap: 8px;
+  gap: 0.5rem;
   margin-left: auto;
 }
 
@@ -17266,10 +17169,10 @@ ul.chat-list { list-style-type: disc; }
   }
   .rac-users-pane, .rac-channels-pane {
     flex: 0 0 auto;
-    max-height: 150px;
+    max-height: 9.375rem;
   }
   .rac-config-pane {
-    min-height: 200px;
+    min-height: 12.5rem;
   }
 }
 
@@ -17284,45 +17187,45 @@ ul.chat-list { list-style-type: disc; }
   #all-members-modal .modal {
     width: 96vw !important;
     max-width: 96vw !important;
-    padding: 14px 10px;
+    padding: 0.875rem 0.625rem;
     max-height: 88vh !important;
   }
-  #all-members-modal .modal h3 { font-size: 16px; margin-bottom: 2px; }
+  #all-members-modal .modal h3 { font-size: 1rem; margin-bottom: 0.125rem; }
 
   /* Member rows: horizontal card, tighter padding */
   .aml-member-row {
-    padding: 6px 8px;
-    gap: 8px;
+    padding: 0.375rem 0.5rem;
+    gap: 0.5rem;
     flex-wrap: nowrap;
   }
-  .aml-avatar-wrap { width: 30px; height: 30px; }
-  .aml-avatar { width: 30px; height: 30px; }
-  .aml-avatar-default { font-size: 12px; }
-  .aml-status-dot { width: 8px; height: 8px; border-width: 1.5px; }
+  .aml-avatar-wrap { width: 1.875rem; height: 1.875rem; }
+  .aml-avatar { width: 1.875rem; height: 1.875rem; }
+  .aml-avatar-default { font-size: 0.75rem; }
+  .aml-status-dot { width: 0.5rem; height: 0.5rem; border-width: 1.5px; }
 
-  .aml-member-name { font-size: 12px; gap: 4px; }
-  .aml-login-name { font-size: 10px; }
-  .aml-admin-badge, .aml-banned-badge, .aml-new-badge { font-size: 9px; padding: 0px 4px; }
+  .aml-member-name { font-size: 0.75rem; gap: 0.25rem; }
+  .aml-login-name { font-size: 0.625rem; }
+  .aml-admin-badge, .aml-banned-badge, .aml-new-badge { font-size: 0.5625rem; padding: 0 0.25rem; }
 
   /* Meta row: keep horizontal flow, don't let it be super vertical */
   .aml-member-meta {
-    gap: 4px;
-    font-size: 10px;
+    gap: 0.25rem;
+    font-size: 0.625rem;
     flex-direction: row;
     flex-wrap: wrap;
   }
-  .aml-role-badge { font-size: 9px; padding: 0px 5px; }
-  .aml-member-joined, .aml-member-channels { font-size: 9px; }
+  .aml-role-badge { font-size: 0.5625rem; padding: 0 0.3125rem; }
+  .aml-member-joined, .aml-member-channels { font-size: 0.5625rem; }
 
   /* Actions: always visible on mobile (no hover), compact */
   .aml-actions {
     opacity: 1;
-    gap: 2px;
+    gap: 0.125rem;
   }
   .aml-action-btn {
-    width: 26px;
-    height: 26px;
-    font-size: 12px;
+    width: 1.625rem;
+    height: 1.625rem;
+    font-size: 0.75rem;
   }
 }
 
@@ -17331,28 +17234,28 @@ ul.chat-list { list-style-type: disc; }
   .role-assign-center-box {
     width: 97vw !important;
     max-width: 97vw !important;
-    padding: 12px 8px !important;
+    padding: 0.75rem 0.5rem !important;
     max-height: 90vh !important;
   }
-  .role-assign-center-box h3 { font-size: 15px; margin-bottom: 2px; }
-  .role-assign-center-subtitle { font-size: 0.72rem; margin-bottom: 6px; }
+  .role-assign-center-box h3 { font-size: 0.9375rem; margin-bottom: 0.125rem; }
+  .role-assign-center-subtitle { font-size: 0.72rem; margin-bottom: 0.375rem; }
 
-  .rac-pane-header { padding: 6px 8px; gap: 4px; }
+  .rac-pane-header { padding: 0.375rem 0.5rem; gap: 0.25rem; }
   .rac-pane-title { font-size: 0.65rem; }
-  .rac-search { padding: 4px 6px; font-size: 0.78rem; }
+  .rac-search { padding: 0.25rem 0.375rem; font-size: 0.78rem; }
 
-  .rac-user-item, .rac-channel-item { padding: 6px 8px; font-size: 0.78rem; }
+  .rac-user-item, .rac-channel-item { padding: 0.375rem 0.5rem; font-size: 0.78rem; }
 
   /* Perms grid: single column on tiny screens */
-  .rac-perms-grid { grid-template-columns: 1fr; gap: 2px 0; }
-  .rac-perm-item { font-size: 0.74rem; padding: 2px 0; }
+  .rac-perms-grid { grid-template-columns: 1fr; gap: 0.125rem 0; }
+  .rac-perm-item { font-size: 0.74rem; padding: 0.125rem 0; }
 
-  .rac-footer { flex-wrap: wrap; gap: 6px; }
-  .rac-footer .btn-sm { min-height: 36px; font-size: 12px; padding: 6px 10px; }
+  .rac-footer { flex-wrap: wrap; gap: 0.375rem; }
+  .rac-footer .btn-sm { min-height: 2.25rem; font-size: 0.75rem; padding: 0.375rem 0.625rem; }
 
   /* Config body: more room */
-  .rac-config-body { padding: 8px; }
-  .rac-level-input { width: 55px; font-size: 0.8rem; }
+  .rac-config-body { padding: 0.5rem; }
+  .rac-level-input { width: 3.4375rem; font-size: 0.8rem; }
   .rac-role-select { font-size: 0.78rem; }
 }
 
@@ -17368,15 +17271,15 @@ ul.chat-list { list-style-type: disc; }
     max-width: none !important;
     justify-content: center;
     flex-wrap: wrap;
-    gap: 4px;
-    padding: 8px;
-    border-radius: 12px;
+    gap: 0.25rem;
+    padding: 0.5rem;
+    border-radius: 0.75rem;
     z-index: 10001;
   }
   .reaction-pick-btn {
-    width: 36px;
-    height: 36px;
-    font-size: 18px;
+    width: 2.25rem;
+    height: 2.25rem;
+    font-size: 1.125rem;
   }
   /* Full emoji picker: also fixed to bottom */
   .reaction-full-picker {
@@ -17401,7 +17304,7 @@ ul.chat-list { list-style-type: disc; }
 .sidebar-section.channel-section:has(.channel-list:empty),
 #channels-pane:has(#channel-list[style*="display: none"]),
 #channels-pane:has(#channel-list[style*="display:none"]) {
-  padding-top: 8px;
+  padding-top: 0.5rem;
   padding-bottom: 0;
 }
 
@@ -17412,7 +17315,7 @@ ul.chat-list { list-style-type: disc; }
 
 /* When collapsed, the channel-list is display:none — section label no gap */
 #channels-pane .section-label {
-  margin-bottom: 4px;
+  margin-bottom: 0.25rem;
 }
 
 #channels-pane[style*="flex: 0 0 auto"] .section-label,
@@ -17424,26 +17327,26 @@ ul.chat-list { list-style-type: disc; }
 @media (max-width: 768px) {
   /* Tighten the mobile servers section */
   .mobile-servers-section {
-    padding: 4px 16px 4px;
+    padding: 0.25rem 1rem 0.25rem;
     border-bottom: 1px solid var(--border);
   }
   .mobile-servers-section .section-label {
-    margin-bottom: 2px;
-    font-size: 10px;
+    margin-bottom: 0.125rem;
+    font-size: 0.625rem;
   }
   .mobile-servers-row {
-    padding: 3px 0;
-    max-height: 44px;
+    padding: 0.1875rem 0;
+    max-height: 2.75rem;
   }
   .mobile-srv-bubble {
-    width: 32px;
-    height: 32px;
-    font-size: 12px;
+    width: 2rem;
+    height: 2rem;
+    font-size: 0.75rem;
   }
   .mobile-srv-add-btn {
-    width: 32px;
-    height: 32px;
-    font-size: 16px;
+    width: 2rem;
+    height: 2rem;
+    font-size: 1rem;
   }
 
   /* Start servers section collapsed by default on mobile to save space */
@@ -17454,16 +17357,16 @@ ul.chat-list { list-style-type: disc; }
   }
 
   /* Sidebar sections: tighter padding on mobile */
-  .sidebar-section { padding: 8px 12px; }
-  .sidebar-section.channel-section { padding: 6px 12px 0; }
-  .sidebar-split .channel-section { padding: 6px 12px 0; }
-  .sidebar-split .dm-section-pane { padding: 0 12px; }
+  .sidebar-section { padding: 0.5rem 0.75rem; }
+  .sidebar-section.channel-section { padding: 0.375rem 0.75rem 0; }
+  .sidebar-split .channel-section { padding: 0.375rem 0.75rem 0; }
+  .sidebar-split .dm-section-pane { padding: 0 0.75rem; }
 
-  .section-label { margin-bottom: 4px; font-size: 10px; }
+  .section-label { margin-bottom: 0.25rem; font-size: 0.625rem; }
 
   /* Sidebar header: more compact */
-  .sidebar-header { padding: 10px 12px; }
-  .brand-text { font-size: 14px; letter-spacing: 2px; }
+  .sidebar-header { padding: 0.625rem 0.75rem; }
+  .brand-text { font-size: 0.875rem; letter-spacing: 2px; }
 }
 
 
@@ -17476,22 +17379,22 @@ ul.chat-list { list-style-type: disc; }
 /* ── Right sidebar: push content below close button on mobile ── */
 @media (max-width: 768px) {
   .right-sidebar {
-    padding-top: calc(48px + env(safe-area-inset-top, 0px)); /* room for close button + iOS status bar */
+    padding-top: calc(3rem + env(safe-area-inset-top, 0px)); /* room for close button + iOS status bar */
   }
 
   /* Settings panel at bottom needs safe area for Android nav bar */
   .right-sidebar .sidebar-settings-panel {
-    padding-bottom: max(env(safe-area-inset-bottom, 0px), 8px);
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 0.5rem);
   }
 }
 
 /* ── Modals: safe area padding for Android nav bar ── */
 @media (max-width: 600px) {
   .modal {
-    padding-bottom: max(env(safe-area-inset-bottom, 0px), 20px) !important;
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 1.25rem) !important;
   }
   #all-members-modal .modal {
-    padding-bottom: max(env(safe-area-inset-bottom, 0px), 16px) !important;
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 1rem) !important;
   }
 }
 
@@ -17508,13 +17411,13 @@ ul.chat-list { list-style-type: disc; }
   top: 50%;
   transform: translateY(-50%);
   z-index: 12;
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 0.375rem;
   background: var(--bg-card, var(--bg-secondary));
   color: var(--text-muted);
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 1;
   cursor: pointer;
   align-items: center;
@@ -17541,14 +17444,14 @@ ul.chat-list { list-style-type: disc; }
   /* Ensure compact messages are tall enough that the ⋯ button (28 px)
      doesn't overflow into adjacent rows and cause visual overlap. */
   .message-compact {
-    min-height: 32px;
+    min-height: 2rem;
     display: flex;
     align-items: flex-start;
   }
   /* Give message rows right padding so text doesn't flow under the ⋯ button */
   .message .message-row,
   .message-compact {
-    padding-right: 38px;
+    padding-right: 2.375rem;
   }
   /* Hide dots button when toolbar is visible (message is selected) */
   .msg-selected .msg-dots-btn {
@@ -17577,7 +17480,7 @@ ul.chat-list { list-style-type: disc; }
   /* Show timestamp BELOW selected compact messages ONLY
      (regular messages already show time in the header) */
   .msg-selected.message-compact {
-    padding-bottom: 22px !important;
+    padding-bottom: 1.375rem !important;
   }
   .msg-selected.message-compact::after {
     content: attr(data-time-short);
@@ -17585,7 +17488,7 @@ ul.chat-list { list-style-type: disc; }
     position: absolute;
     bottom: 3px;
     left: 8px;
-    font-size: 10px;
+    font-size: 0.625rem;
     color: var(--text-muted);
     opacity: 0.8;
     pointer-events: none;
@@ -17604,20 +17507,20 @@ ul.chat-list { list-style-type: disc; }
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding-top: min(20vh, 160px);
+  padding-top: min(20vh, 10rem);
 }
 .quick-switcher-box {
   background: var(--bg-secondary, #2b2d31);
-  border-radius: var(--radius-lg, 12px);
-  width: min(480px, 90vw);
+  border-radius: var(--radius-lg, 0.75rem);
+  width: min(30rem, 90vw);
   box-shadow: 0 8px 32px rgba(0,0,0,.5);
   overflow: hidden;
   border: 1px solid var(--border, #3f4147);
 }
 #quick-switcher-input {
   width: 100%;
-  padding: 14px 16px;
-  font-size: 15px;
+  padding: 0.875rem 1rem;
+  font-size: 0.9375rem;
   background: transparent;
   border: none;
   border-bottom: 1px solid var(--border, #3f4147);
@@ -17627,19 +17530,19 @@ ul.chat-list { list-style-type: disc; }
 }
 #quick-switcher-input::placeholder { color: var(--text-muted, #949ba4); }
 #quick-switcher-results {
-  max-height: 340px;
+  max-height: 21.25rem;
   overflow-y: auto;
-  padding: 4px;
+  padding: 0.25rem;
 }
 .quick-switcher-item {
   display: flex;
   align-items: center;
-  padding: 8px 12px;
-  border-radius: var(--radius-sm, 6px);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm, 0.375rem);
   cursor: pointer;
   color: var(--text-secondary, #b5bac1);
-  font-size: 14px;
-  gap: 8px;
+  font-size: 0.875rem;
+  gap: 0.5rem;
 }
 .quick-switcher-item:hover,
 .quick-switcher-item.selected {
@@ -17650,11 +17553,11 @@ ul.chat-list { list-style-type: disc; }
   margin-left: auto;
   background: var(--danger, #ed4245);
   color: #fff;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 700;
-  padding: 1px 6px;
-  border-radius: 10px;
-  min-width: 16px;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.625rem;
+  min-width: 1rem;
   text-align: center;
 }
 
@@ -17666,8 +17569,8 @@ ul.chat-list { list-style-type: disc; }
   position: absolute;
   bottom: -2px;
   right: -2px;
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   background: var(--danger, #ed4245);
   border-radius: 50%;
   border: 2px solid var(--bg-secondary, #2b2d31);
@@ -17693,7 +17596,7 @@ ul.chat-list { list-style-type: disc; }
 .move-selection-mode .messages .move-selected {
   background: var(--accent-alpha, rgba(88, 101, 242, 0.15));
   border-left: 3px solid var(--accent, #5865f2);
-  padding-left: calc(var(--msg-padding-left, 12px) - 3px);
+  padding-left: calc(var(--msg-padding-left, 0.75rem) - 0.1875rem);
 }
 
 /* Dim the toolbar in selection mode (don't need per-message actions) */
@@ -17710,40 +17613,40 @@ ul.chat-list { list-style-type: disc; }
   transform: translateX(-50%);
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 18px;
+  gap: 0.625rem;
+  padding: 0.625rem 1.125rem;
   background: var(--bg-secondary, #2b2d31);
   border: 1px solid var(--border, #3f4147);
-  border-radius: 10px;
+  border-radius: 0.625rem;
   box-shadow: 0 4px 20px rgba(0,0,0,0.4);
   /* #5377: must clear .message-input-area (99995) which creates a stacking
      context above #fx-layers. See /memories/repo/haven-zindex-layer-map.md
      before changing this. */
   z-index: 100000;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: var(--text-primary, #dbdee1);
 }
-.move-msg-toolbar .btn-sm { min-width: 80px; }
+.move-msg-toolbar .btn-sm { min-width: 5rem; }
 .move-msg-toolbar .btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* Channel picker modal */
 .move-msg-channel-list {
-  max-height: 300px;
+  max-height: 18.75rem;
   overflow-y: auto;
-  margin: 12px 0;
+  margin: 0.75rem 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
 }
 .move-msg-channel-item {
   display: block;
   width: 100%;
-  padding: 10px 14px;
+  padding: 0.625rem 0.875rem;
   background: transparent;
   border: none;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   color: var(--text-primary, #dbdee1);
-  font-size: 14px;
+  font-size: 0.875rem;
   text-align: left;
   cursor: pointer;
   transition: background 0.15s;
@@ -17752,16 +17655,16 @@ ul.chat-list { list-style-type: disc; }
   background: var(--bg-hover, #36373d);
 }
 .move-msg-empty {
-  padding: 20px;
+  padding: 1.25rem;
   text-align: center;
   color: var(--text-muted, #949ba4);
 }
 
 /* -- Channel Media Gallery (#5350) ----------------------- */
 .media-gallery-modal {
-  width: min(95vw, 1100px);
-  max-width: 1100px;
-  height: min(90vh, 800px);
+  width: min(95vw, 68.75rem);
+  max-width: 68.75rem;
+  height: min(90vh, 50rem);
   max-height: 90vh;
   display: flex;
   flex-direction: column;
@@ -17772,14 +17675,14 @@ ul.chat-list { list-style-type: disc; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 18px 10px;
+  padding: 0.875rem 1.125rem 0.625rem;
   border-bottom: 1px solid var(--border);
 }
 .media-gallery-header h3 { margin: 0; font-size: 1.05rem; }
 .media-gallery-tabs {
   display: flex;
-  gap: 2px;
-  padding: 6px 10px 0;
+  gap: 0.125rem;
+  padding: 0.375rem 0.625rem 0;
   border-bottom: 1px solid var(--border);
   overflow-x: auto;
   flex-shrink: 0;
@@ -17789,14 +17692,14 @@ ul.chat-list { list-style-type: disc; }
   border: 0;
   border-bottom: 2px solid transparent;
   color: var(--text-muted);
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   font: inherit;
   font-size: 0.85rem;
   cursor: pointer;
   white-space: nowrap;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   transition: color .12s, border-color .12s;
 }
 .media-tab:hover { color: var(--text); }
@@ -17808,31 +17711,31 @@ ul.chat-list { list-style-type: disc; }
   background: var(--bg-tertiary, var(--bg-secondary));
   color: var(--text-muted);
   font-size: 0.7rem;
-  padding: 1px 6px;
-  border-radius: 10px;
-  min-width: 18px;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.625rem;
+  min-width: 1.125rem;
   text-align: center;
 }
 .media-tab.active .media-tab-count { background: var(--accent); color: #fff; }
 .media-gallery-body {
   flex: 1 1 auto;
   overflow-y: auto;
-  padding: 14px;
+  padding: 0.875rem;
 }
 .media-gallery-empty {
   text-align: center;
-  padding: 40px 20px;
+  padding: 2.5rem 1.25rem;
   font-size: 0.9rem;
 }
 .media-gallery-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 8px;
+  gap: 0.5rem;
 }
 .media-grid-item {
   position: relative;
   aspect-ratio: 1 / 1;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   overflow: hidden;
   background: var(--bg-secondary);
   cursor: pointer;
@@ -17855,7 +17758,7 @@ ul.chat-list { list-style-type: disc; }
   background: linear-gradient(to top, rgba(0,0,0,.75), transparent);
   color: #fff;
   font-size: 0.68rem;
-  padding: 14px 6px 5px;
+  padding: 0.875rem 0.375rem 0.3125rem;
   pointer-events: none;
   text-shadow: 0 1px 2px rgba(0,0,0,.6);
 }
@@ -17867,21 +17770,21 @@ ul.chat-list { list-style-type: disc; }
   font-size: 1.8rem;
   color: #fff;
   background: rgba(0,0,0,.5);
-  width: 44px;
-  height: 44px;
+  width: 2.75rem;
+  height: 2.75rem;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   pointer-events: none;
 }
-.media-list { display: flex; flex-direction: column; gap: 4px; }
+.media-list { display: flex; flex-direction: column; gap: 0.25rem; }
 .media-list-item {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 8px 10px;
-  border-radius: 6px;
+  gap: 0.75rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: 0.375rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   text-decoration: none;
@@ -17892,7 +17795,7 @@ ul.chat-list { list-style-type: disc; }
 .media-list-icon {
   flex: 0 0 auto;
   font-size: 1.4rem;
-  width: 32px;
+  width: 2rem;
   text-align: center;
 }
 .media-list-info {
@@ -17910,27 +17813,27 @@ ul.chat-list { list-style-type: disc; }
   display: block;
   font-size: 0.72rem;
   color: var(--text-muted);
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 .media-list-audio {
   width: 100%;
-  margin-top: 6px;
-  height: 32px;
+  margin-top: 0.375rem;
+  height: 2rem;
 }
 .media-list-jump {
   flex: 0 0 auto;
   background: transparent;
   border: 1px solid var(--border);
   color: var(--text-muted);
-  padding: 4px 8px;
-  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
   font-size: 0.72rem;
   cursor: pointer;
 }
 .media-list-jump:hover { color: var(--text); border-color: var(--accent); }
 @media (max-width: 600px) {
   .media-gallery-modal { width: 100vw; height: 100vh; max-width: 100vw; max-height: 100vh; border-radius: 0; }
-  .media-gallery-grid { grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); gap: 4px; }
+  .media-gallery-grid { grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); gap: 0.25rem; }
 }
 
 /* Media gallery toolbar: sort dropdown + select/delete bar (#5375) */
@@ -17938,8 +17841,8 @@ ul.chat-list { list-style-type: disc; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 8px 14px;
+  gap: 0.75rem;
+  padding: 0.5rem 0.875rem;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   flex-wrap: wrap;
@@ -17947,7 +17850,7 @@ ul.chat-list { list-style-type: disc; }
 .media-gallery-sort-label {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 0.375rem;
   font-size: 0.78rem;
   color: var(--text-muted);
 }
@@ -17955,15 +17858,15 @@ ul.chat-list { list-style-type: disc; }
   background: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   font-size: 0.8rem;
   cursor: pointer;
 }
 .media-gallery-actions {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
   flex-wrap: wrap;
 }
 .media-gallery-selection-info {
@@ -17978,8 +17881,8 @@ ul.chat-list { list-style-type: disc; }
   left: 6px;
   z-index: 5;
   background: rgba(0,0,0,0.6);
-  border-radius: 4px;
-  padding: 3px;
+  border-radius: 0.25rem;
+  padding: 0.1875rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -17989,11 +17892,11 @@ ul.chat-list { list-style-type: disc; }
   position: static;
   background: transparent;
   padding: 0;
-  margin-right: 2px;
+  margin-right: 0.125rem;
 }
 .media-select-box input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
+  width: 1rem;
+  height: 1rem;
   cursor: pointer;
   accent-color: var(--accent);
   margin: 0;
@@ -18016,9 +17919,9 @@ ul.chat-list { list-style-type: disc; }
   font-size: 0.68rem;
   color: var(--text-muted);
   background: var(--bg-tertiary, transparent);
-  padding: 1px 5px;
-  border-radius: 8px;
-  margin-left: 4px;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.5rem;
+  margin-left: 0.25rem;
   vertical-align: middle;
 }
 .media-grid-item .media-size-badge {
@@ -18031,27 +17934,27 @@ ul.chat-list { list-style-type: disc; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 0.5rem;
 }
 .personas-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  max-height: 220px;
+  gap: 0.375rem;
+  max-height: 13.75rem;
   overflow-y: auto;
 }
 .persona-item {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 6px 8px;
+  gap: 0.625rem;
+  padding: 0.375rem 0.5rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 0.375rem;
 }
 .persona-item-avatar {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   border-radius: 50%;
   background: var(--bg-tertiary, var(--bg-secondary));
   object-fit: cover;
@@ -18082,15 +17985,15 @@ ul.chat-list { list-style-type: disc; }
 }
 .persona-item-actions {
   display: flex;
-  gap: 4px;
+  gap: 0.25rem;
   flex-shrink: 0;
 }
 .persona-item-actions button {
   background: transparent;
   border: 1px solid var(--border);
   color: var(--text-muted);
-  border-radius: 4px;
-  padding: 3px 7px;
+  border-radius: 0.25rem;
+  padding: 0.1875rem 0.4375rem;
   font-size: 0.72rem;
   cursor: pointer;
 }
@@ -18099,15 +18002,15 @@ ul.chat-list { list-style-type: disc; }
 .persona-edit-row {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 8px;
+  gap: 0.375rem;
+  padding: 0.5rem;
   background: var(--bg-secondary);
   border: 1px dashed var(--accent);
-  border-radius: 6px;
+  border-radius: 0.375rem;
 }
 .persona-edit-row .persona-edit-controls {
   display: flex;
-  gap: 6px;
+  gap: 0.375rem;
   flex-wrap: wrap;
   align-items: center;
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -301,7 +301,7 @@ class HavenApp {
     this.modMode?.init();
     this._setupDensityPicker();
     this._setupToggleStylePicker();
-    this._setupFontSizePicker();
+    this._setupZoomSlider();
     this._setupEmojiSizePicker();
     this._setupImageModePicker();
     this._setupEmbedSizePicker();

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -553,7 +553,7 @@ _applyServerSettings() {
     if (this.serverSettings.server_banner) {
       bannerPreview.innerHTML = `<img src="${this._escapeHtml(this.serverSettings.server_banner)}" style="max-width:100%;max-height:80px;border-radius:6px;object-fit:cover">`;
     } else {
-      bannerPreview.innerHTML = '<span class="muted-text" style="font-size:11px">No banner</span>';
+      bannerPreview.innerHTML = '<span class="muted-text" style="font-size:0.6875rem">No banner</span>';
     }
   }
 
@@ -586,7 +586,7 @@ _renderWebhooksList(webhooks) {
     const avatarHtml = wh.avatar_url
       ? `<img src="${this._escapeHtml(wh.avatar_url)}" style="width:20px;height:20px;border-radius:50%;object-fit:cover">`
       : '🤖';
-    return `<div class="role-preview-item">${avatarHtml} <span style="font-weight:600">${this._escapeHtml(wh.name)}</span> <span style="opacity:0.5;font-size:11px">#${this._escapeHtml(wh.channel_name)}</span> ${statusDot}</div>`;
+    return `<div class="role-preview-item">${avatarHtml} <span style="font-weight:600">${this._escapeHtml(wh.name)}</span> <span style="opacity:0.5;font-size:0.6875rem">#${this._escapeHtml(wh.channel_name)}</span> ${statusDot}</div>`;
   }).join('');
 },
 
@@ -999,14 +999,14 @@ async _renderAdminThemeList() {
   } catch { /* server not ready */ }
 
   if (themes.length === 0) {
-    container.innerHTML = '<span style="font-size:12px;color:var(--text-muted)">No themes found. Add <code>.theme.css</code> files to the <code>themes/</code> folder and refresh.</span>';
+    container.innerHTML = '<span style="font-size:0.75rem;color:var(--text-muted)">No themes found. Add <code>.theme.css</code> files to the <code>themes/</code> folder and refresh.</span>';
     return;
   }
 
   container.innerHTML = '';
   for (const theme of themes) {
     const label = document.createElement('label');
-    label.style.cssText = 'display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer';
+    label.style.cssText = 'display:flex;align-items:center;gap:8px;font-size:0.8125rem;cursor:pointer';
     const cb = document.createElement('input');
     cb.type = 'checkbox';
     cb.dataset.file = theme.file;
@@ -1014,7 +1014,7 @@ async _renderAdminThemeList() {
     const nameSpan = document.createElement('span');
     nameSpan.textContent = theme.name || theme.file;
     const descSpan = document.createElement('span');
-    descSpan.style.cssText = 'font-size:11px;color:var(--text-muted)';
+    descSpan.style.cssText = 'font-size:0.6875rem;color:var(--text-muted)';
     descSpan.textContent = theme.description || '';
     label.append(cb, nameSpan);
     if (theme.description) label.append(descSpan);
@@ -3328,7 +3328,7 @@ async _importPickGuild(guild) {
       }
       const icon = typeIcons[ch.type] || '#';
       const tagHint = ch.tags && ch.tags.length
-        ? ` <span class="muted-text" style="font-size:10px">(${ch.tags.map(t => t.name).join(', ')})</span>`
+        ? ` <span class="muted-text" style="font-size:0.625rem">(${ch.tags.map(t => t.name).join(', ')})</span>`
         : '';
       const row = document.createElement('div');
       row.className = 'import-channel-row';
@@ -3350,7 +3350,7 @@ async _importPickGuild(guild) {
         const childThreads = data.threads.filter(t => t.parentId === ch.id);
         childThreads.forEach(t => {
           const tagStr = t.tags && t.tags.length
-            ? ` <span class="muted-text" style="font-size:10px">[${t.tags.join(', ')}]</span>`
+            ? ` <span class="muted-text" style="font-size:0.625rem">[${t.tags.join(', ')}]</span>`
             : '';
           const tRow = document.createElement('div');
           tRow.className = 'import-channel-row import-thread-row';
@@ -3389,7 +3389,7 @@ async _importPickGuild(guild) {
           tRow.innerHTML = `
             <label>
               <input type="checkbox" checked>
-              <span class="import-ch-name">🧵 ${this._escapeHtml(t.name)}${t.parentName ? ` <span class="muted-text" style="font-size:10px">in #${this._escapeHtml(t.parentName)}</span>` : ''}</span>
+              <span class="import-ch-name">🧵 ${this._escapeHtml(t.name)}${t.parentName ? ` <span class="muted-text" style="font-size:0.625rem">in #${this._escapeHtml(t.parentName)}</span>` : ''}</span>
             </label>
             <span class="import-ch-count import-type-badge">thread</span>
           `;
@@ -3654,8 +3654,8 @@ _renderRolesPreview() {
   container.innerHTML = this._allRoles.map(r =>
     `<div class="role-preview-item">
       <span class="role-color-dot" style="background:${this._safeColor(r.color, '#aaa')}"></span>
-      <span>${this._escapeHtml(r.name)}${r.auto_assign ? ` <span title="${t('settings.admin.role_form.auto_assign')}" style="font-size:10px;opacity:0.6">⚡</span>` : ''}</span>
-      <span class="muted-text" style="font-size:11px;margin-left:auto">Lv.${r.level}</span>
+      <span>${this._escapeHtml(r.name)}${r.auto_assign ? ` <span title="${t('settings.admin.role_form.auto_assign')}" style="font-size:0.625rem;opacity:0.6">⚡</span>` : ''}</span>
+      <span class="muted-text" style="font-size:0.6875rem;margin-left:auto">Lv.${r.level}</span>
     </div>`
   ).join('');
   // Keep the "channel creator role" picker in sync with the role list (#5461)
@@ -3742,27 +3742,27 @@ _renderRoleDetail() {
       <input type="color" id="role-edit-color" value="${role.color || '#aaaaaa'}" style="width:50px;height:30px;border:none;cursor:pointer">
       <label class="settings-label" style="margin-top:8px;">Role Icon</label>
       <div class="role-icon-upload-row">
-        ${role.icon ? `<img class="role-icon-preview" src="${this._escapeHtml(role.icon)}" alt="icon">` : '<div class="role-icon-preview" style="display:flex;align-items:center;justify-content:center;font-size:11px;color:var(--text-muted)">None</div>'}
+        ${role.icon ? `<img class="role-icon-preview" src="${this._escapeHtml(role.icon)}" alt="icon">` : '<div class="role-icon-preview" style="display:flex;align-items:center;justify-content:center;font-size:0.6875rem;color:var(--text-muted)">None</div>'}
         <input type="file" id="role-icon-file" accept="image/png,image/jpeg,image/gif,image/webp" style="display:none">
         <button class="btn-sm" id="role-icon-upload-btn" type="button">Upload</button>
         ${role.icon ? '<button class="btn-sm danger" id="role-icon-remove-btn" type="button">Remove</button>' : ''}
       </div>
-      <small class="muted-text" style="font-size:11px;">Icon shown next to role name (auto-resized to 16×16). Max 512KB.</small>
+      <small class="muted-text" style="font-size:0.6875rem;">Icon shown next to role name (auto-resized to 16×16). Max 512KB.</small>
       <label class="toggle-row" style="margin-top:12px;">
         <span>${t('settings.admin.role_form.auto_assign')}</span>
         <input type="checkbox" id="role-edit-auto-assign" ${role.auto_assign ? 'checked' : ''}>
       </label>
-      <small class="muted-text" style="font-size:11px;">${t('settings.admin.role_form.auto_assign_hint')}</small>
+      <small class="muted-text" style="font-size:0.6875rem;">${t('settings.admin.role_form.auto_assign_hint')}</small>
       <div class="role-channel-access-section">
         <h5 class="settings-section-subtitle" style="margin-top:12px;">${t('settings.admin.role_form.channel_access')}</h5>
         <label class="toggle-row">
           <span>${t('settings.admin.role_form.link_channel_access')}</span>
           <input type="checkbox" id="role-edit-link-channel-access" ${role.link_channel_access ? 'checked' : ''}>
         </label>
-        <small class="muted-text" style="font-size:11px;">${t('settings.admin.role_form.link_channel_access_hint')}</small>
+        <small class="muted-text" style="font-size:0.6875rem;">${t('settings.admin.role_form.link_channel_access_hint')}</small>
         <div id="role-channel-access-panel" style="display:${role.link_channel_access ? 'block' : 'none'};margin-top:8px;">
           <div class="role-channel-access-list" id="role-channel-access-list">
-            <p class="muted-text" style="padding:12px;text-align:center;font-size:12px">${t('modals.common.loading')}</p>
+            <p class="muted-text" style="padding:12px;text-align:center;font-size:0.75rem">${t('modals.common.loading')}</p>
           </div>
           <button class="btn-sm btn-accent rca-reapply-btn" id="rca-reapply-btn" title="${this._escapeHtml(t('settings.admin.role_form.reapply_access_tooltip') || 'Re-runs the channel-access rules above against every user who already holds this role. Useful after editing the Grant/Revoke checkboxes: it brings existing members in line with the current configuration without you having to re-assign the role.')}">🔄 ${t('settings.admin.role_form.reapply_access')}</button>
         </div>
@@ -3822,7 +3822,7 @@ _renderRoleDetail() {
   document.getElementById('role-icon-remove-btn')?.addEventListener('click', () => {
     this._pendingRoleIcon = null;
     const preview = panel.querySelector('.role-icon-preview');
-    if (preview) { preview.outerHTML = '<div class="role-icon-preview" style="display:flex;align-items:center;justify-content:center;font-size:11px;color:var(--text-muted)">None</div>'; }
+    if (preview) { preview.outerHTML = '<div class="role-icon-preview" style="display:flex;align-items:center;justify-content:center;font-size:0.6875rem;color:var(--text-muted)">None</div>'; }
     const removeBtn = document.getElementById('role-icon-remove-btn');
     if (removeBtn) removeBtn.remove();
     this._showToast('Icon removed — save role to apply', 'success');
@@ -3992,11 +3992,11 @@ _openRoleMembersModal(role) {
         ? `<img class="rac-user-avatar" src="${this._escapeHtml(u.avatar)}" alt="${initial}" style="${shapeStyle}">`
         : `<span class="rac-user-avatar" style="background-color:${color};${shapeStyle}">${initial}</span>`;
       const badgeHtml = hasRole
-        ? `<span class="role-member-badge" style="background:${this._safeColor(role.color,'#aaa')}22;color:${this._safeColor(role.color,'#aaa')};border:1px solid ${this._safeColor(role.color,'#aaa')}44;border-radius:4px;padding:1px 6px;font-size:11px;white-space:nowrap">${this._escapeHtml(role.name)}</span>`
+        ? `<span class="role-member-badge" style="background:${this._safeColor(role.color,'#aaa')}22;color:${this._safeColor(role.color,'#aaa')};border:1px solid ${this._safeColor(role.color,'#aaa')}44;border-radius:4px;padding:1px 6px;font-size:0.6875rem;white-space:nowrap">${this._escapeHtml(role.name)}</span>`
         : '';
       return `<div class="rac-user-item" style="cursor:default;gap:10px" data-uid="${u.id}">
         ${avatarHtml}
-        <span style="flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:13px">${this._escapeHtml(this._getNickname(u.id, u.displayName))}</span>
+        <span style="flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:0.8125rem">${this._escapeHtml(this._getNickname(u.id, u.displayName))}</span>
         ${badgeHtml}
         <button class="btn-sm${hasRole ? ' danger' : ' btn-accent'} role-member-toggle-btn" data-uid="${u.id}" data-has="${hasRole}" style="flex-shrink:0;min-width:64px">
           ${hasRole ? 'Remove' : 'Assign'}
@@ -4048,11 +4048,11 @@ _openRoleMembersModal(role) {
 _loadRoleChannelAccess(roleId) {
   const listEl = document.getElementById('role-channel-access-list');
   if (!listEl) return;
-  listEl.innerHTML = `<p class="muted-text" style="padding:12px;text-align:center;font-size:12px">${t('modals.common.loading')}</p>`;
+  listEl.innerHTML = `<p class="muted-text" style="padding:12px;text-align:center;font-size:0.75rem">${t('modals.common.loading')}</p>`;
 
   this.socket.emit('get-role-channel-access', { roleId }, (res) => {
     if (res && res.error) {
-      listEl.innerHTML = `<p class="muted-text" style="padding:12px;text-align:center;font-size:12px">${this._escapeHtml(res.error)}</p>`;
+      listEl.innerHTML = `<p class="muted-text" style="padding:12px;text-align:center;font-size:0.75rem">${this._escapeHtml(res.error)}</p>`;
       return;
     }
     const channels = res.channels || [];
@@ -4060,7 +4060,7 @@ _loadRoleChannelAccess(roleId) {
     (res.access || []).forEach(a => { accessMap[a.channel_id] = a; });
 
     if (!channels.length) {
-      listEl.innerHTML = `<p class="muted-text" style="padding:12px;text-align:center;font-size:12px">${t('settings.admin.roles_no_channels')}</p>`;
+      listEl.innerHTML = `<p class="muted-text" style="padding:12px;text-align:center;font-size:0.75rem">${t('settings.admin.roles_no_channels')}</p>`;
       return;
     }
 

--- a/public/js/modules/app-context.js
+++ b/public/js/modules/app-context.js
@@ -868,17 +868,17 @@ _showPushError(reason) {
   // Detect Brave-specific advice and add a copy button for the settings URL
   if (reason.includes('brave://settings')) {
     const settingsUrl = 'brave://settings/privacy';
-    html += `<div style="margin-top:12px;padding:10px;background:var(--bg-secondary);border-radius:6px;font-family:monospace;font-size:13px;display:flex;align-items:center;gap:8px;justify-content:center;">
+    html += `<div style="margin-top:12px;padding:10px;background:var(--bg-secondary);border-radius:6px;font-family:monospace;font-size:0.8125rem;display:flex;align-items:center;gap:8px;justify-content:center;">
       <span style="user-select:all;">${settingsUrl}</span>
       <button class="btn-accent" onclick="navigator.clipboard.writeText('${settingsUrl}');this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)"
-        style="padding:4px 10px;font-size:12px;min-width:52px;">Copy</button>
+        style="padding:4px 10px;font-size:0.75rem;min-width:52px;">Copy</button>
     </div>
-    <p style="color:var(--text-muted);font-size:11px;margin:8px 0 0;">Paste this into your Brave address bar, then enable "Use Google Services for Push Messaging" and restart Brave.</p>`;
+    <p style="color:var(--text-muted);font-size:0.6875rem;margin:8px 0 0;">Paste this into your Brave address bar, then enable "Use Google Services for Push Messaging" and restart Brave.</p>`;
   }
 
   // Detect permission denied and provide Chrome/Edge settings hints
   if (reason.includes('Permission denied') || reason.includes('permission was denied')) {
-    html += `<div style="margin-top:12px;font-size:12px;color:var(--text-secondary);line-height:1.6;">
+    html += `<div style="margin-top:12px;font-size:0.75rem;color:var(--text-secondary);line-height:1.6;">
       <strong>How to fix:</strong><br>
       \u2022 Click the lock/info icon in your address bar → Site settings → Notifications → Allow<br>
       \u2022 Or go to browser settings → Privacy → Site Settings → Notifications
@@ -887,7 +887,7 @@ _showPushError(reason) {
 
   // iOS standalone hint
   if (reason.includes('Add to Home Screen')) {
-    html += `<div style="margin-top:12px;font-size:12px;color:var(--text-secondary);line-height:1.6;">
+    html += `<div style="margin-top:12px;font-size:0.75rem;color:var(--text-secondary);line-height:1.6;">
       <strong>Steps:</strong><br>
       1. Tap the <strong>Share</strong> button (box with arrow) in Safari<br>
       2. Scroll down and tap <strong>"Add to Home Screen"</strong><br>

--- a/public/js/modules/app-media.js
+++ b/public/js/modules/app-media.js
@@ -259,7 +259,7 @@ _updateAvatarPreview() {
   } else {
     const color = this._getUserColor(this.user.username);
     const initial = this.user.username.charAt(0).toUpperCase();
-    preview.innerHTML = `<div style="background-color:${color};width:100%;height:100%;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:18px;color:white">${initial}</div>`;
+    preview.innerHTML = `<div style="background-color:${color};width:100%;height:100%;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:1.125rem;color:white">${initial}</div>`;
   }
 },
 
@@ -317,7 +317,7 @@ _setupAvatarUpload() {
       if (preview) {
         const color = this._getUserColor(this.user.username);
         const initial = this.user.username.charAt(0).toUpperCase();
-        preview.innerHTML = `<div style="background-color:${color};width:100%;height:100%;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:18px;color:white">${initial}</div>`;
+        preview.innerHTML = `<div style="background-color:${color};width:100%;height:100%;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:1.125rem;color:white">${initial}</div>`;
       }
       this._markAvatarUnsaved();
       return;
@@ -1045,7 +1045,7 @@ _popOutSoundboard() {
     </div>
     <div class="sb-pip-body">
       <div class="sound-search-row" style="padding:0;margin-bottom:0">
-        <input type="text" id="sb-pip-search" placeholder="Search sounds..." class="settings-text-input" style="flex:1;font-size:12px">
+        <input type="text" id="sb-pip-search" placeholder="Search sounds..." class="settings-text-input" style="flex:1;font-size:0.75rem">
       </div>
       <div id="sb-pip-grid" class="sb-pip-grid"></div>
     </div>
@@ -1922,7 +1922,7 @@ _renderStickerList(stickers) {
   });
   list.innerHTML = Object.keys(packs).sort().map(pack => `
     <div class="sticker-pack-group" style="margin-top:8px">
-      <div style="font-size:12px;font-weight:600;margin-bottom:4px;color:var(--text-secondary)">${this._escapeHtml(pack)}</div>
+      <div style="font-size:0.75rem;font-weight:600;margin-bottom:4px;color:var(--text-secondary)">${this._escapeHtml(pack)}</div>
       ${packs[pack].map(s => `
         <div class="custom-sound-item">
           <img src="${this._escapeHtml(s.url)}" alt=":${this._escapeHtml(s.name)}:" style="width:48px;height:48px;vertical-align:middle;margin-right:8px;object-fit:contain;border-radius:4px;background:var(--bg-secondary)">
@@ -2110,7 +2110,7 @@ _renderBotSidebar(webhooks) {
   sidebar.innerHTML = webhooks.map(wh => {
     const avatarHtml = wh.avatar_url
       ? `<img src="${this._escapeHtml(wh.avatar_url)}" style="width:20px;height:20px;border-radius:50%;object-fit:cover;flex-shrink:0">`
-      : `<span style="width:20px;height:20px;border-radius:50%;background:var(--accent);display:flex;align-items:center;justify-content:center;font-size:10px;flex-shrink:0;color:#fff">🤖</span>`;
+      : `<span style="width:20px;height:20px;border-radius:50%;background:var(--accent);display:flex;align-items:center;justify-content:center;font-size:0.625rem;flex-shrink:0;color:#fff">🤖</span>`;
     const activeClass = this._selectedBotId === wh.id ? ' active' : '';
     return `<div class="role-sidebar-item${activeClass}" data-bot-id="${wh.id}">${avatarHtml}<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${this._escapeHtml(wh.name)}</span></div>`;
   }).join('');
@@ -2141,7 +2141,7 @@ _showBotDetail(botId) {
       <label class="settings-label">${t('modals.bot_mgmt.avatar_label')}</label>
       <div class="bot-avatar-row" style="display:flex;align-items:center;gap:10px;margin-bottom:8px">
         <div class="bot-avatar-preview" style="width:48px;height:48px;border-radius:50%;overflow:hidden;border:2px solid var(--border);background:var(--bg-tertiary);flex-shrink:0;display:flex;align-items:center;justify-content:center">
-          ${wh.avatar_url ? `<img src="${this._escapeHtml(wh.avatar_url)}" style="width:100%;height:100%;object-fit:cover">` : '<span style="font-size:24px">🤖</span>'}
+          ${wh.avatar_url ? `<img src="${this._escapeHtml(wh.avatar_url)}" style="width:100%;height:100%;object-fit:cover">` : '<span style="font-size:1.5rem">🤖</span>'}
         </div>
         <div style="display:flex;flex-direction:column;gap:4px">
           <button class="btn-xs btn-accent" id="bot-upload-avatar-btn">📷 ${t('modals.bot_mgmt.upload_avatar_btn')}</button>
@@ -2164,20 +2164,20 @@ _showBotDetail(botId) {
 
       <label class="settings-label">${t('modals.bot_mgmt.webhook_url_label')}</label>
       <div style="display:flex;gap:4px;align-items:center;margin-bottom:8px">
-        <code style="flex:1;font-size:11px;padding:6px 8px;background:var(--bg-input);border-radius:4px;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${this._escapeHtml(webhookUrl)}</code>
+        <code style="flex:1;font-size:0.6875rem;padding:6px 8px;background:var(--bg-input);border-radius:4px;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${this._escapeHtml(webhookUrl)}</code>
         <button class="btn-xs" id="bot-detail-copy-url" title="${t('modals.bot_mgmt.copy_url_title')}">📋</button>
       </div>
 
       <label class="settings-label">${t('modals.bot_mgmt.token_label')}</label>
-      <div style="font-size:11px;font-family:monospace;padding:4px 8px;background:var(--bg-input);border-radius:4px;color:var(--text-muted);margin-bottom:12px">${maskedToken}</div>
+      <div style="font-size:0.6875rem;font-family:monospace;padding:4px 8px;background:var(--bg-input);border-radius:4px;color:var(--text-muted);margin-bottom:12px">${maskedToken}</div>
 
-      <label class="settings-label">📡 Callback URL <span style="font-size:10px;color:var(--text-muted)">(optional — Haven will POST messages to this URL)</span></label>
+      <label class="settings-label">📡 Callback URL <span style="font-size:0.625rem;color:var(--text-muted)">(optional — Haven will POST messages to this URL)</span></label>
       <input type="url" id="bot-detail-callback-url" value="${this._escapeHtml(wh.callback_url || '')}" placeholder="https://mybot.example.com/haven-events" class="settings-text-input" style="width:100%;margin-bottom:8px">
 
-      <label class="settings-label">🔑 Callback Secret <span style="font-size:10px;color:var(--text-muted)">(optional — used to sign payloads via X-Haven-Signature)</span></label>
+      <label class="settings-label">🔑 Callback Secret <span style="font-size:0.625rem;color:var(--text-muted)">(optional — used to sign payloads via X-Haven-Signature)</span></label>
       <input type="text" id="bot-detail-callback-secret" value="${this._escapeHtml(wh.callback_secret || '')}" placeholder="my-secret-key" class="settings-text-input" style="width:100%;margin-bottom:12px">
 
-      <label class="settings-label">🛡️ Moderation <span style="font-size:10px;color:var(--text-muted)">(admin only — let this bot kick / ban / mute users via REST API)</span></label>
+      <label class="settings-label">🛡️ Moderation <span style="font-size:0.625rem;color:var(--text-muted)">(admin only — let this bot kick / ban / mute users via REST API)</span></label>
       <label class="toggle-row" style="margin-bottom:12px">
         <input type="checkbox" id="bot-detail-can-moderate" ${wh.can_moderate ? 'checked' : ''} ${this.user && this.user.isAdmin ? '' : 'disabled'}>
         <span>Allow this bot to perform moderation actions</span>
@@ -2343,25 +2343,40 @@ _setupToggleStylePicker() {
 
 // ── Font Size Picker ──
 
-_setupFontSizePicker() {
-  const picker = document.getElementById('font-size-picker');
-  if (!picker) return;
+// ── Interface Zoom slider ──
+// Scales the whole UI by setting the root font-size through --ui-scale (a
+// percentage). Everything is sized in rem, so one change rescales the entire
+// interface crisply and the layout reflows — no CSS zoom/transform.
+_setupZoomSlider() {
+  const slider = document.getElementById('ui-zoom-slider');
+  if (!slider) return;
+  const label = document.getElementById('ui-zoom-value');
+  const outBtn = document.getElementById('zoom-out-btn');
+  const inBtn = document.getElementById('zoom-in-btn');
 
-  const saved = localStorage.getItem('haven-fontsize') || 'normal';
-  document.documentElement.dataset.fontsize = saved;
-  picker.querySelectorAll('[data-fontsize]').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.fontsize === saved);
-  });
+  const MIN = parseInt(slider.min, 10) || 70;
+  const MAX = parseInt(slider.max, 10) || 150;
+  const STEP = parseInt(slider.step, 10) || 5;
+  const clamp = (n) => Math.min(MAX, Math.max(MIN, n));
 
-  picker.addEventListener('click', (e) => {
-    const btn = e.target.closest('[data-fontsize]');
-    if (!btn) return;
-    const size = btn.dataset.fontsize;
-    document.documentElement.dataset.fontsize = size;
-    localStorage.setItem('haven-fontsize', size);
-    picker.querySelectorAll('[data-fontsize]').forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-  });
+  // Starting value: saved scale, else migrate the old 4-tier setting, else 100.
+  const LEGACY = { small: 85, normal: 100, large: 118, 'x-large': 138 };
+  let pct = parseInt(localStorage.getItem('haven-zoom'), 10);
+  if (!pct) pct = LEGACY[localStorage.getItem('haven-fontsize')] || 100;
+  pct = clamp(pct);
+
+  const apply = (value, persist) => {
+    pct = clamp(value);
+    document.documentElement.style.setProperty('--ui-scale', pct + '%');
+    slider.value = pct;
+    if (label) label.textContent = pct + '%';
+    if (persist) localStorage.setItem('haven-zoom', pct);
+  };
+
+  apply(pct, false);
+  slider.addEventListener('input', () => apply(parseInt(slider.value, 10) || 100, true));
+  outBtn?.addEventListener('click', () => apply(pct - STEP, true));
+  inBtn?.addEventListener('click', () => apply(pct + STEP, true));
 },
 
 // ── Emoji Reaction Size Picker ──

--- a/public/js/modules/app-platform.js
+++ b/public/js/modules/app-platform.js
@@ -288,13 +288,13 @@ _initWelcomePopups() {
     const remaining = queue.length - idx - 1;
     const footer = document.createElement('div');
     footer.className = 'haven-welcome-queue-footer';
-    footer.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:14px;padding-top:12px;border-top:1px solid var(--border, rgba(255,255,255,0.08));font-size:12px;color:var(--text-muted, #888);';
+    footer.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:14px;padding-top:12px;border-top:1px solid var(--border, rgba(255,255,255,0.08));font-size:0.75rem;color:var(--text-muted, #888);';
     const isLast = remaining === 0;
     footer.innerHTML = `
       <span class="haven-welcome-queue-pos">${idx + 1} of ${queue.length}</span>
       <span style="display:flex;align-items:center;gap:8px;">
-        ${queue.length > 1 && !isLast ? `<button type="button" class="haven-welcome-queue-skip" style="background:none;border:none;color:var(--text-muted, #888);text-decoration:underline;cursor:pointer;font-size:12px;padding:4px 8px;">Skip all</button>` : ''}
-        <button type="button" class="haven-welcome-queue-next" style="background:var(--accent, #5865f2);color:#fff;border:none;border-radius:6px;padding:6px 14px;cursor:pointer;font-size:12px;font-weight:600;">${isLast ? 'Done' : 'Next'}</button>
+        ${queue.length > 1 && !isLast ? `<button type="button" class="haven-welcome-queue-skip" style="background:none;border:none;color:var(--text-muted, #888);text-decoration:underline;cursor:pointer;font-size:0.75rem;padding:4px 8px;">Skip all</button>` : ''}
+        <button type="button" class="haven-welcome-queue-next" style="background:var(--accent, #5865f2);color:#fff;border:none;border-radius:6px;padding:6px 14px;cursor:pointer;font-size:0.75rem;font-weight:600;">${isLast ? 'Done' : 'Next'}</button>
       </span>
     `;
     // Find the deepest single-child div to append into; falls back gracefully
@@ -1149,10 +1149,10 @@ async _showE2EVerification() {
     overlay.innerHTML = `
       <div class="modal" style="max-width:420px;text-align:center">
         <h3 style="margin-bottom:8px">🔐 ${t('header.verify_encryption')}</h3>
-        <p style="font-size:13px;color:var(--text-muted);margin-bottom:16px">
+        <p style="font-size:0.8125rem;color:var(--text-muted);margin-bottom:16px">
           ${t('modals.e2e_verify.desc', { name: this._escapeHtml(partnerName) })}
         </p>
-        <div class="e2e-safety-number" style="font-family:monospace;font-size:18px;letter-spacing:2px;line-height:2;padding:16px;background:var(--bg-secondary);border-radius:var(--radius-md);border:1px solid var(--border);user-select:all;word-break:break-all">${code}</div>
+        <div class="e2e-safety-number" style="font-family:monospace;font-size:1.125rem;letter-spacing:2px;line-height:2;padding:16px;background:var(--bg-secondary);border-radius:var(--radius-md);border:1px solid var(--border);user-select:all;word-break:break-all">${code}</div>
         <div style="margin-top:16px;display:flex;gap:8px;justify-content:center">
           <button class="btn-sm btn-accent" id="e2e-copy-code-btn">${t('modals.e2e_verify.copy_btn')}</button>
           <button class="btn-sm" id="e2e-close-verify-btn">${t('modals.common.close')}</button>
@@ -1214,7 +1214,7 @@ _showE2EResetConfirmation() {
         ${t('modals.e2e_reset.warning_permanent')}
       </div>
       <div class="e2e-confirm-type">
-        <p style="font-size:13px;color:var(--text-muted);margin-bottom:8px">${t('modals.e2e_reset.type_confirm')}</p>
+        <p style="font-size:0.8125rem;color:var(--text-muted);margin-bottom:8px">${t('modals.e2e_reset.type_confirm')}</p>
         <input type="text" id="e2e-reset-confirm-input" placeholder="${t('modals.e2e_reset.confirm_placeholder')}" autocomplete="off" spellcheck="false">
       </div>
       <div class="e2e-reset-actions">

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -5714,7 +5714,7 @@ _renderMobileServerList() {
   if (!list || !this.serverManager) return;
   const servers = this.serverManager.getAll();
   if (servers.length === 0) {
-    list.innerHTML = `<div style="padding:8px 10px;color:var(--text-muted);font-size:12px;">${t('servers.no_servers')}</div>`;
+    list.innerHTML = `<div style="padding:8px 10px;color:var(--text-muted);font-size:0.75rem;">${t('servers.no_servers')}</div>`;
     return;
   }
   list.innerHTML = servers.map(s => {

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -1043,7 +1043,7 @@ _showExternalLinkWarning(displayText, url) {
       <div class="risky-download-icon">🔗</div>
       <h3 style="color:var(--text-primary,#dbdee1)">External Link</h3>
       <p>You're about to visit:</p>
-      <p style="background:var(--bg-tertiary,#232428);padding:8px 12px;border-radius:6px;font-size:13px;word-break:break-all;color:var(--accent,#5865f2)">${this._escapeHtml(url)}</p>
+      <p style="background:var(--bg-tertiary,#232428);padding:8px 12px;border-radius:6px;font-size:0.8125rem;word-break:break-all;color:var(--accent,#5865f2)">${this._escapeHtml(url)}</p>
       <p class="risky-download-desc">Make sure you trust this link before continuing.</p>
       <div class="risky-download-actions">
         <button class="risky-download-cancel">Cancel</button>
@@ -1244,7 +1244,7 @@ _toggleEmojiPicker(anchorEl) {
         list = stickers.filter(s => (s.pack_name || 'General') === self._activeStickerPack);
       }
       if (list.length === 0) {
-        grid.innerHTML = `<p class="muted-text" style="padding:12px;font-size:12px;width:100%;text-align:center">${
+        grid.innerHTML = `<p class="muted-text" style="padding:12px;font-size:0.75rem;width:100%;text-align:center">${
           stickers.length === 0
             ? (t('emoji.no_stickers') || 'No stickers yet — an admin can upload some from the Manage Stickers panel')
             : (t('emoji.no_results') || 'No results')
@@ -1459,7 +1459,7 @@ _toggleEmojiPicker(anchorEl) {
         });
       }
       if (matched.size === 0) {
-        grid.innerHTML = `<p class="muted-text" style="padding:12px;font-size:12px;width:100%;text-align:center">${t('emoji.no_results')}</p>`;
+        grid.innerHTML = `<p class="muted-text" style="padding:12px;font-size:0.75rem;width:100%;text-align:center">${t('emoji.no_results')}</p>`;
         return;
       }
       const results = document.createElement('div');
@@ -2198,7 +2198,7 @@ _showQuickEmojiEditor(picker, msgEl, msgId) {
 
   const hint = document.createElement('p');
   hint.className = 'muted-text';
-  hint.style.cssText = 'font-size:11px;padding:0 8px 6px;margin:0';
+  hint.style.cssText = 'font-size:0.6875rem;padding:0 8px 6px;margin:0';
   hint.textContent = t('emoji.customize_quick_hint');
   editor.appendChild(hint);
 

--- a/public/js/theme-init.js
+++ b/public/js/theme-init.js
@@ -32,6 +32,19 @@
     document.documentElement.setAttribute('data-toggle-style', 'switch');
   }
 
+  // Apply the saved interface scale before first paint so the UI doesn't render
+  // at 100% and then jump. Mirrors the slider logic in app-media.js and
+  // migrates the retired 4-tier font-size setting.
+  try {
+    var _z = parseInt(localStorage.getItem('haven-zoom'), 10);
+    if (!_z) {
+      var _legacyZoom = { small: 85, normal: 100, large: 118, 'x-large': 138 };
+      _z = _legacyZoom[localStorage.getItem('haven-fontsize')] || 100;
+    }
+    _z = Math.min(150, Math.max(70, _z));
+    document.documentElement.style.setProperty('--ui-scale', _z + '%');
+  } catch (e) {}
+
   var t = localStorage.getItem('haven_theme');
   if (t) {
     if (t.indexOf('file:') === 0) {


### PR DESCRIPTION
## Rem interface zoom

Replaces the four fixed font-size tiers (Small/Normal/Large/XL) with a Zoom slider that scales the **entire** UI

### Why
The old font size buttons only touched enumerated text elements, so most of the UI (server rail, sidebars, icons, spacing) never scaled properly

### How
- A Zoom slider (70–150%) drives the root `font-size` via `--ui-scale`. Because everything is sized in `rem`, one root change rescales text, spacing, avatars, the server rail, sidebars, headers, and icons together. And the flex layout **reflows** instead of running off screen. 
- Converted the remaining fixedpx chrome to rem (layout width vars, server rail, sidebars, icon boxes, structural padding/gaps). Media query breakpoints, borders, shadows, and positioning offsets deliberately stay in px.
- Density stays its own independent axis (rem spacing tokens).
- Zoom is applied pre-paint in `theme-init.js` (no flash on load), persists to `localStorage`, and migrates anyone's old small/normal/large/x-large setting to the equivalent scale.

### Notes
- At 100% the UI is pixel-identical to before — this is non-destructive at the default.