### PR TITLE
Fix silent crash on launch (swallowed bind errors), allow Node 24, and add opt-in Braid themes + layout plugin

### DIFF
--- a/Start Haven.bat
+++ b/Start Haven.bat
@@ -70,19 +70,18 @@ exit /b 1
 for /f "tokens=1 delims=v." %%v in ('node -v 2^>nul') do set "NODE_MAJOR=%%v"
 echo  [OK] Node.js found: & node -v
 
-:: Warn if Node major version is too new (native modules won't have prebuilts)
+:: Warn if Node major version is very new (native modules may lack prebuilts).
+:: Don't hard-refuse on a version number — Node 24 is the current LTS and
+:: better-sqlite3 ships prebuilts for it.  The real gate is the functional
+:: native-module load check after npm install below.
 if defined NODE_MAJOR (
-    if %NODE_MAJOR% GEQ 24 (
+    if %NODE_MAJOR% GEQ 25 (
         color 0E
         echo.
-        echo  [!] WARNING: Node.js v%NODE_MAJOR% detected. Haven requires Node 18-22.
-        echo      Native modules like better-sqlite3 may not have prebuilt
-        echo      binaries yet, causing build failures.
+        echo  [!] WARNING: Node.js v%NODE_MAJOR% detected. Haven is tested on Node 18-24.
+        echo      If the native module check fails below, install
+        echo      Node.js 24 LTS from https://nodejs.org
         echo.
-        echo      Please install Node.js 22 LTS from https://nodejs.org
-        echo.
-        pause
-        exit /b 1
     )
 )
 
@@ -94,6 +93,18 @@ if %ERRORLEVEL% NEQ 0 (
     color 0C
     echo.
     echo  [ERROR] npm install failed. Check the errors above.
+    echo.
+    pause
+    exit /b 1
+)
+:: Verify native modules actually load on this Node version (the honest
+:: compatibility test — version-number guessing refuses working setups).
+node -e "require('better-sqlite3')" >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    color 0C
+    echo.
+    echo  [ERROR] The better-sqlite3 native module failed to load on Node v%NODE_MAJOR%.
+    echo          Install Node.js 24 LTS from https://nodejs.org and try again.
     echo.
     pause
     exit /b 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haven",
-  "version": "3.31.2",
+  "version": "3.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haven",
-      "version": "3.31.2",
+      "version": "3.39.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "adm-zip": "^0.5.16",
@@ -30,7 +30,7 @@
         "innosetup-compiler": "^6.3.1"
       },
       "engines": {
-        "node": ">=18.0.0 <24.0.0"
+        "node": ">=18.0.0 <25.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0",
   "main": "server.js",
   "engines": {
-    "node": ">=18.0.0 <24.0.0"
+    "node": ">=18.0.0 <25.0.0"
   },
   "scripts": {
     "start": "node server.js",

--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -1,0 +1,440 @@
+/**
+ * @name Braid Layout
+ * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, tucks header extras into a kebab menu, and calms the chrome. Pairs with the Braid / Braid Light themes.
+ * @author Amnibro
+ * @version 1.0
+ */
+class BraidLayout {
+  start() {
+    this._hidden = new Map();          // el -> { display, hadHidden }
+    this._lsPrev = new Map();          // localStorage key -> previous value (null = absent)
+    this._listeners = [];              // [target, type, fn, opts]
+    this._collapsedAdded = [];         // elements we added a class to
+    HavenApi.DOM.addStyle('BraidLayoutCSS', BraidLayout._LAYOUT_CSS);
+    HavenApi.DOM.addStyle('BraidShapeCSS', BraidLayout._SHAPE_CSS);
+    HavenApi.DOM.addStyle('BraidMotionCSS', BraidLayout._MOTION_CSS);
+    document.documentElement.setAttribute('data-braid-layout', '1');
+    this._collapseJoinCreate();
+    this._setPeopleOpen(false);
+    this._buildMoreMenu();
+    this._applyLayout();
+    let scheduled = false;
+    let applying = false;
+    // childList-only observer: _applyLayout mutates style/attributes and its
+    // one-time builds are idempotent, so the observer can't feed back on itself.
+    this._obs = new MutationObserver(() => {
+      if (applying || scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(() => {
+        scheduled = false;
+        if (applying) return;
+        applying = true;
+        try { this._applyLayout(); }
+        finally { applying = false; }
+      });
+    });
+    this._obs.observe(document.getElementById('app-body') || document.body, { childList: true, subtree: true });
+    console.log('[BraidLayout] Started');
+  }
+
+  stop() {
+    if (this._obs) { this._obs.disconnect(); this._obs = null; }
+    // Unfold the server rail back to its own column
+    const bar = document.getElementById('server-bar');
+    const strip = document.getElementById('braid-server-strip');
+    if (bar && strip) {
+      while (strip.firstChild) bar.appendChild(strip.firstChild);
+      delete bar.dataset.braidFolded;
+      bar.removeAttribute('aria-hidden');
+    }
+    strip?.remove();
+    document.querySelector('.braid-more-wrap')?.remove();
+    document.getElementById('braid-apps-drawer')?.remove();
+    // Restore everything we hid
+    for (const [el, prev] of this._hidden) {
+      el.style.display = prev.display;
+      if (!prev.hadHidden) el.removeAttribute('hidden');
+    }
+    this._hidden.clear();
+    // Restore the right sidebar to interactive state
+    const right = document.getElementById('right-sidebar');
+    if (right) { right.style.display = ''; right.style.width = ''; right.style.opacity = ''; right.style.pointerEvents = ''; }
+    // Undo collapse classes we added (leave ones the user already had)
+    for (const [el, cls] of this._collapsedAdded) el.classList.remove(cls);
+    this._collapsedAdded = [];
+    // Restore localStorage keys we introduced
+    for (const [key, prev] of this._lsPrev) {
+      try { prev === null ? localStorage.removeItem(key) : localStorage.setItem(key, prev); } catch {}
+    }
+    this._lsPrev.clear();
+    for (const [t, type, fn, opts] of this._listeners) t.removeEventListener(type, fn, opts);
+    this._listeners = [];
+    document.documentElement.classList.remove('braid-people-open', 'braid-sound-open', 'braid-status-open');
+    document.documentElement.removeAttribute('data-braid-layout');
+    HavenApi.DOM.removeStyle('BraidLayoutCSS');
+    HavenApi.DOM.removeStyle('BraidMotionCSS');
+    HavenApi.DOM.removeStyle('BraidShapeCSS');
+    console.log('[BraidLayout] Stopped');
+  }
+
+  _listen(target, type, fn, opts) {
+    target.addEventListener(type, fn, opts);
+    this._listeners.push([target, type, fn, opts]);
+  }
+
+  _setLS(key, value) {
+    try {
+      if (!this._lsPrev.has(key)) this._lsPrev.set(key, localStorage.getItem(key));
+      localStorage.setItem(key, value);
+    } catch {}
+  }
+
+  _hide(el) {
+    if (!el) return;
+    if (!this._hidden.has(el)) this._hidden.set(el, { display: el.style.display === 'none' ? '' : el.style.display, hadHidden: el.hasAttribute('hidden') });
+    if (el.style.display !== 'none') el.style.display = 'none';
+    if (!el.hasAttribute('hidden')) el.setAttribute('hidden', '');
+  }
+
+  _addClass(el, cls) {
+    if (!el || el.classList.contains(cls)) return;
+    el.classList.add(cls);
+    this._collapsedAdded.push([el, cls]);
+  }
+
+  _foldServersIntoSidebar() {
+    const bar = document.getElementById('server-bar');
+    const sidebar = document.querySelector('.sidebar');
+    if (!bar || !sidebar || bar.dataset.braidFolded === '1') return;
+    let strip = sidebar.querySelector('.braid-server-strip');
+    if (!strip) {
+      strip = document.createElement('div');
+      strip.className = 'braid-server-strip';
+      strip.id = 'braid-server-strip';
+      const header = sidebar.querySelector('.sidebar-header');
+      if (header) sidebar.insertBefore(strip, header);
+      else sidebar.prepend(strip);
+    }
+    while (bar.firstChild) strip.appendChild(bar.firstChild);
+    bar.dataset.braidFolded = '1';
+    bar.setAttribute('aria-hidden', 'true');
+  }
+
+  _collapseJoinCreate() {
+    if (localStorage.getItem('haven_join_collapsed') === null) this._setLS('haven_join_collapsed', '1');
+    if (localStorage.getItem('haven_create_collapsed') === null) this._setLS('haven_create_collapsed', '1');
+    document.querySelectorAll('#join-section-body, #create-section-body').forEach((el) => this._addClass(el, 'collapsed'));
+    document.querySelectorAll('#join-section-arrow, #create-section-arrow').forEach((el) => this._addClass(el, 'collapsed'));
+    document.querySelectorAll('.sidebar-section[data-mod-id="join"], #admin-controls').forEach((s) => this._addClass(s, 'braid-collapsed'));
+  }
+
+  _hideEdgeChrome() {
+    // Banners are inline-hidden (their features live in the kebab menu).
+    // Soundboard and status bar are hidden by CSS only, so the kebab
+    // toggles can bring them back via the braid-sound-open /
+    // braid-status-open classes.
+    ['desktop-app-banner', 'android-beta-banner', 'update-banner', 'sidebar-toggle-btn'].forEach((id) => {
+      this._hide(document.getElementById(id));
+    });
+    document.querySelectorAll('.sidebar-collapse-btn').forEach((el) => this._hide(el));
+    if (!document.documentElement.classList.contains('braid-people-open')) {
+      const right = document.getElementById('right-sidebar');
+      if (right) {
+        this._addClass(right, 'collapsed');
+        if (right.style.display !== 'none') right.style.display = 'none';
+      }
+    }
+    this._setLS('haven_hide_desktop_banner', '1');
+    this._setLS('haven_hide_android_banner', '1');
+    this._setLS('haven_members_collapsed', '1');
+  }
+
+  _setPeopleOpen(open) {
+    document.documentElement.classList.toggle('braid-people-open', !!open);
+    const right = document.getElementById('right-sidebar');
+    if (!right) return;
+    if (open) {
+      right.classList.remove('collapsed');
+      right.style.display = '';
+      right.style.width = '';
+      right.style.opacity = '';
+      right.style.pointerEvents = '';
+    } else {
+      this._addClass(right, 'collapsed');
+      if (right.style.display !== 'none') right.style.display = 'none';
+    }
+  }
+
+  _buildMoreMenu() {
+    const header = document.querySelector('.channel-header');
+    if (!header || header.querySelector('.braid-more-wrap')) return;
+    const wrap = document.createElement('div');
+    wrap.className = 'braid-more-wrap';
+    wrap.innerHTML =
+      '<button type="button" class="braid-more-btn" id="braid-more-btn" title="More" aria-label="More">' +
+      '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">' +
+      '<circle cx="12" cy="5" r="1.2"/><circle cx="12" cy="12" r="1.2"/><circle cx="12" cy="19" r="1.2"/></svg></button>' +
+      '<div class="braid-more-menu" id="braid-more-menu" role="menu"></div>';
+    const voice = header.querySelector('.voice-controls');
+    if (voice) header.insertBefore(wrap, voice);
+    else header.appendChild(wrap);
+    const menu = wrap.querySelector('#braid-more-menu');
+    const btn = wrap.querySelector('#braid-more-btn');
+    const addItem = (label, onClick, muted) => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.innerHTML = muted ? `${label} <span class="muted">${muted}</span>` : label;
+      b.addEventListener('click', () => { menu.classList.remove('open'); onClick(); });
+      menu.appendChild(b);
+    };
+    const toggleHtmlClass = (cls) => document.documentElement.classList.toggle(cls);
+    addItem('People & voice', () => this._setPeopleOpen(!document.documentElement.classList.contains('braid-people-open')), 'right panel');
+    addItem('Soundboard', () => toggleHtmlClass('braid-sound-open'), 'toggle');
+    addItem('Status bar', () => toggleHtmlClass('braid-status-open'), 'debug footer');
+    [
+      { id: 'search-toggle-btn', label: 'Search messages' },
+      { id: 'pinned-toggle-btn', label: 'Pinned messages' },
+      { id: 'gallery-toggle-btn', label: 'Files & media' },
+      { id: 'copy-code-btn', label: 'Copy channel code' },
+      { id: 'channel-code-settings-btn', label: 'Channel code settings' },
+      { id: 'e2e-menu-btn', label: 'Encryption' },
+    ].forEach((it) => {
+      const src = document.getElementById(it.id);
+      if (!src) return;
+      addItem(it.label, () => src.click());
+    });
+    const desktopBanner = document.getElementById('desktop-app-banner');
+    if (desktopBanner) addItem('Desktop app', () => (desktopBanner.querySelector('a') || desktopBanner).click(), 'download');
+    const androidBanner = document.getElementById('android-beta-banner');
+    if (androidBanner) addItem('Android app', () => androidBanner.click(), 'download');
+    addItem('Settings', () => {
+      document.getElementById('open-settings-btn')?.click();
+      document.getElementById('mobile-settings-btn')?.click();
+    });
+    const peopleHdr = document.getElementById('mobile-users-btn');
+    if (peopleHdr) {
+      this._listen(peopleHdr, 'click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this._setPeopleOpen(!document.documentElement.classList.contains('braid-people-open'));
+      }, true);
+    }
+    const sideMembers = document.getElementById('sidebar-members-btn');
+    if (sideMembers) {
+      if (sideMembers.style.display === 'none') sideMembers.style.display = '';
+      this._listen(sideMembers, 'click', (e) => {
+        e.preventDefault();
+        this._setPeopleOpen(!document.documentElement.classList.contains('braid-people-open'));
+      });
+    }
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      menu.classList.toggle('open');
+    });
+    this._listen(document, 'click', (e) => {
+      if (!wrap.contains(e.target)) menu.classList.remove('open');
+    });
+  }
+
+  _quietChips() {
+    const vc = document.querySelector('.voice-controls');
+    if (!vc) return;
+    vc.querySelectorAll('button, .pill, .chip, span, div').forEach((el) => {
+      const t = (el.textContent || '').toLowerCase();
+      if (t.includes('get the desktop') || t.includes('android app')) this._hide(el);
+    });
+  }
+
+  _applyLayout() {
+    this._foldServersIntoSidebar();
+    this._hideEdgeChrome();
+    this._quietChips();
+  }
+}
+
+BraidLayout._LAYOUT_CSS = `
+html[data-braid-layout="1"]{--sidebar-width:17.5rem;--braid-bar-h:3.25rem}
+html[data-braid-layout="1"] body,
+html[data-braid-layout="1"] #app{overflow:hidden}
+html[data-braid-layout="1"] #app-body{display:flex!important;flex-direction:row!important;min-height:0;height:100%}
+html[data-braid-layout="1"] .server-bar{display:none!important}
+html[data-braid-layout="1"] .sidebar{width:var(--sidebar-width)!important;min-width:15rem!important;max-width:21.25rem!important;flex:0 0 var(--sidebar-width)!important;background:var(--bg-secondary)!important;border-right:1px solid var(--border)!important;display:flex!important;flex-direction:column!important;position:relative;z-index:5}
+html[data-braid-layout="1"] .braid-server-strip{display:flex;align-items:center;gap:.375rem;padding:.625rem .625rem .5rem;overflow-x:auto;border-bottom:1px solid var(--border);flex-shrink:0;scrollbar-width:thin}
+html[data-braid-layout="1"] .braid-server-strip .server-icon{width:2.25rem!important;height:2.25rem!important;min-width:2.25rem;border-radius:.6875rem!important;flex-shrink:0;position:relative}
+html[data-braid-layout="1"] .braid-server-strip .server-separator{display:none}
+html[data-braid-layout="1"] .sidebar-header{order:0;padding:.625rem .75rem!important;border-bottom:1px solid var(--border)!important;background:color-mix(in srgb,var(--bg-secondary) 92%,transparent)!important;backdrop-filter:saturate(180%) blur(14px);-webkit-backdrop-filter:saturate(180%) blur(14px)}
+html[data-braid-layout="1"] .brand{margin-bottom:.5rem!important;gap:.5rem!important}
+html[data-braid-layout="1"] .brand-text{font-size:.9375rem!important;font-weight:650!important;letter-spacing:-.03em!important;text-transform:none!important}
+html[data-braid-layout="1"] .user-bar{border-radius:.75rem!important;padding:.5rem .625rem!important;gap:.5rem!important;background:var(--bg-tertiary)!important;border:1px solid var(--border)!important}
+html[data-braid-layout="1"] .sidebar-mod-container{order:1;flex:1;min-height:0;overflow:auto;display:flex;flex-direction:column;padding:2px 0 .375rem}
+html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"],
+html[data-braid-layout="1"] .sidebar-section#admin-controls{order:3;border:0!important;padding:2px .625rem!important;margin:0!important}
+html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"] .section-label,
+html[data-braid-layout="1"] .sidebar-section#admin-controls .section-label{font-size:.71875rem!important;letter-spacing:0!important;text-transform:none!important;font-weight:550!important;color:var(--text-muted)!important;margin:2px 0!important;padding:.4375rem .5rem;border-radius:.625rem}
+html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"] .section-label:hover,
+html[data-braid-layout="1"] .sidebar-section#admin-controls .section-label:hover{background:var(--bg-hover);color:var(--text-primary)}
+html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"].braid-collapsed .collapsible-section-body,
+html[data-braid-layout="1"] .sidebar-section#admin-controls.braid-collapsed .collapsible-section-body,
+html[data-braid-layout="1"] #join-section-body.collapsed,
+html[data-braid-layout="1"] #create-section-body.collapsed{display:none!important}
+html[data-braid-layout="1"] .sidebar-split{order:1;flex:1;min-height:0;display:flex;flex-direction:column;border:0!important}
+html[data-braid-layout="1"] .channel-section{flex:1;min-height:0;padding:2px .375rem .375rem!important;border:0!important}
+html[data-braid-layout="1"] .dm-section-pane{flex:0 0 auto;max-height:28%;padding:2px .375rem .375rem!important;border-top:1px solid var(--border)!important}
+html[data-braid-layout="1"] .section-label.channels-toggle,
+html[data-braid-layout="1"] .section-label.dm-section-label{font-size:.625rem!important;font-weight:650!important;letter-spacing:.12em!important;text-transform:uppercase!important;color:var(--text-muted)!important;margin:.5rem .5rem .25rem!important}
+html[data-braid-layout="1"] .channel-item{margin:1px .375rem!important;padding:.5rem .625rem!important;border-radius:.625rem!important}
+html[data-braid-layout="1"] .channel-item.active{background:var(--bg-active)!important}
+html[data-braid-layout="1"] .sidebar-bottom{order:4;border-top:1px solid var(--border)!important;background:var(--bg-secondary)!important;flex-shrink:0}
+html[data-braid-layout="1"] .sidebar-bottom-bar{padding:.5rem!important;gap:2px!important;display:flex;align-items:center}
+html[data-braid-layout="1"] .sidebar-bottom-btn{width:2.125rem;height:2.125rem;border-radius:.625rem!important;border:0!important;background:transparent!important;color:var(--text-muted)!important}
+html[data-braid-layout="1"] .sidebar-bottom-btn:hover{background:var(--bg-hover)!important;color:var(--text-primary)!important}
+html[data-braid-layout="1"] .theme-popup{position:fixed!important;left:1rem!important;bottom:4rem!important;top:auto!important;right:auto!important;width:min(18.75rem,calc(100vw - 2.5rem))!important;max-height:min(60vh,30rem)!important;overflow:auto!important;z-index:80!important;border-radius:1rem!important;border:1px solid var(--border)!important;box-shadow:0 16px 48px -12px rgba(0,0,0,.28),var(--braid-shadow,0 1px 2px rgba(0,0,0,.2))!important;background:var(--bg-card)!important;padding:.75rem!important}
+html[data-braid-layout="1"] .main{flex:1!important;min-width:0!important;display:flex!important;flex-direction:column!important;background:var(--bg-primary)!important;position:relative}
+html[data-braid-layout="1"] .channel-header{flex:0 0 var(--braid-bar-h)!important;min-height:var(--braid-bar-h)!important;max-height:var(--braid-bar-h)!important;padding:0 .75rem 0 1rem!important;gap:.375rem!important;overflow:hidden;display:flex;align-items:center!important;background:color-mix(in srgb,var(--bg-secondary) 90%,transparent)!important;backdrop-filter:saturate(180%) blur(16px)!important;-webkit-backdrop-filter:saturate(180%) blur(16px)!important;border-bottom:1px solid var(--border)!important}
+html[data-braid-layout="1"] #channel-header-name{font-size:.90625rem!important;font-weight:650!important;letter-spacing:-.02em!important;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:min(40vw,20rem)}
+html[data-braid-layout="1"] .header-actions-box{display:flex!important;align-items:center;gap:2px!important;padding:0!important;border:0!important;background:transparent!important}
+html[data-braid-layout="1"] .header-actions-box .channel-code-tag,
+html[data-braid-layout="1"] .header-actions-box #copy-code-btn,
+html[data-braid-layout="1"] .header-actions-box #channel-code-settings-btn,
+html[data-braid-layout="1"] .header-actions-box .header-actions-divider{display:none!important}
+html[data-braid-layout="1"] .header-actions-box .icon-btn{width:2.125rem;height:2.125rem;border-radius:.625rem;color:var(--text-muted)}
+html[data-braid-layout="1"] .header-actions-box .icon-btn:hover{background:var(--bg-hover);color:var(--text-primary)}
+html[data-braid-layout="1"] #desktop-app-banner,
+html[data-braid-layout="1"] #android-beta-banner,
+html[data-braid-layout="1"] #update-banner{display:none!important;visibility:hidden!important;pointer-events:none!important;width:0!important;height:0!important;overflow:hidden!important;margin:0!important;padding:0!important}
+html[data-braid-layout="1"] .voice-controls{display:flex;align-items:center;gap:.25rem;margin-left:auto;flex-shrink:0}
+html[data-braid-layout="1"] .voice-active-indicator,
+html[data-braid-layout="1"] .btn-voice{border-radius:999px!important;border:1px solid var(--border)!important;background:var(--bg-tertiary)!important;color:var(--text-secondary)!important;font-size:.75rem!important;font-weight:550!important;padding:.25rem .625rem!important;box-shadow:none!important}
+html[data-braid-layout="1"] .voice-active-indicator{background:color-mix(in srgb,var(--accent) 10%,var(--bg-tertiary))!important;border-color:color-mix(in srgb,var(--accent) 28%,var(--border))!important;color:var(--accent)!important}
+html[data-braid-layout="1"] .voice-controls button[style*="background"],
+html[data-braid-layout="1"] .voice-controls div[style*="background"],
+html[data-braid-layout="1"] .voice-controls span[style*="background"]{background:var(--bg-tertiary)!important;color:var(--text-secondary)!important;border:1px solid var(--border)!important;border-radius:999px!important;box-shadow:none!important}
+html[data-braid-layout="1"] .message-area{flex:1;min-height:0;display:flex;flex-direction:column}
+html[data-braid-layout="1"] .messages{padding:1.125rem 1.75rem .5rem!important;width:100%;box-sizing:border-box}
+html[data-braid-layout="1"] .message-input-area,
+html[data-braid-layout="1"] .message-input-container{padding:.625rem 1.25rem .875rem!important;width:100%;box-sizing:border-box;border-top:1px solid var(--border)!important;background:color-mix(in srgb,var(--bg-secondary) 94%,transparent)!important}
+html[data-braid-layout="1"] .right-sidebar,
+html[data-braid-layout="1"] .right-sidebar.collapsed,
+html[data-braid-layout="1"] #right-sidebar{display:none!important;width:0!important;min-width:0!important;max-width:0!important;border:0!important;opacity:0!important;pointer-events:none!important;overflow:hidden!important}
+html[data-braid-layout="1"].braid-people-open .right-sidebar,
+html[data-braid-layout="1"].braid-people-open #right-sidebar{display:flex!important;width:var(--right-width,16.25rem)!important;min-width:12.5rem!important;max-width:22.5rem!important;opacity:1!important;pointer-events:auto!important;overflow:hidden!important;background:var(--bg-secondary)!important;border-left:1px solid var(--border)!important;flex:0 0 auto!important}
+html[data-braid-layout="1"] .sidebar-collapse-btn,
+html[data-braid-layout="1"] #sidebar-toggle-btn,
+html[data-braid-layout="1"] .status-bar,
+html[data-braid-layout="1"] #status-bar,
+html[data-braid-layout="1"] .status-bar-toggle-tab,
+html[data-braid-layout="1"] #status-bar-toggle,
+html[data-braid-layout="1"] #soundboard-sidebar,
+html[data-braid-layout="1"] .soundboard-sidebar{display:none!important;visibility:hidden!important;pointer-events:none!important}
+html[data-braid-layout="1"].braid-sound-open #soundboard-sidebar,
+html[data-braid-layout="1"].braid-sound-open .soundboard-sidebar{display:flex!important;visibility:visible!important;pointer-events:auto!important}
+html[data-braid-layout="1"].braid-status-open .status-bar,
+html[data-braid-layout="1"].braid-status-open #status-bar{display:flex!important;visibility:visible!important;pointer-events:auto!important}
+html[data-braid-layout="1"] .braid-more-wrap{position:relative}
+html[data-braid-layout="1"] .braid-more-btn{width:2.125rem;height:2.125rem;border:0;border-radius:.625rem;background:transparent;color:var(--text-muted);cursor:pointer;display:grid;place-items:center}
+html[data-braid-layout="1"] .braid-more-btn:hover{background:var(--bg-hover);color:var(--text-primary)}
+html[data-braid-layout="1"] .braid-more-menu{display:none;position:absolute;right:0;top:calc(100% + .375rem);min-width:13.75rem;z-index:50;background:var(--bg-card);border:1px solid var(--border);border-radius:.875rem;box-shadow:0 16px 48px -12px rgba(0,0,0,.22),var(--braid-shadow,0 1px 2px rgba(0,0,0,.2));padding:.375rem}
+html[data-braid-layout="1"] .braid-more-menu.open{display:block}
+html[data-braid-layout="1"] .braid-more-menu button{display:flex;width:100%;align-items:center;gap:.5rem;border:0;background:transparent;padding:.5625rem .625rem;border-radius:.625rem;font-size:.8125rem;font-weight:550;color:var(--text-primary);cursor:pointer;text-align:left}
+html[data-braid-layout="1"] .braid-more-menu button:hover{background:var(--bg-hover)}
+html[data-braid-layout="1"] .braid-more-menu .muted{color:var(--text-muted);font-size:.71875rem;font-weight:450;margin-left:auto}
+html[data-braid-layout="1"] .welcome-content{text-align:center;max-width:36ch;padding:2rem 1.25rem;margin:auto}
+html[data-braid-layout="1"] .welcome-content h2{font-size:1.625rem;font-weight:680;letter-spacing:-.035em;margin:0 0 .625rem}
+html[data-braid-layout="1"] .welcome-content p{color:var(--text-muted);font-size:.9375rem;line-height:1.5}
+@media (max-width:53.75rem){
+html[data-braid-layout="1"] .messages{padding:.875rem .75rem!important;max-width:none}
+html[data-braid-layout="1"] .server-bar{display:none!important}
+html[data-braid-layout="1"].braid-people-open .right-sidebar{position:fixed;right:0;top:0;bottom:0;z-index:40;max-width:86vw!important}
+}
+`;
+
+BraidLayout._SHAPE_CSS = `
+html[data-braid-layout="1"]{--radius:.875rem;--radius-sm:.75rem}
+html[data-braid-layout="1"] ::-webkit-scrollbar{width:.5rem;height:.5rem}
+html[data-braid-layout="1"] ::-webkit-scrollbar-thumb{background:var(--border-light);border-radius:999px;border:2px solid transparent;background-clip:padding-box}
+html[data-braid-layout="1"] :focus-visible{outline:2px solid color-mix(in srgb,var(--accent) 55%,transparent);outline-offset:2px;border-radius:.5rem}
+html[data-braid-layout="1"] .icon-btn{border-radius:.625rem}
+html[data-braid-layout="1"] .message{border-radius:.875rem!important}
+html[data-braid-layout="1"] .message:hover{background:color-mix(in srgb,var(--bg-hover) 80%,transparent)!important;box-shadow:none!important}
+html[data-braid-layout="1"] .message-row{gap:.875rem!important;padding:.5rem .75rem!important}
+html[data-braid-layout="1"] .message-avatar,
+html[data-braid-layout="1"] .message-avatar-img{width:2.375rem!important;height:2.375rem!important;border-radius:.75rem!important;border:0!important;box-shadow:none!important}
+html[data-braid-layout="1"] .message-author,
+html[data-braid-layout="1"] .message-username{font-weight:650;letter-spacing:-.01em}
+html[data-braid-layout="1"] .message-text,
+html[data-braid-layout="1"] .message-content{line-height:1.58!important;letter-spacing:-.01em}
+html[data-braid-layout="1"] .btn-send,
+html[data-braid-layout="1"] .thread-send-btn{border-radius:.875rem!important;box-shadow:none!important}
+html[data-braid-layout="1"] .input-row input{border-radius:.625rem}
+html[data-braid-layout="1"] .input-row input:focus{border-color:color-mix(in srgb,var(--accent) 45%,var(--border));box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 12%,transparent)}
+html[data-braid-layout="1"] .btn-sm,
+html[data-braid-layout="1"] .btn-secondary,
+html[data-braid-layout="1"] .btn.secondary,
+html[data-braid-layout="1"] .btn-primary,
+html[data-braid-layout="1"] .btn-accent,
+html[data-braid-layout="1"] .profile-dm-btn,
+html[data-braid-layout="1"] .btn-admin-save{border-radius:.75rem!important;box-shadow:none!important}
+html[data-braid-layout="1"] .modal,
+html[data-braid-layout="1"] .modal-content,
+html[data-braid-layout="1"] .settings-modal,
+html[data-braid-layout="1"] .dialog,
+html[data-braid-layout="1"] .settings-panel{border-radius:1.125rem!important;border:1px solid var(--border)!important}
+html[data-braid-layout="1"] .settings-tab,
+html[data-braid-layout="1"] .settings-nav-item,
+html[data-braid-layout="1"] .sound-tab{border-radius:.625rem!important}
+html[data-braid-layout="1"] .settings-tab.active,
+html[data-braid-layout="1"] .settings-nav-item.active,
+html[data-braid-layout="1"] .sound-tab.active{background:color-mix(in srgb,var(--accent) 16%,var(--bg-tertiary))!important;color:var(--accent)!important;border:1px solid color-mix(in srgb,var(--accent) 30%,transparent)!important}
+html[data-braid-layout="1"] .context-menu,
+html[data-braid-layout="1"] .dropdown-menu,
+html[data-braid-layout="1"] .msg-toolbar{border-radius:.875rem!important;border:1px solid var(--border)!important}
+html[data-braid-layout="1"] .profile-popup,
+html[data-braid-layout="1"] .profile-card{border-radius:1rem!important;border:1px solid var(--border)!important}
+html[data-braid-layout="1"] .theme-btn{border-radius:.75rem!important}
+html[data-braid-layout="1"] .reaction,
+html[data-braid-layout="1"] .reaction-chip,
+html[data-braid-layout="1"] .reaction-badge{border-radius:999px!important}
+html[data-braid-layout="1"] .toast,
+html[data-braid-layout="1"] .notification-toast,
+html[data-braid-layout="1"] .chip-toast{border-radius:999px!important;backdrop-filter:blur(10px)}
+html[data-braid-layout="1"] .jump-to-bottom{border-radius:999px!important;border:1px solid var(--border-light)!important}
+html[data-braid-layout="1"] .inline-code,
+html[data-braid-layout="1"] code{border-radius:.375rem!important}
+html[data-braid-layout="1"] .mention{border-radius:.375rem!important}
+html[data-braid-layout="1"] .user-item,
+html[data-braid-layout="1"] .member-item{margin:2px .625rem;padding:.625rem .75rem;border-radius:.75rem}
+html[data-braid-layout="1"] .user-item:hover,
+html[data-braid-layout="1"] .member-item:hover{background:var(--bg-hover)}
+html[data-braid-layout="1"] .message-input-area textarea,
+html[data-braid-layout="1"] .message-input-container textarea{border-radius:1.25rem!important;border:1px solid var(--border-light)!important;transition:border-color .15s,box-shadow .15s}
+html[data-braid-layout="1"] .message-input-area textarea:focus,
+html[data-braid-layout="1"] .message-input-container textarea:focus{border-color:color-mix(in srgb,var(--accent) 45%,var(--border))!important;box-shadow:0 0 0 4px color-mix(in srgb,var(--accent) 12%,transparent)!important}
+html[data-braid-layout="1"] .music-panel-controls button,
+html[data-braid-layout="1"] .music-btn{border-radius:.625rem!important}
+`;
+
+BraidLayout._MOTION_CSS = `
+@keyframes braid-msg-in{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+@keyframes braid-pop{from{transform:scale(.82);opacity:0}to{transform:scale(1);opacity:1}}
+@keyframes braid-fade{from{opacity:0}to{opacity:1}}
+html[data-braid-layout="1"] .message,html[data-braid-layout="1"] .message-compact{animation:braid-msg-in .18s cubic-bezier(.16,1,.3,1) both}
+html[data-braid-layout="1"] .messages{animation:braid-fade .22s ease-out both}
+html[data-braid-layout="1"] .reaction,html[data-braid-layout="1"] .message-reactions>*{animation:braid-pop .16s cubic-bezier(.16,1,.3,1) both;transition:transform .12s ease,background .15s ease,border-color .15s ease}
+html[data-braid-layout="1"] .reaction:hover,html[data-braid-layout="1"] .message-reactions>*:hover{transform:translateY(-1px)}
+html[data-braid-layout="1"] .reaction:active,html[data-braid-layout="1"] .message-reactions>*:active{transform:scale(.94)}
+html[data-braid-layout="1"] .channel-item{transition:background .15s ease,border-color .15s ease,transform .12s ease}
+html[data-braid-layout="1"] .channel-item:active{transform:scale(.99)}
+html[data-braid-layout="1"] .btn-send,html[data-braid-layout="1"] .icon-btn{transition:transform .12s ease,background .15s ease,color .15s ease}
+html[data-braid-layout="1"] .btn-send:active,html[data-braid-layout="1"] .icon-btn:active{transform:scale(.92)}
+html[data-braid-layout="1"] .message-input-area textarea,html[data-braid-layout="1"] .message-input-container textarea{transition:border-color .15s ease,box-shadow .15s ease,background .15s ease}
+html[data-braid-layout="1"] .typing-indicator,html[data-braid-layout="1"] .typing-text{animation:braid-fade .2s ease-out both}
+html[data-braid-layout="1"] .msg-toolbar,html[data-braid-layout="1"] .context-menu,html[data-braid-layout="1"] .dropdown-menu{animation:braid-pop .13s cubic-bezier(.16,1,.3,1) both;transform-origin:top right}
+html[data-braid-layout="1"] .theme-popup,html[data-braid-layout="1"] .modal-content,html[data-braid-layout="1"] .settings-panel{animation:braid-msg-in .2s cubic-bezier(.16,1,.3,1) both}
+@media (prefers-reduced-motion: reduce){
+html[data-braid-layout="1"] .message,html[data-braid-layout="1"] .message-compact,html[data-braid-layout="1"] .messages,html[data-braid-layout="1"] .reaction,html[data-braid-layout="1"] .message-reactions>*,html[data-braid-layout="1"] .typing-indicator,html[data-braid-layout="1"] .typing-text,html[data-braid-layout="1"] .msg-toolbar,html[data-braid-layout="1"] .context-menu,html[data-braid-layout="1"] .dropdown-menu,html[data-braid-layout="1"] .theme-popup,html[data-braid-layout="1"] .modal-content,html[data-braid-layout="1"] .settings-panel{animation:none!important}
+html[data-braid-layout="1"] .channel-item,html[data-braid-layout="1"] .btn-send,html[data-braid-layout="1"] .icon-btn,html[data-braid-layout="1"] .reaction{transition:none!important;transform:none!important}
+}
+`;
+
+// Register with the plugin loader's _win scope
+if (typeof _win !== 'undefined') _win.BraidLayout = BraidLayout;

--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -1,8 +1,8 @@
 /**
  * @name Braid Layout
- * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, tucks header extras into a kebab menu, and calms the chrome. Pairs with the Braid / Braid Light themes.
+ * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, tucks header extras into a kebab menu, merges message runs into cards, and calms the chrome. Pairs with the Braid / Braid Light themes.
  * @author Amnibro
- * @version 1.0
+ * @version 1.1
  */
 class BraidLayout {
   start() {
@@ -12,8 +12,11 @@ class BraidLayout {
     this._collapsedAdded = [];         // elements we added a class to
     HavenApi.DOM.addStyle('BraidLayoutCSS', BraidLayout._LAYOUT_CSS);
     HavenApi.DOM.addStyle('BraidShapeCSS', BraidLayout._SHAPE_CSS);
+    HavenApi.DOM.addStyle('BraidFormCSS', BraidLayout._FORM_CSS);
     HavenApi.DOM.addStyle('BraidMotionCSS', BraidLayout._MOTION_CSS);
     document.documentElement.setAttribute('data-braid-layout', '1');
+    document.documentElement.setAttribute('data-braid-form', '1');
+    this._paintOwn();
     this._collapseJoinCreate();
     this._setPeopleOpen(false);
     this._buildMoreMenu();
@@ -71,9 +74,13 @@ class BraidLayout {
     this._listeners = [];
     document.documentElement.classList.remove('braid-people-open', 'braid-sound-open', 'braid-status-open');
     document.documentElement.removeAttribute('data-braid-layout');
+    document.documentElement.removeAttribute('data-braid-form');
+    document.querySelectorAll('[data-braid-run]').forEach((el) => el.removeAttribute('data-braid-run'));
     HavenApi.DOM.removeStyle('BraidLayoutCSS');
     HavenApi.DOM.removeStyle('BraidMotionCSS');
     HavenApi.DOM.removeStyle('BraidShapeCSS');
+    HavenApi.DOM.removeStyle('BraidFormCSS');
+    HavenApi.DOM.removeStyle('BraidFormOwn');
     console.log('[BraidLayout] Stopped');
   }
 
@@ -249,11 +256,53 @@ class BraidLayout {
     this._foldServersIntoSidebar();
     this._hideEdgeChrome();
     this._quietChips();
+    this._markRuns();
+  }
+
+  // Run position for the merged cards, desktop twin of Haven-Mobile's
+  // braidForm(). This is deliberately NOT :has(+ .message-compact) —
+  // Chromium re-runs :has() invalidation on every sibling insert, which
+  // made a 600-message channel load go quadratic (622ms vs 80ms).
+  // Attribute marking here is O(n) per observer batch.
+  _markRuns() {
+    const runOf = (first, last) => (first ? (last ? 'solo' : 'start') : (last ? 'end' : 'mid'));
+    document.querySelectorAll('.messages > .message, .messages > .message-compact').forEach((el) => {
+      const next = el.nextElementSibling;
+      const v = runOf(el.classList.contains('message'), !next || !next.classList.contains('message-compact'));
+      if (el.getAttribute('data-braid-run') !== v) el.setAttribute('data-braid-run', v);
+    });
+    document.querySelectorAll('.channel-item').forEach((el) => {
+      const prev = el.previousElementSibling;
+      const next = el.nextElementSibling;
+      const v = runOf(!prev || !prev.classList.contains('channel-item'), !next || !next.classList.contains('channel-item'));
+      if (el.getAttribute('data-braid-run') !== v) el.setAttribute('data-braid-run', v);
+    });
+  }
+
+  // Own messages get an accent-tinted card, like mobile.
+  _paintOwn() {
+    let id = null;
+    try { id = (JSON.parse(localStorage.getItem('haven_user') || 'null') || {}).id; } catch {}
+    if (!id) { HavenApi.DOM.removeStyle('BraidFormOwn'); return; }
+    const sel = `html[data-braid-form="1"] .message[data-user-id="${id}"]>.message-row>.message-body,` +
+      `html[data-braid-form="1"] .message-compact[data-user-id="${id}"]>.message-body`;
+    HavenApi.DOM.addStyle('BraidFormOwn',
+      `${sel}{background:var(--braid-me);border-color:var(--braid-me-line)}` +
+      sel.split(',').map((s) => s + ':hover').join(',') +
+      `{background:color-mix(in srgb,var(--accent) 18%,var(--bg-secondary))}`);
   }
 }
 
 BraidLayout._LAYOUT_CSS = `
-html[data-braid-layout="1"]{--sidebar-width:17.5rem;--braid-bar-h:3.25rem}
+html[data-braid-layout="1"]{--sidebar-width:17.5rem;--braid-bar-h:3rem}
+html[data-braid-layout="1"] .channel-topic-bar{background:transparent!important;border-bottom:0!important;padding:.125rem 1.75rem .375rem!important;font-size:.71875rem!important;min-height:0!important;line-height:1.4!important;color:var(--text-muted)!important}
+html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"] .section-label,
+html[data-braid-layout="1"] .sidebar-section#admin-controls .section-label{padding:.3125rem .5rem!important}
+html[data-braid-layout="1"] .user-bar{padding:.5rem .625rem!important}
+html[data-braid-layout="1"] .sidebar-bottom-bar{padding:.375rem .5rem!important}
+html[data-braid-layout="1"] .message-input-area .icon-btn,
+html[data-braid-layout="1"] .message-input-area>button,
+html[data-braid-layout="1"] .message-input-container .icon-btn{width:2rem;height:2rem}
 html[data-braid-layout="1"] body,
 html[data-braid-layout="1"] #app{overflow:hidden}
 html[data-braid-layout="1"] #app-body{display:flex!important;flex-direction:row!important;min-height:0;height:100%}
@@ -312,7 +361,7 @@ html[data-braid-layout="1"] .voice-controls span[style*="background"]{background
 html[data-braid-layout="1"] .message-area{flex:1;min-height:0;display:flex;flex-direction:column}
 html[data-braid-layout="1"] .messages{padding:1.125rem 1.75rem .5rem!important;width:100%;box-sizing:border-box}
 html[data-braid-layout="1"] .message-input-area,
-html[data-braid-layout="1"] .message-input-container{padding:.625rem 1.25rem .875rem!important;width:100%;box-sizing:border-box;border-top:1px solid var(--border)!important;background:color-mix(in srgb,var(--bg-secondary) 94%,transparent)!important}
+html[data-braid-layout="1"] .message-input-container{padding:.5rem 1rem .75rem!important;width:100%;box-sizing:border-box;border-top:1px solid var(--border)!important;background:color-mix(in srgb,var(--bg-secondary) 94%,transparent)!important}
 html[data-braid-layout="1"] .right-sidebar,
 html[data-braid-layout="1"] .right-sidebar.collapsed,
 html[data-braid-layout="1"] #right-sidebar{display:none!important;width:0!important;min-width:0!important;max-width:0!important;border:0!important;opacity:0!important;pointer-events:none!important;overflow:hidden!important}
@@ -346,6 +395,57 @@ html[data-braid-layout="1"] .messages{padding:.875rem .75rem!important;max-width
 html[data-braid-layout="1"] .server-bar{display:none!important}
 html[data-braid-layout="1"].braid-people-open .right-sidebar{position:fixed;right:0;top:0;bottom:0;z-index:40;max-width:86vw!important}
 }
+`;
+
+BraidLayout._FORM_CSS = `
+html[data-braid-form="1"]{
+--braid-r:.875rem;
+--braid-bub:var(--bg-hover,var(--bg-card));
+--braid-line:var(--border);
+--braid-seam:color-mix(in srgb,var(--border) 55%,var(--braid-bub));
+--braid-me:color-mix(in srgb,var(--accent) 12%,var(--bg-secondary));
+--braid-me-line:color-mix(in srgb,var(--accent) 35%,var(--border));
+--braid-gutter:3.625rem;
+}
+html[data-braid-form="1"] .message,
+html[data-braid-form="1"] .message-compact{background:transparent!important;border:0!important;border-radius:0!important;box-shadow:none!important;margin:0!important}
+html[data-braid-form="1"] .messages{gap:0!important}
+html[data-braid-form="1"] .message{padding:0 1.125rem 0 .625rem!important}
+html[data-braid-form="1"] .message-compact{padding:0 1.125rem 0 var(--braid-gutter)!important}
+html[data-braid-form="1"] .message-row{padding:0!important;gap:.75rem!important;align-items:flex-start}
+html[data-braid-form="1"] .message-avatar,
+html[data-braid-form="1"] .message-avatar-img{width:2.25rem!important;height:2.25rem!important;min-width:2.25rem!important;box-sizing:border-box!important;border:0!important;margin:0!important}
+html[data-braid-form="1"] .message:hover,
+html[data-braid-form="1"] .message-compact:hover{background:transparent!important}
+html[data-braid-form="1"] .message>.message-row>.message-body,
+html[data-braid-form="1"] .message-compact>.message-body{position:relative;flex:1 1 auto;min-width:0;background:var(--braid-bub);border:1px solid var(--braid-line);border-top:0;border-radius:0;padding:.3125rem .8125rem}
+html[data-braid-form="1"] .message[data-braid-run="start"]>.message-row>.message-body,
+html[data-braid-form="1"] .message[data-braid-run="solo"]>.message-row>.message-body{border-top:1px solid var(--braid-line);border-top-left-radius:var(--braid-r);border-top-right-radius:var(--braid-r);padding-top:.5625rem;margin-top:.5rem}
+html[data-braid-form="1"] .message[data-braid-run="end"]>.message-row>.message-body,
+html[data-braid-form="1"] .message[data-braid-run="solo"]>.message-row>.message-body,
+html[data-braid-form="1"] .message-compact[data-braid-run="end"]>.message-body{border-bottom-left-radius:var(--braid-r);border-bottom-right-radius:var(--braid-r);padding-bottom:.5625rem;margin-bottom:.5rem}
+html[data-braid-form="1"] .message-compact>.message-body::before{content:'';position:absolute;left:.8125rem;right:.8125rem;top:0;border-top:1px dashed var(--braid-seam);pointer-events:none}
+html[data-braid-form="1"] .message>.message-row>.message-body:hover,
+html[data-braid-form="1"] .message-compact>.message-body:hover{background:color-mix(in srgb,var(--bg-active) 40%,var(--braid-bub))}
+html[data-braid-form="1"] .message-user-sep{border-top:0!important;padding-top:0!important}
+html[data-braid-form="1"] .message.system-message>.message-row>.message-body,
+html[data-braid-form="1"] .message.announcement>.message-row>.message-body{background:transparent;border:0;border-radius:0}
+html[data-braid-form="1"] .channel-item{position:relative;margin:0 .5rem!important;border:1px solid var(--braid-line)!important;border-top:0!important;border-radius:0!important;background:var(--braid-bub)}
+html[data-braid-form="1"] .channel-item[data-braid-run="start"],
+html[data-braid-form="1"] .channel-item[data-braid-run="solo"]{border-top:1px solid var(--braid-line)!important;border-top-left-radius:.75rem!important;border-top-right-radius:.75rem!important;margin-top:.25rem!important}
+html[data-braid-form="1"] .channel-item[data-braid-run="end"],
+html[data-braid-form="1"] .channel-item[data-braid-run="solo"]{border-bottom-left-radius:.75rem!important;border-bottom-right-radius:.75rem!important;margin-bottom:.25rem!important}
+html[data-braid-form="1"] .channel-item[data-braid-run="mid"]::before,
+html[data-braid-form="1"] .channel-item[data-braid-run="end"]::before{content:'';position:absolute;left:.75rem;right:.75rem;top:0;border-top:1px dashed var(--braid-seam);pointer-events:none}
+html[data-braid-form="1"] .channel-item:hover{background:color-mix(in srgb,var(--bg-active) 45%,var(--braid-bub))}
+html[data-braid-form="1"] .channel-item.active{background:color-mix(in srgb,var(--accent) 16%,var(--bg-secondary));border-color:var(--accent)!important}
+html[data-braid-form="1"] .channel-item.active::before,
+html[data-braid-form="1"] .channel-item.active + .channel-item::before{display:none!important}
+html[data-braid-form="1"] .reaction,
+html[data-braid-form="1"] .reaction-add,
+html[data-braid-form="1"] .message-reactions>*{border-radius:999px!important}
+html[data-braid-form="1"] .message-input-area textarea,
+html[data-braid-form="1"] .message-input-container textarea{background:var(--bg-primary)!important}
 `;
 
 BraidLayout._SHAPE_CSS = `

--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -1,8 +1,8 @@
 /**
  * @name Braid Layout
- * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, tucks header extras into a kebab menu, merges message runs into cards, and calms the chrome. Pairs with the Braid / Braid Light themes.
+ * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, tucks header extras into a kebab menu, merges message runs into cards, and calms the chrome. Suspends itself while Mod Mode edits the layout. Pairs with the Braid / Braid Light themes.
  * @author Amnibro
- * @version 1.1
+ * @version 1.2
  */
 class BraidLayout {
   start() {
@@ -14,9 +14,22 @@ class BraidLayout {
     HavenApi.DOM.addStyle('BraidShapeCSS', BraidLayout._SHAPE_CSS);
     HavenApi.DOM.addStyle('BraidFormCSS', BraidLayout._FORM_CSS);
     HavenApi.DOM.addStyle('BraidMotionCSS', BraidLayout._MOTION_CSS);
+    this._evalOrderCSS();
     document.documentElement.setAttribute('data-braid-layout', '1');
     document.documentElement.setAttribute('data-braid-form', '1');
     this._paintOwn();
+    this._themeBottomIcons();
+    // Mod Mode (Haven's layout editor) must see the real chrome to drag
+    // it around — suspend the whole Braid layer while it is editing and
+    // come back when it saves. body class changes are attribute
+    // mutations, which the main childList observer deliberately ignores.
+    this._suspended = false;
+    this._modObs = new MutationObserver(() => {
+      const editing = document.body.classList.contains('mod-mode-on');
+      if (editing && !this._suspended) this._suspend();
+      else if (!editing && this._suspended) this._resume();
+    });
+    this._modObs.observe(document.body, { attributes: true, attributeFilter: ['class'] });
     this._collapseJoinCreate();
     this._setPeopleOpen(false);
     this._buildMoreMenu();
@@ -42,6 +55,8 @@ class BraidLayout {
 
   stop() {
     if (this._obs) { this._obs.disconnect(); this._obs = null; }
+    if (this._modObs) { this._modObs.disconnect(); this._modObs = null; }
+    this._restoreBottomIcons();
     // Unfold the server rail back to its own column
     const bar = document.getElementById('server-bar');
     const strip = document.getElementById('braid-server-strip');
@@ -81,6 +96,7 @@ class BraidLayout {
     HavenApi.DOM.removeStyle('BraidShapeCSS');
     HavenApi.DOM.removeStyle('BraidFormCSS');
     HavenApi.DOM.removeStyle('BraidFormOwn');
+    HavenApi.DOM.removeStyle('BraidOrderCSS');
     console.log('[BraidLayout] Stopped');
   }
 
@@ -214,6 +230,11 @@ class BraidLayout {
     if (desktopBanner) addItem('Desktop app', () => (desktopBanner.querySelector('a') || desktopBanner).click(), 'download');
     const androidBanner = document.getElementById('android-beta-banner');
     if (androidBanner) addItem('Android app', () => androidBanner.click(), 'download');
+    addItem('Edit layout', () => {
+      const mm = window.app && window.app.modMode;
+      if (mm) mm.toggle();
+      else document.getElementById('mod-mode-settings-toggle')?.click();
+    }, 'Mod Mode');
     addItem('Settings', () => {
       document.getElementById('open-settings-btn')?.click();
       document.getElementById('mobile-settings-btn')?.click();
@@ -253,10 +274,88 @@ class BraidLayout {
   }
 
   _applyLayout() {
+    if (this._suspended) return;
     this._foldServersIntoSidebar();
     this._hideEdgeChrome();
     this._quietChips();
     this._markRuns();
+    this._themeBottomIcons();
+  }
+
+  // ── Mod Mode interop ─────────────────────────────────────
+  // While the layout editor is active the Braid gates come off and the
+  // server rail unfolds, so every draggable section and panel handle is
+  // real and visible. On exit the layer re-applies — and honours any
+  // custom section order the user just saved (see _evalOrderCSS).
+  _suspend() {
+    this._suspended = true;
+    const bar = document.getElementById('server-bar');
+    const strip = document.getElementById('braid-server-strip');
+    if (bar && strip) {
+      while (strip.firstChild) bar.appendChild(strip.firstChild);
+      delete bar.dataset.braidFolded;
+      bar.removeAttribute('aria-hidden');
+      bar.style.display = '';
+    }
+    const right = document.getElementById('right-sidebar');
+    if (right) right.style.display = '';
+    document.documentElement.removeAttribute('data-braid-layout');
+    document.documentElement.removeAttribute('data-braid-form');
+  }
+
+  _resume() {
+    this._suspended = false;
+    this._evalOrderCSS();
+    document.documentElement.setAttribute('data-braid-layout', '1');
+    document.documentElement.setAttribute('data-braid-form', '1');
+    this._setPeopleOpen(document.documentElement.classList.contains('braid-people-open'));
+    this._applyLayout();
+  }
+
+  // Braid pushes join/create below the channel list by default, but a
+  // user who reordered sections in Mod Mode has expressed an explicit
+  // preference — the CSS order overrides only apply when no custom
+  // layout is saved.
+  _evalOrderCSS() {
+    let custom = null;
+    try { custom = JSON.parse(localStorage.getItem('haven-layout')); } catch {}
+    if (Array.isArray(custom) && custom.length) HavenApi.DOM.removeStyle('BraidOrderCSS');
+    else HavenApi.DOM.addStyle('BraidOrderCSS', BraidLayout._ORDER_CSS);
+  }
+
+  // ── Themed bottom-left icons ─────────────────────────────
+  // The stock buttons are colored emoji, which fight every palette.
+  // Swap them for line icons drawn with currentColor so they follow
+  // the theme like the rest of the chrome; originals are stashed for
+  // stop(). Buttons added later (voice mute/deafen appear on join)
+  // are themed by the observer pass.
+  _themeBottomIcons() {
+    const svg = (paths) =>
+      `<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
+    const icons = {
+      'theme-popup-toggle': svg('<circle cx="12" cy="12" r="9"/><path d="M12 3a9 9 0 0 0 0 18c1.2 0 1.8-.9 1.8-1.8 0-.5-.2-.9-.5-1.3-.3-.4-.5-.8-.5-1.3 0-1 .8-1.8 1.8-1.8H17a4 4 0 0 0 4-4c0-4.4-4-7.8-9-7.8Z"/><circle cx="7.5" cy="11.5" r=".6"/><circle cx="10.5" cy="7.5" r=".6"/><circle cx="15" cy="7.5" r=".6"/>'),
+      'activities-btn': svg('<path d="M6 9h4M8 7v4M15 8.5h.01M17.5 11h.01"/><path d="M17.3 5H6.7a4.7 4.7 0 0 0-4.6 4L1.3 14a3.2 3.2 0 0 0 5.7 2.6L8.6 14h6.8l1.6 2.6A3.2 3.2 0 0 0 22.7 14l-.8-5a4.7 4.7 0 0 0-4.6-4Z"/>'),
+      'sidebar-members-btn': svg('<circle cx="9" cy="8" r="3.2"/><path d="M3.5 19c.6-3 2.8-4.7 5.5-4.7s4.9 1.7 5.5 4.7"/><path d="M16 5.4a3.2 3.2 0 0 1 0 5.9M17.8 14.6c1.5.7 2.4 2 2.7 4"/>'),
+      'mobile-settings-btn': svg('<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1 1.55V21a2 2 0 1 1-4 0v-.09a1.7 1.7 0 0 0-1-1.55 1.7 1.7 0 0 0-1.87.34l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.7 1.7 0 0 0 .34-1.87 1.7 1.7 0 0 0-1.55-1H3a2 2 0 1 1 0-4h.09a1.7 1.7 0 0 0 1.55-1 1.7 1.7 0 0 0-.34-1.87l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.7 1.7 0 0 0 1.87.34h.01a1.7 1.7 0 0 0 1-1.55V3a2 2 0 1 1 4 0v.09a1.7 1.7 0 0 0 1 1.55h.01a1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.7 1.7 0 0 0-.34 1.87v.01a1.7 1.7 0 0 0 1.55 1H21a2 2 0 1 1 0 4h-.09a1.7 1.7 0 0 0-1.55 1Z"/>'),
+      'donors-btn': svg('<path d="M12 20.3 4.8 13a4.7 4.7 0 0 1 6.6-6.6l.6.6.6-.6a4.7 4.7 0 0 1 6.6 6.6Z"/>'),
+      'voice-mute-btn': svg('<rect x="9" y="3" width="6" height="11" rx="3"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3"/>'),
+      'voice-deafen-btn': svg('<path d="M4 13a8 8 0 0 1 16 0"/><path d="M4 13v4a2 2 0 0 0 2 2h1v-6H6a2 2 0 0 0-2 2ZM20 13v4a2 2 0 0 1-2 2h-1v-6h1a2 2 0 0 1 2 2Z"/>'),
+    };
+    Object.entries(icons).forEach(([id, markup]) => {
+      const btn = document.getElementById(id);
+      if (!btn || btn.dataset.braidIcon === '1') return;
+      btn.dataset.braidIcon = '1';
+      btn.dataset.braidOrig = btn.innerHTML;
+      btn.innerHTML = markup;
+    });
+  }
+
+  _restoreBottomIcons() {
+    document.querySelectorAll('[data-braid-icon="1"]').forEach((btn) => {
+      btn.innerHTML = btn.dataset.braidOrig || btn.innerHTML;
+      delete btn.dataset.braidIcon;
+      delete btn.dataset.braidOrig;
+    });
   }
 
   // Run position for the merged cards, desktop twin of Haven-Mobile's
@@ -317,7 +416,9 @@ html[data-braid-layout="1"] .brand-text{font-size:.9375rem!important;font-weight
 html[data-braid-layout="1"] .user-bar{border-radius:.75rem!important;padding:.5rem .625rem!important;gap:.5rem!important;background:var(--bg-tertiary)!important;border:1px solid var(--border)!important}
 html[data-braid-layout="1"] .sidebar-mod-container{order:1;flex:1;min-height:0;overflow:auto;display:flex;flex-direction:column;padding:2px 0 .375rem}
 html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"],
-html[data-braid-layout="1"] .sidebar-section#admin-controls{order:3;border:0!important;padding:2px .625rem!important;margin:0!important}
+html[data-braid-layout="1"] .sidebar-section#admin-controls{border:0!important;padding:2px .625rem!important;margin:0!important}
+html:not([data-braid-layout="1"]) .braid-more-wrap,
+html:not([data-braid-layout="1"]) .braid-server-strip{display:none!important}
 html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"] .section-label,
 html[data-braid-layout="1"] .sidebar-section#admin-controls .section-label{font-size:.71875rem!important;letter-spacing:0!important;text-transform:none!important;font-weight:550!important;color:var(--text-muted)!important;margin:2px 0!important;padding:.4375rem .5rem;border-radius:.625rem}
 html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"] .section-label:hover,
@@ -326,7 +427,7 @@ html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"].braid-collapsed
 html[data-braid-layout="1"] .sidebar-section#admin-controls.braid-collapsed .collapsible-section-body,
 html[data-braid-layout="1"] #join-section-body.collapsed,
 html[data-braid-layout="1"] #create-section-body.collapsed{display:none!important}
-html[data-braid-layout="1"] .sidebar-split{order:1;flex:1;min-height:0;display:flex;flex-direction:column;border:0!important}
+html[data-braid-layout="1"] .sidebar-split{flex:1;min-height:0;display:flex;flex-direction:column;border:0!important}
 html[data-braid-layout="1"] .channel-section{flex:1;min-height:0;padding:2px .375rem .375rem!important;border:0!important}
 html[data-braid-layout="1"] .dm-section-pane{flex:0 0 auto;max-height:28%;padding:2px .375rem .375rem!important;border-top:1px solid var(--border)!important}
 html[data-braid-layout="1"] .section-label.channels-toggle,
@@ -397,6 +498,12 @@ html[data-braid-layout="1"].braid-people-open .right-sidebar{position:fixed;righ
 }
 `;
 
+BraidLayout._ORDER_CSS = `
+html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"],
+html[data-braid-layout="1"] .sidebar-section#admin-controls{order:3}
+html[data-braid-layout="1"] .sidebar-split{order:1}
+`;
+
 BraidLayout._FORM_CSS = `
 html[data-braid-form="1"]{
 --braid-r:.875rem;
@@ -424,7 +531,7 @@ html[data-braid-form="1"] .message[data-braid-run="solo"]>.message-row>.message-
 html[data-braid-form="1"] .message[data-braid-run="end"]>.message-row>.message-body,
 html[data-braid-form="1"] .message[data-braid-run="solo"]>.message-row>.message-body,
 html[data-braid-form="1"] .message-compact[data-braid-run="end"]>.message-body{border-bottom-left-radius:var(--braid-r);border-bottom-right-radius:var(--braid-r);padding-bottom:.5625rem;margin-bottom:.5rem}
-html[data-braid-form="1"] .message-compact>.message-body::before{content:'';position:absolute;left:.8125rem;right:.8125rem;top:0;border-top:1px dashed var(--braid-seam);pointer-events:none}
+html[data-braid-form="1"] .message-compact>.message-body::before{content:'';position:absolute;left:50%;transform:translateX(-50%);width:min(7rem,45%);top:0;border-top:1px dotted color-mix(in srgb,var(--braid-seam) 75%,transparent);pointer-events:none}
 html[data-braid-form="1"] .message>.message-row>.message-body:hover,
 html[data-braid-form="1"] .message-compact>.message-body:hover{background:color-mix(in srgb,var(--bg-active) 40%,var(--braid-bub))}
 html[data-braid-form="1"] .message-user-sep{border-top:0!important;padding-top:0!important}
@@ -511,6 +618,29 @@ html[data-braid-layout="1"] .message-input-area textarea:focus,
 html[data-braid-layout="1"] .message-input-container textarea:focus{border-color:color-mix(in srgb,var(--accent) 45%,var(--border))!important;box-shadow:0 0 0 4px color-mix(in srgb,var(--accent) 12%,transparent)!important}
 html[data-braid-layout="1"] .music-panel-controls button,
 html[data-braid-layout="1"] .music-btn{border-radius:.625rem!important}
+html[data-braid-layout="1"] .sidebar-bottom-btn svg{display:block}
+
+/* ── Modern settings ── the long scrolling column becomes cards, the
+   nav becomes a pill rail, and the inline hairline separators between
+   sections go away (the cards carry the separation). */
+html[data-braid-layout="1"] .modal-settings{border-radius:1.25rem!important;overflow:hidden}
+html[data-braid-layout="1"] .settings-header{padding:.875rem 1.25rem!important;border-bottom:1px solid var(--border)!important;background:color-mix(in srgb,var(--bg-secondary) 92%,transparent)!important;backdrop-filter:saturate(180%) blur(16px);-webkit-backdrop-filter:saturate(180%) blur(16px);gap:.75rem}
+html[data-braid-layout="1"] .settings-header h3{font-size:1rem!important;font-weight:650!important;letter-spacing:-.02em!important}
+html[data-braid-layout="1"] .settings-tab-bar{background:var(--bg-tertiary)!important;border:1px solid var(--border)!important;border-radius:.75rem!important;padding:3px!important;gap:2px!important}
+html[data-braid-layout="1"] .settings-tab{border-radius:.5625rem!important;border:0!important;padding:.375rem .875rem!important;font-weight:550!important}
+html[data-braid-layout="1"] .settings-close-btn{width:2.125rem;height:2.125rem;border-radius:.625rem!important;border:0!important;background:transparent!important;color:var(--text-muted)!important;font-size:1.125rem;display:grid;place-items:center}
+html[data-braid-layout="1"] .settings-close-btn:hover{background:var(--bg-hover)!important;color:var(--text-primary)!important}
+html[data-braid-layout="1"] .settings-nav{background:var(--bg-secondary)!important;border-right:1px solid var(--border)!important;padding:.625rem!important}
+html[data-braid-layout="1"] .settings-nav-group-label{font-size:.625rem!important;font-weight:650!important;letter-spacing:.12em!important;text-transform:uppercase!important;color:var(--text-muted)!important;margin:.875rem .5rem .25rem!important}
+html[data-braid-layout="1"] .settings-nav-item{border-radius:.625rem!important;padding:.4375rem .625rem!important;margin:1px 0!important;font-size:.8125rem!important;font-weight:550!important;border:1px solid transparent!important}
+html[data-braid-layout="1"] .settings-nav-item:hover{background:var(--bg-hover)!important}
+html[data-braid-layout="1"] .settings-nav-item.active{background:color-mix(in srgb,var(--accent) 14%,var(--bg-tertiary))!important;color:var(--accent)!important;border:1px solid color-mix(in srgb,var(--accent) 28%,transparent)!important}
+html[data-braid-layout="1"] .settings-section{background:var(--bg-card)!important;border:1px solid var(--border)!important;border-top:1px solid var(--border)!important;border-radius:1rem!important;padding:1rem 1.125rem!important;margin:0 0 .75rem!important}
+html[data-braid-layout="1"] .settings-section-subtitle{font-weight:650!important;letter-spacing:-.015em!important}
+html[data-braid-layout="1"] .settings-section select,
+html[data-braid-layout="1"] .settings-section input[type="text"],
+html[data-braid-layout="1"] .settings-section input[type="password"],
+html[data-braid-layout="1"] .settings-section input[type="number"]{border-radius:.625rem!important;border:1px solid var(--border)!important;background:var(--bg-input)!important;padding:.5rem .75rem!important}
 `;
 
 BraidLayout._MOTION_CSS = `

--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -2,7 +2,7 @@
  * @name Braid Layout
  * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, tucks header extras into a kebab menu, merges message runs into cards, and calms the chrome. Suspends itself while Mod Mode edits the layout. Pairs with the Braid / Braid Light themes.
  * @author Amnibro
- * @version 1.3
+ * @version 1.4
  */
 class BraidLayout {
   start() {
@@ -199,16 +199,21 @@ class BraidLayout {
   }
 
   _buildMoreMenu() {
+    if (document.querySelector('.braid-more-wrap')) return;
+    // The hamburger lives bottom-left, where the icon bar it absorbed
+    // used to be — the popups it opens (themes, activities) anchor down
+    // there, so the menu and its children share a corner.
+    const bar = document.querySelector('.sidebar-bottom-bar');
     const header = document.querySelector('.channel-header');
-    if (!header || header.querySelector('.braid-more-wrap')) return;
+    const host = bar || header;
+    if (!host) return;
     const wrap = document.createElement('div');
     wrap.className = 'braid-more-wrap';
     wrap.innerHTML =
       '<button type="button" class="braid-more-btn" id="braid-more-btn" title="Menu" aria-label="Menu" aria-expanded="false">' +
-      '<span class="braid-ham"><span class="braid-ham-line"></span><span class="braid-ham-line"></span><span class="braid-ham-line"></span></span></button>';
-    const voice = header.querySelector('.voice-controls');
-    if (voice) header.insertBefore(wrap, voice);
-    else header.appendChild(wrap);
+      '<span class="braid-ham"><span class="braid-ham-line"></span><span class="braid-ham-line"></span><span class="braid-ham-line"></span></span>' +
+      '<span class="braid-ham-label">Menu</span></button>';
+    host.prepend(wrap);
     // The menu lives on <body>: the blurred header is a containing block
     // (backdrop-filter) with overflow:hidden, which would trap and clip
     // even a position:fixed dropdown rendered inside it.
@@ -312,6 +317,7 @@ class BraidLayout {
     this._quietChips();
     this._markRuns();
     this._themeBottomIcons();
+    this._themeSettingsNav();
     this._injectTextSliders();
   }
 
@@ -445,6 +451,68 @@ class BraidLayout {
       btn.innerHTML = btn.dataset.braidOrig || btn.innerHTML;
       delete btn.dataset.braidIcon;
       delete btn.dataset.braidOrig;
+    });
+  }
+
+  // ── Themed settings-nav icons ────────────────────────────
+  // Same treatment as the old bottom-left buttons: the leading emoji on
+  // every nav row (and the User/Admin tabs) becomes a currentColor line
+  // glyph, so the rail follows the palette. Unmapped rows get the Haven
+  // hexagon. Idempotent per element; originals restore on disable.
+  _themeSettingsNav() {
+    const svg = (paths, size = 15) =>
+      `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
+    const hex = '<path d="M12 2.5 20.2 7.25v9.5L12 21.5 3.8 16.75v-9.5Z"/>';
+    const map = {
+      'section-language': '<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14.5 14.5 0 0 1 0 18M12 3a14.5 14.5 0 0 0 0 18"/>',
+      'section-density': '<rect x="3" y="3" width="18" height="18" rx="2.5"/><path d="M9 3v18M3 9h6"/>',
+      'section-font-size': '<path d="M4 19 10 5h1.5L17.5 19M6.2 14h8.1M19 12v7M16.5 14.5 19 12l2.5 2.5"/>',
+      'section-emoji-size': '<circle cx="12" cy="12" r="9"/><path d="M8.5 14.5a4.5 4.5 0 0 0 7 0M9 9.5h.01M15 9.5h.01"/>',
+      'section-role-display': '<path d="M12 2.7 20 7v10l-8 4.3L4 17V7Z"/><circle cx="12" cy="10" r="2.2"/><path d="M8.5 16.2c.7-1.8 1.9-2.7 3.5-2.7s2.8.9 3.5 2.7"/>',
+      'section-toolbar-icons': '<path d="M14.7 6.3a4 4 0 0 0-5.2 5.2L4 17l3 3 5.5-5.5a4 4 0 0 0 5.2-5.2l-2.6 2.6-2.4-2.4Z"/>',
+      'section-image-display': '<rect x="3" y="4" width="18" height="16" rx="2.5"/><circle cx="9" cy="10" r="1.6"/><path d="m4 18 5-5 3 3 4-4 4 4"/>',
+      'section-embed-size': '<rect x="3" y="4" width="18" height="16" rx="2.5"/><path d="m10.5 9 4.5 3-4.5 3Z"/>',
+      'section-statusbar': '<path d="M3 12h4l2.5-6 4 12L16 12h5"/>',
+      'section-chat-behavior': '<path d="M21 12a8 8 0 0 1-11.6 7.1L4 21l1.9-5.4A8 8 0 1 1 21 12Z"/>',
+      'section-soundboard-mode': '<path d="M9 18V6l10-2v11.5"/><circle cx="6.5" cy="18" r="2.5"/><circle cx="16.5" cy="15.5" r="2.5"/>',
+      'section-sounds': '<path d="M4 10v4h3.5L12 18V6l-4.5 4Z"/><path d="M15.5 9a4.2 4.2 0 0 1 0 6M18 6.7a8 8 0 0 1 0 10.6"/>',
+      'section-push': '<path d="M18 9a6 6 0 1 0-12 0c0 6-2.5 7-2.5 7h17S18 15 18 9"/><path d="M10.3 20a2 2 0 0 0 3.4 0"/>',
+      'section-activity': '<circle cx="12" cy="12" r="2"/><path d="M7.5 7.5a6.4 6.4 0 0 0 0 9M16.5 7.5a6.4 6.4 0 0 1 0 9M4.6 4.6a10.5 10.5 0 0 0 0 14.8M19.4 4.6a10.5 10.5 0 0 1 0 14.8"/>',
+      'section-score-badges': '<circle cx="12" cy="9" r="5.5"/><path d="m8.8 13.7-1.5 6.8 4.7-2.7 4.7 2.7-1.5-6.8"/>',
+      'section-password': '<rect x="4.5" y="10.5" width="15" height="9.5" rx="2.5"/><path d="M8 10.5V7.5a4 4 0 0 1 8 0v3M12 14.5v2"/>',
+      'section-two-factor': '<path d="M12 2.7 20 6.5v5.2c0 4.8-3.2 8.2-8 9.6-4.8-1.4-8-4.8-8-9.6V6.5Z"/><path d="m8.8 12 2.2 2.2 4.2-4.4"/>',
+      'section-recovery': '<circle cx="8.5" cy="8.5" r="5"/><path d="m12 12 8.5 8.5M17 17l2-2M14.5 19.5l2-2"/>',
+      'section-account': '<circle cx="12" cy="8.5" r="4"/><path d="M4.5 20c.9-4 3.7-6 7.5-6s6.6 2 7.5 6"/>',
+      'section-plugins': '<path d="M10 3.5V6H7a2 2 0 0 0-2 2v3H2.5v2H5v3a2 2 0 0 0 2 2h3v2.5h2V18h3a2 2 0 0 0 2-2v-3h2.5v-2H19V8a2 2 0 0 0-2-2h-3V3.5Z"/>',
+      'section-debug': '<rect x="8" y="7" width="8" height="11" rx="4"/><path d="M12 7V4.5M6 10H3.5M20.5 10H18M6 15H3.5M20.5 15H18M9 5.5 7.5 4M15 5.5 16.5 4"/>',
+      'section-modmode': '<path d="M4 9h16M4 15h16M9 4v16M15 4v16"/><rect x="4" y="4" width="16" height="16" rx="2.5"/>',
+    };
+    document.querySelectorAll('.settings-nav-item').forEach((item) => {
+      if (item.dataset.braidIcon === '1') return;
+      item.dataset.braidIcon = '1';
+      item.dataset.braidOrig = item.innerHTML;
+      const label = item.querySelector('span');
+      const paths = map[item.dataset.target] || hex;
+      if (label) {
+        item.innerHTML = svg(paths);
+        item.appendChild(label);
+      } else {
+        const text = item.textContent.replace(/^[^\p{L}\p{N}]+\s*/u, '').trim();
+        item.innerHTML = `${svg(paths)}<span>${text}</span>`;
+      }
+    });
+    document.querySelectorAll('.settings-tab').forEach((tab) => {
+      if (tab.dataset.braidIcon === '1') return;
+      tab.dataset.braidIcon = '1';
+      tab.dataset.braidOrig = tab.innerHTML;
+      const label = tab.querySelector('span');
+      const paths = tab.dataset.tab === 'admin'
+        ? '<path d="M12 2.7 20 6.5v5.2c0 4.8-3.2 8.2-8 9.6-4.8-1.4-8-4.8-8-9.6V6.5Z"/>'
+        : '<circle cx="12" cy="8.5" r="4"/><path d="M4.5 20c.9-4 3.7-6 7.5-6s6.6 2 7.5 6"/>';
+      if (label) {
+        tab.innerHTML = svg(paths, 13);
+        tab.appendChild(label);
+      }
     });
   }
 
@@ -593,20 +661,22 @@ html[data-braid-layout="1"].braid-sound-open #soundboard-sidebar,
 html[data-braid-layout="1"].braid-sound-open .soundboard-sidebar{display:flex!important;visibility:visible!important;pointer-events:auto!important}
 html[data-braid-layout="1"].braid-status-open .status-bar,
 html[data-braid-layout="1"].braid-status-open #status-bar{display:flex!important;visibility:visible!important;pointer-events:auto!important}
-html[data-braid-layout="1"] .sidebar-bottom-bar{display:none!important}
-html[data-braid-layout="1"] .braid-more-wrap{position:relative}
-html[data-braid-layout="1"] .braid-more-btn{width:2.125rem;height:2.125rem;border:0;border-radius:.625rem;background:transparent;color:var(--text-muted);cursor:pointer;display:grid;place-items:center}
-html[data-braid-layout="1"] .braid-more-btn:hover{background:var(--bg-hover);color:var(--text-primary)}
+html[data-braid-layout="1"] .sidebar-bottom-bar{display:flex!important;padding:.5rem .625rem!important}
+html[data-braid-layout="1"] .sidebar-bottom-bar>*:not(.braid-more-wrap){display:none!important}
+html[data-braid-layout="1"] .braid-more-wrap{position:relative;flex:1;display:flex}
+html[data-braid-layout="1"] .braid-more-btn{flex:1;display:flex;align-items:center;gap:.625rem;height:2.5rem;padding:0 .875rem;border:1px solid var(--border)!important;border-radius:.75rem;background:var(--bg-tertiary);color:var(--text-secondary);cursor:pointer;font-size:calc(.8125rem*var(--braid-ui-scale,1));font-weight:600;letter-spacing:-.01em;transition:background .15s,color .15s,border-color .15s}
+html[data-braid-layout="1"] .braid-more-btn:hover{background:var(--bg-hover);color:var(--text-primary);border-color:color-mix(in srgb,var(--accent) 35%,var(--border))!important}
+html[data-braid-layout="1"] .braid-ham-label{pointer-events:none}
 html[data-braid-layout="1"] .braid-ham{display:flex;flex-direction:column;justify-content:center;gap:.25rem;width:1.0625rem;height:1.0625rem}
 html[data-braid-layout="1"] .braid-ham-line{display:block;height:2px;width:100%;border-radius:2px;background:currentColor;transition:transform .28s cubic-bezier(.16,1,.3,1),opacity .18s ease;transform-origin:center}
 html[data-braid-layout="1"] .braid-more-wrap.open .braid-more-btn{color:var(--accent);background:color-mix(in srgb,var(--accent) 12%,transparent)}
 html[data-braid-layout="1"] .braid-more-wrap.open .braid-ham-line:nth-child(1){transform:translateY(.375rem) rotate(45deg)}
 html[data-braid-layout="1"] .braid-more-wrap.open .braid-ham-line:nth-child(2){opacity:0;transform:scaleX(.2)}
 html[data-braid-layout="1"] .braid-more-wrap.open .braid-ham-line:nth-child(3){transform:translateY(-.375rem) rotate(-45deg)}
-html[data-braid-layout="1"] .braid-more-menu{display:none;position:fixed;right:1rem;top:calc(var(--braid-bar-h,3rem) + .625rem);min-width:15rem;max-height:min(72vh,34rem);overflow:auto;z-index:90;background:var(--bg-card);border:1px solid var(--border);border-radius:.875rem;box-shadow:0 16px 48px -12px rgba(0,0,0,.22),var(--braid-shadow,0 1px 2px rgba(0,0,0,.2));padding:.375rem;transform-origin:top right}
+html[data-braid-layout="1"] .braid-more-menu{display:none;position:fixed;left:1rem;bottom:3.875rem;top:auto;right:auto;min-width:15rem;max-height:min(72vh,34rem);overflow:auto;z-index:90;background:var(--bg-card);border:1px solid var(--border);border-radius:.875rem;box-shadow:0 16px 48px -12px rgba(0,0,0,.28),var(--braid-shadow,0 1px 2px rgba(0,0,0,.2));padding:.375rem;transform-origin:bottom left}
 html[data-braid-layout="1"] .braid-more-menu.open{display:block;animation:braid-menu-pop .22s cubic-bezier(.16,1,.3,1) both}
-@keyframes braid-menu-pop{from{opacity:0;transform:scale(.92) translateY(-.25rem)}to{opacity:1;transform:none}}
-@keyframes braid-item-in{from{opacity:0;transform:translateY(-.375rem)}to{opacity:1;transform:none}}
+@keyframes braid-menu-pop{from{opacity:0;transform:scale(.92) translateY(.375rem)}to{opacity:1;transform:none}}
+@keyframes braid-item-in{from{opacity:0;transform:translateY(.375rem)}to{opacity:1;transform:none}}
 html[data-braid-layout="1"] .braid-more-menu.open>button,
 html[data-braid-layout="1"] .braid-more-menu.open>.braid-menu-label{animation:braid-item-in .3s cubic-bezier(.16,1,.3,1) both;animation-delay:calc(var(--i,0)*18ms)}
 html[data-braid-layout="1"] .braid-menu-label{font-size:.59375rem;font-weight:650;letter-spacing:.13em;text-transform:uppercase;color:var(--text-muted);padding:.5rem .625rem .25rem}
@@ -772,11 +842,18 @@ html[data-braid-layout="1"] .settings-tab-bar{background:var(--bg-tertiary)!impo
 html[data-braid-layout="1"] .settings-tab{border-radius:.5625rem!important;border:0!important;padding:.375rem .875rem!important;font-weight:550!important}
 html[data-braid-layout="1"] .settings-close-btn{width:2.125rem;height:2.125rem;border-radius:.625rem!important;border:0!important;background:transparent!important;color:var(--text-muted)!important;font-size:1.125rem;display:grid;place-items:center}
 html[data-braid-layout="1"] .settings-close-btn:hover{background:var(--bg-hover)!important;color:var(--text-primary)!important}
-html[data-braid-layout="1"] .settings-nav{background:var(--bg-secondary)!important;border-right:1px solid var(--border)!important;padding:.625rem!important}
-html[data-braid-layout="1"] .settings-nav-group-label{font-size:.625rem!important;font-weight:650!important;letter-spacing:.12em!important;text-transform:uppercase!important;color:var(--text-muted)!important;margin:.875rem .5rem .25rem!important}
-html[data-braid-layout="1"] .settings-nav-item{border-radius:.625rem!important;padding:.4375rem .625rem!important;margin:1px 0!important;font-size:.8125rem!important;font-weight:550!important;border:1px solid transparent!important}
+html[data-braid-layout="1"] .settings-nav{background:var(--bg-secondary)!important;border-right:1px solid var(--border)!important;padding:.625rem .5rem .625rem .625rem!important}
+html[data-braid-layout="1"] .settings-nav-group-label{font-size:.625rem!important;font-weight:650!important;letter-spacing:.12em!important;text-transform:uppercase!important;color:var(--text-muted)!important;margin:.875rem .375rem .25rem!important}
+/* Full-width pills. Stock uses a hanging-indent hack (padding-left
+   1.625rem + negative text-indent) so wrapped lines clear the leading
+   emoji — with a real icon element that hack would push the first line
+   left OUT of the pill, which is why highlights never covered the row. */
+html[data-braid-layout="1"] .settings-nav-item{display:flex!important;align-items:center;gap:.5rem;width:100%;box-sizing:border-box;border-radius:.625rem!important;padding:.4375rem .625rem!important;text-indent:0!important;margin:1px 0!important;font-size:calc(.8125rem*var(--braid-ui-scale,1))!important;font-weight:550!important;border:1px solid transparent!important}
+html[data-braid-layout="1"] .settings-nav-item svg{flex:0 0 auto;opacity:.75}
 html[data-braid-layout="1"] .settings-nav-item:hover{background:var(--bg-hover)!important}
 html[data-braid-layout="1"] .settings-nav-item.active{background:color-mix(in srgb,var(--accent) 14%,var(--bg-tertiary))!important;color:var(--accent)!important;border:1px solid color-mix(in srgb,var(--accent) 28%,transparent)!important}
+html[data-braid-layout="1"] .settings-nav-item.active svg{opacity:1}
+html[data-braid-layout="1"] .settings-tab svg{margin-right:.375rem;vertical-align:-.1875rem}
 html[data-braid-layout="1"] .settings-section{background:var(--bg-card)!important;border:1px solid var(--border)!important;border-top:1px solid var(--border)!important;border-radius:1rem!important;padding:1rem 1.125rem!important;margin:0 0 .75rem!important}
 html[data-braid-layout="1"] .settings-section-subtitle{font-weight:650!important;letter-spacing:-.015em!important}
 html[data-braid-layout="1"] .settings-section select,

--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -2,7 +2,7 @@
  * @name Braid Layout
  * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, tucks header extras into a kebab menu, merges message runs into cards, and calms the chrome. Suspends itself while Mod Mode edits the layout. Pairs with the Braid / Braid Light themes.
  * @author Amnibro
- * @version 1.2
+ * @version 1.3
  */
 class BraidLayout {
   start() {
@@ -19,6 +19,11 @@ class BraidLayout {
     document.documentElement.setAttribute('data-braid-form', '1');
     this._paintOwn();
     this._themeBottomIcons();
+    this._applyTextScales();
+    // Channel switches get the hex loader moment
+    this._listen(document, 'click', (e) => {
+      if (e.target.closest && e.target.closest('.channel-item')) this._showHexLoader();
+    }, true);
     // Mod Mode (Haven's layout editor) must see the real chrome to drag
     // it around — suspend the whole Braid layer while it is editing and
     // come back when it saves. body class changes are attribute
@@ -57,6 +62,10 @@ class BraidLayout {
     if (this._obs) { this._obs.disconnect(); this._obs = null; }
     if (this._modObs) { this._modObs.disconnect(); this._modObs = null; }
     this._restoreBottomIcons();
+    document.getElementById('braid-text-sliders')?.remove();
+    document.getElementById('braid-hex-overlay')?.remove();
+    document.documentElement.style.removeProperty('--braid-chat-scale');
+    document.documentElement.style.removeProperty('--braid-ui-scale');
     // Unfold the server rail back to its own column
     const bar = document.getElementById('server-bar');
     const strip = document.getElementById('braid-server-strip');
@@ -67,6 +76,7 @@ class BraidLayout {
     }
     strip?.remove();
     document.querySelector('.braid-more-wrap')?.remove();
+    document.getElementById('braid-more-menu')?.remove();
     document.getElementById('braid-apps-drawer')?.remove();
     // Restore everything we hid
     for (const [el, prev] of this._hidden) {
@@ -194,51 +204,78 @@ class BraidLayout {
     const wrap = document.createElement('div');
     wrap.className = 'braid-more-wrap';
     wrap.innerHTML =
-      '<button type="button" class="braid-more-btn" id="braid-more-btn" title="More" aria-label="More">' +
-      '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">' +
-      '<circle cx="12" cy="5" r="1.2"/><circle cx="12" cy="12" r="1.2"/><circle cx="12" cy="19" r="1.2"/></svg></button>' +
-      '<div class="braid-more-menu" id="braid-more-menu" role="menu"></div>';
+      '<button type="button" class="braid-more-btn" id="braid-more-btn" title="Menu" aria-label="Menu" aria-expanded="false">' +
+      '<span class="braid-ham"><span class="braid-ham-line"></span><span class="braid-ham-line"></span><span class="braid-ham-line"></span></span></button>';
     const voice = header.querySelector('.voice-controls');
     if (voice) header.insertBefore(wrap, voice);
     else header.appendChild(wrap);
-    const menu = wrap.querySelector('#braid-more-menu');
+    // The menu lives on <body>: the blurred header is a containing block
+    // (backdrop-filter) with overflow:hidden, which would trap and clip
+    // even a position:fixed dropdown rendered inside it.
+    const menu = document.createElement('div');
+    menu.className = 'braid-more-menu';
+    menu.id = 'braid-more-menu';
+    menu.setAttribute('role', 'menu');
+    document.body.appendChild(menu);
     const btn = wrap.querySelector('#braid-more-btn');
+    // One hamburger absorbs the header extras AND the old bottom-left
+    // icon bar — every Haven feature keeps a door, just behind one
+    // animated menu instead of chrome on two edges.
+    let itemIndex = 0;
+    const addLabel = (text) => {
+      const d = document.createElement('div');
+      d.className = 'braid-menu-label';
+      d.textContent = text;
+      d.style.setProperty('--i', itemIndex++);
+      menu.appendChild(d);
+    };
     const addItem = (label, onClick, muted) => {
       const b = document.createElement('button');
       b.type = 'button';
       b.innerHTML = muted ? `${label} <span class="muted">${muted}</span>` : label;
-      b.addEventListener('click', () => { menu.classList.remove('open'); onClick(); });
+      b.style.setProperty('--i', itemIndex++);
+      b.addEventListener('click', () => { closeMenu(); onClick(); });
       menu.appendChild(b);
     };
+    const addProxy = (id, label, muted) => {
+      const src = document.getElementById(id);
+      if (src) addItem(label, () => src.click(), muted);
+    };
     const toggleHtmlClass = (cls) => document.documentElement.classList.toggle(cls);
+    const closeMenu = () => {
+      menu.classList.remove('open');
+      wrap.classList.remove('open');
+      btn.setAttribute('aria-expanded', 'false');
+    };
+    addLabel('Channel');
+    addProxy('search-toggle-btn', 'Search messages');
+    addProxy('pinned-toggle-btn', 'Pinned messages');
+    addProxy('gallery-toggle-btn', 'Files & media');
+    addProxy('copy-code-btn', 'Copy channel code');
+    addProxy('channel-code-settings-btn', 'Channel code settings');
+    addProxy('e2e-menu-btn', 'Encryption');
+    addLabel('View');
     addItem('People & voice', () => this._setPeopleOpen(!document.documentElement.classList.contains('braid-people-open')), 'right panel');
     addItem('Soundboard', () => toggleHtmlClass('braid-sound-open'), 'toggle');
-    addItem('Status bar', () => toggleHtmlClass('braid-status-open'), 'debug footer');
-    [
-      { id: 'search-toggle-btn', label: 'Search messages' },
-      { id: 'pinned-toggle-btn', label: 'Pinned messages' },
-      { id: 'gallery-toggle-btn', label: 'Files & media' },
-      { id: 'copy-code-btn', label: 'Copy channel code' },
-      { id: 'channel-code-settings-btn', label: 'Channel code settings' },
-      { id: 'e2e-menu-btn', label: 'Encryption' },
-    ].forEach((it) => {
-      const src = document.getElementById(it.id);
-      if (!src) return;
-      addItem(it.label, () => src.click());
-    });
-    const desktopBanner = document.getElementById('desktop-app-banner');
-    if (desktopBanner) addItem('Desktop app', () => (desktopBanner.querySelector('a') || desktopBanner).click(), 'download');
-    const androidBanner = document.getElementById('android-beta-banner');
-    if (androidBanner) addItem('Android app', () => androidBanner.click(), 'download');
+    addItem('Status bar', () => toggleHtmlClass('braid-status-open'), 'toggle');
     addItem('Edit layout', () => {
       const mm = window.app && window.app.modMode;
       if (mm) mm.toggle();
       else document.getElementById('mod-mode-settings-toggle')?.click();
     }, 'Mod Mode');
+    addLabel('App');
+    addProxy('theme-popup-toggle', 'Themes');
+    addProxy('activities-btn', 'Activities');
+    addProxy('sidebar-members-btn', 'All members');
     addItem('Settings', () => {
       document.getElementById('open-settings-btn')?.click();
       document.getElementById('mobile-settings-btn')?.click();
     });
+    addProxy('donors-btn', 'Support Haven', '♥');
+    const desktopBanner = document.getElementById('desktop-app-banner');
+    if (desktopBanner) addItem('Desktop app', () => (desktopBanner.querySelector('a') || desktopBanner).click(), 'download');
+    const androidBanner = document.getElementById('android-beta-banner');
+    if (androidBanner) addItem('Android app', () => androidBanner.click(), 'download');
     const peopleHdr = document.getElementById('mobile-users-btn');
     if (peopleHdr) {
       this._listen(peopleHdr, 'click', (e) => {
@@ -247,20 +284,15 @@ class BraidLayout {
         this._setPeopleOpen(!document.documentElement.classList.contains('braid-people-open'));
       }, true);
     }
-    const sideMembers = document.getElementById('sidebar-members-btn');
-    if (sideMembers) {
-      if (sideMembers.style.display === 'none') sideMembers.style.display = '';
-      this._listen(sideMembers, 'click', (e) => {
-        e.preventDefault();
-        this._setPeopleOpen(!document.documentElement.classList.contains('braid-people-open'));
-      });
-    }
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      menu.classList.toggle('open');
+      const opening = !menu.classList.contains('open');
+      menu.classList.toggle('open', opening);
+      wrap.classList.toggle('open', opening);
+      btn.setAttribute('aria-expanded', opening ? 'true' : 'false');
     });
     this._listen(document, 'click', (e) => {
-      if (!wrap.contains(e.target)) menu.classList.remove('open');
+      if (!wrap.contains(e.target) && !menu.contains(e.target)) closeMenu();
     });
   }
 
@@ -280,6 +312,64 @@ class BraidLayout {
     this._quietChips();
     this._markRuns();
     this._themeBottomIcons();
+    this._injectTextSliders();
+  }
+
+  // ── Text size sliders (Settings → Text Size card) ────────
+  _applyTextScales() {
+    const chat = parseFloat(HavenApi.Data.load('BraidLayout', 'chatScale', '1')) || 1;
+    const ui = parseFloat(HavenApi.Data.load('BraidLayout', 'uiScale', '1')) || 1;
+    document.documentElement.style.setProperty('--braid-chat-scale', chat);
+    document.documentElement.style.setProperty('--braid-ui-scale', ui);
+  }
+
+  _injectTextSliders() {
+    if (document.getElementById('braid-text-sliders')) return;
+    const anchor = document.getElementById('section-font-size');
+    if (!anchor) return;
+    const card = document.createElement('div');
+    card.className = 'settings-section';
+    card.id = 'braid-text-sliders';
+    const row = (id, label, min, max) => `
+      <div style="display:flex;align-items:center;gap:.75rem;margin-top:.625rem">
+        <span style="flex:0 0 7.5rem;font-size:.8125rem;color:var(--text-secondary)">${label}</span>
+        <input type="range" id="${id}" min="${min}" max="${max}" step="5" style="flex:1;accent-color:var(--accent)">
+        <span id="${id}-val" style="flex:0 0 3rem;text-align:right;font-size:.75rem;color:var(--text-muted)"></span>
+      </div>`;
+    card.innerHTML = `
+      <h5 class="settings-section-subtitle">🪢 Braid text size</h5>
+      <p style="font-size:.75rem;color:var(--text-muted);margin:.25rem 0 0">Continuous sliders, layered on top of Zoom — chat text and interface text scale independently.</p>
+      ${row('braid-chat-scale', 'Chat text', 80, 160)}
+      ${row('braid-ui-scale', 'Interface text', 85, 140)}`;
+    anchor.after(card);
+    const wire = (id, key) => {
+      const input = card.querySelector(`#${id}`);
+      const val = card.querySelector(`#${id}-val`);
+      const current = Math.round((parseFloat(HavenApi.Data.load('BraidLayout', key, '1')) || 1) * 100);
+      input.value = current;
+      val.textContent = `${current}%`;
+      input.addEventListener('input', () => {
+        const scale = parseInt(input.value, 10) / 100;
+        val.textContent = `${input.value}%`;
+        HavenApi.Data.save('BraidLayout', key, String(scale));
+        document.documentElement.style.setProperty(key === 'chatScale' ? '--braid-chat-scale' : '--braid-ui-scale', scale);
+      });
+    };
+    wire('braid-chat-scale', 'chatScale');
+    wire('braid-ui-scale', 'uiScale');
+  }
+
+  // ── Hex loader ───────────────────────────────────────────
+  _showHexLoader() {
+    if (this._suspended || document.getElementById('braid-hex-overlay')) return;
+    const main = document.querySelector('.main');
+    if (!main) return;
+    const overlay = document.createElement('div');
+    overlay.id = 'braid-hex-overlay';
+    overlay.innerHTML = '<span class="braid-hex-loader" role="status" aria-label="Loading"></span>';
+    main.appendChild(overlay);
+    setTimeout(() => overlay.classList.add('braid-fade'), 520);
+    setTimeout(() => overlay.remove(), 740);
   }
 
   // ── Mod Mode interop ─────────────────────────────────────
@@ -363,13 +453,35 @@ class BraidLayout {
   // Chromium re-runs :has() invalidation on every sibling insert, which
   // made a 600-message channel load go quadratic (622ms vs 80ms).
   // Attribute marking here is O(n) per observer batch.
+  //
+  // Runs chain on AUTHOR, not on the app's compact grouping: consecutive
+  // posts by the same user (same persona, no explicit break_chain, not a
+  // system notice) merge into one card even when the app rendered them as
+  // separate full .message elements. A continuing .message gets
+  // data-braid-cont="1" — its avatar/header hide and its timestamp
+  // surfaces in the gutter on hover via data-time-short.
   _markRuns() {
     const runOf = (first, last) => (first ? (last ? 'solo' : 'start') : (last ? 'end' : 'mid'));
-    document.querySelectorAll('.messages > .message, .messages > .message-compact').forEach((el) => {
-      const next = el.nextElementSibling;
-      const v = runOf(el.classList.contains('message'), !next || !next.classList.contains('message-compact'));
+    const chainKey = (el) => {
+      if (!el || (!el.classList.contains('message') && !el.classList.contains('message-compact'))) return null;
+      if (el.classList.contains('system-message') || el.classList.contains('announcement')) return null;
+      return `${el.dataset.userId || '?'}|${el.dataset.personaId || ''}`;
+    };
+    const nodes = [...document.querySelectorAll('.messages > .message, .messages > .message-compact')];
+    for (let i = 0; i < nodes.length; i++) {
+      const el = nodes[i];
+      const key = chainKey(el);
+      const prevKey = i > 0 ? chainKey(nodes[i - 1]) : null;
+      const nextEl = i + 1 < nodes.length ? nodes[i + 1] : null;
+      const nextKey = chainKey(nextEl);
+      const first = !key || key !== prevKey || el.dataset.breakChain === '1';
+      const last = !key || key !== nextKey || (nextEl && nextEl.dataset.breakChain === '1');
+      const v = runOf(first, last);
       if (el.getAttribute('data-braid-run') !== v) el.setAttribute('data-braid-run', v);
-    });
+      const cont = !first && el.classList.contains('message') ? '1' : null;
+      if (cont) { if (el.getAttribute('data-braid-cont') !== '1') el.setAttribute('data-braid-cont', '1'); }
+      else if (el.hasAttribute('data-braid-cont')) el.removeAttribute('data-braid-cont');
+    }
     document.querySelectorAll('.channel-item').forEach((el) => {
       const prev = el.previousElementSibling;
       const next = el.nextElementSibling;
@@ -418,6 +530,7 @@ html[data-braid-layout="1"] .sidebar-mod-container{order:1;flex:1;min-height:0;o
 html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"],
 html[data-braid-layout="1"] .sidebar-section#admin-controls{border:0!important;padding:2px .625rem!important;margin:0!important}
 html:not([data-braid-layout="1"]) .braid-more-wrap,
+html:not([data-braid-layout="1"]) .braid-more-menu,
 html:not([data-braid-layout="1"]) .braid-server-strip{display:none!important}
 html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"] .section-label,
 html[data-braid-layout="1"] .sidebar-section#admin-controls .section-label{font-size:.71875rem!important;letter-spacing:0!important;text-transform:none!important;font-weight:550!important;color:var(--text-muted)!important;margin:2px 0!important;padding:.4375rem .5rem;border-radius:.625rem}
@@ -480,14 +593,30 @@ html[data-braid-layout="1"].braid-sound-open #soundboard-sidebar,
 html[data-braid-layout="1"].braid-sound-open .soundboard-sidebar{display:flex!important;visibility:visible!important;pointer-events:auto!important}
 html[data-braid-layout="1"].braid-status-open .status-bar,
 html[data-braid-layout="1"].braid-status-open #status-bar{display:flex!important;visibility:visible!important;pointer-events:auto!important}
+html[data-braid-layout="1"] .sidebar-bottom-bar{display:none!important}
 html[data-braid-layout="1"] .braid-more-wrap{position:relative}
 html[data-braid-layout="1"] .braid-more-btn{width:2.125rem;height:2.125rem;border:0;border-radius:.625rem;background:transparent;color:var(--text-muted);cursor:pointer;display:grid;place-items:center}
 html[data-braid-layout="1"] .braid-more-btn:hover{background:var(--bg-hover);color:var(--text-primary)}
-html[data-braid-layout="1"] .braid-more-menu{display:none;position:absolute;right:0;top:calc(100% + .375rem);min-width:13.75rem;z-index:50;background:var(--bg-card);border:1px solid var(--border);border-radius:.875rem;box-shadow:0 16px 48px -12px rgba(0,0,0,.22),var(--braid-shadow,0 1px 2px rgba(0,0,0,.2));padding:.375rem}
-html[data-braid-layout="1"] .braid-more-menu.open{display:block}
-html[data-braid-layout="1"] .braid-more-menu button{display:flex;width:100%;align-items:center;gap:.5rem;border:0;background:transparent;padding:.5625rem .625rem;border-radius:.625rem;font-size:.8125rem;font-weight:550;color:var(--text-primary);cursor:pointer;text-align:left}
+html[data-braid-layout="1"] .braid-ham{display:flex;flex-direction:column;justify-content:center;gap:.25rem;width:1.0625rem;height:1.0625rem}
+html[data-braid-layout="1"] .braid-ham-line{display:block;height:2px;width:100%;border-radius:2px;background:currentColor;transition:transform .28s cubic-bezier(.16,1,.3,1),opacity .18s ease;transform-origin:center}
+html[data-braid-layout="1"] .braid-more-wrap.open .braid-more-btn{color:var(--accent);background:color-mix(in srgb,var(--accent) 12%,transparent)}
+html[data-braid-layout="1"] .braid-more-wrap.open .braid-ham-line:nth-child(1){transform:translateY(.375rem) rotate(45deg)}
+html[data-braid-layout="1"] .braid-more-wrap.open .braid-ham-line:nth-child(2){opacity:0;transform:scaleX(.2)}
+html[data-braid-layout="1"] .braid-more-wrap.open .braid-ham-line:nth-child(3){transform:translateY(-.375rem) rotate(-45deg)}
+html[data-braid-layout="1"] .braid-more-menu{display:none;position:fixed;right:1rem;top:calc(var(--braid-bar-h,3rem) + .625rem);min-width:15rem;max-height:min(72vh,34rem);overflow:auto;z-index:90;background:var(--bg-card);border:1px solid var(--border);border-radius:.875rem;box-shadow:0 16px 48px -12px rgba(0,0,0,.22),var(--braid-shadow,0 1px 2px rgba(0,0,0,.2));padding:.375rem;transform-origin:top right}
+html[data-braid-layout="1"] .braid-more-menu.open{display:block;animation:braid-menu-pop .22s cubic-bezier(.16,1,.3,1) both}
+@keyframes braid-menu-pop{from{opacity:0;transform:scale(.92) translateY(-.25rem)}to{opacity:1;transform:none}}
+@keyframes braid-item-in{from{opacity:0;transform:translateY(-.375rem)}to{opacity:1;transform:none}}
+html[data-braid-layout="1"] .braid-more-menu.open>button,
+html[data-braid-layout="1"] .braid-more-menu.open>.braid-menu-label{animation:braid-item-in .3s cubic-bezier(.16,1,.3,1) both;animation-delay:calc(var(--i,0)*18ms)}
+html[data-braid-layout="1"] .braid-menu-label{font-size:.59375rem;font-weight:650;letter-spacing:.13em;text-transform:uppercase;color:var(--text-muted);padding:.5rem .625rem .25rem}
+html[data-braid-layout="1"] .braid-more-menu button{display:flex;width:100%;align-items:center;gap:.5rem;border:0;background:transparent;padding:.5rem .625rem;border-radius:.625rem;font-size:calc(.8125rem*var(--braid-ui-scale,1));font-weight:550;color:var(--text-primary);cursor:pointer;text-align:left}
 html[data-braid-layout="1"] .braid-more-menu button:hover{background:var(--bg-hover)}
 html[data-braid-layout="1"] .braid-more-menu .muted{color:var(--text-muted);font-size:.71875rem;font-weight:450;margin-left:auto}
+@media (prefers-reduced-motion: reduce){
+html[data-braid-layout="1"] .braid-more-menu.open,html[data-braid-layout="1"] .braid-more-menu.open>button,html[data-braid-layout="1"] .braid-more-menu.open>.braid-menu-label{animation:none!important}
+html[data-braid-layout="1"] .braid-ham-line{transition:none!important}
+}
 html[data-braid-layout="1"] .welcome-content{text-align:center;max-width:36ch;padding:2rem 1.25rem;margin:auto}
 html[data-braid-layout="1"] .welcome-content h2{font-size:1.625rem;font-weight:680;letter-spacing:-.035em;margin:0 0 .625rem}
 html[data-braid-layout="1"] .welcome-content p{color:var(--text-muted);font-size:.9375rem;line-height:1.5}
@@ -510,8 +639,8 @@ html[data-braid-form="1"]{
 --braid-bub:var(--bg-hover,var(--bg-card));
 --braid-line:var(--border);
 --braid-seam:color-mix(in srgb,var(--border) 55%,var(--braid-bub));
---braid-me:color-mix(in srgb,var(--accent) 12%,var(--bg-secondary));
---braid-me-line:color-mix(in srgb,var(--accent) 35%,var(--border));
+--braid-me:color-mix(in srgb,var(--accent) 8%,var(--bg-secondary));
+--braid-me-line:color-mix(in srgb,var(--accent) 26%,var(--border));
 --braid-gutter:3.625rem;
 }
 html[data-braid-form="1"] .message,
@@ -524,14 +653,27 @@ html[data-braid-form="1"] .message-avatar,
 html[data-braid-form="1"] .message-avatar-img{width:2.25rem!important;height:2.25rem!important;min-width:2.25rem!important;box-sizing:border-box!important;border:0!important;margin:0!important}
 html[data-braid-form="1"] .message:hover,
 html[data-braid-form="1"] .message-compact:hover{background:transparent!important}
+/* No internal horizontal borders inside a run — every body keeps only its
+   side rails; the run's top and bottom edges are drawn by start/end alone.
+   (The old base rule left border-bottom on every body, which stacked a
+   solid line under the dotted seam and read as a full-width divider.) */
 html[data-braid-form="1"] .message>.message-row>.message-body,
-html[data-braid-form="1"] .message-compact>.message-body{position:relative;flex:1 1 auto;min-width:0;background:var(--braid-bub);border:1px solid var(--braid-line);border-top:0;border-radius:0;padding:.3125rem .8125rem}
+html[data-braid-form="1"] .message-compact>.message-body{position:relative;flex:1 1 auto;min-width:0;background:var(--braid-bub);border:1px solid var(--braid-line);border-top:0;border-bottom:0;border-radius:0;padding:.3125rem .8125rem}
 html[data-braid-form="1"] .message[data-braid-run="start"]>.message-row>.message-body,
 html[data-braid-form="1"] .message[data-braid-run="solo"]>.message-row>.message-body{border-top:1px solid var(--braid-line);border-top-left-radius:var(--braid-r);border-top-right-radius:var(--braid-r);padding-top:.5625rem;margin-top:.5rem}
 html[data-braid-form="1"] .message[data-braid-run="end"]>.message-row>.message-body,
 html[data-braid-form="1"] .message[data-braid-run="solo"]>.message-row>.message-body,
-html[data-braid-form="1"] .message-compact[data-braid-run="end"]>.message-body{border-bottom-left-radius:var(--braid-r);border-bottom-right-radius:var(--braid-r);padding-bottom:.5625rem;margin-bottom:.5rem}
-html[data-braid-form="1"] .message-compact>.message-body::before{content:'';position:absolute;left:50%;transform:translateX(-50%);width:min(7rem,45%);top:0;border-top:1px dotted color-mix(in srgb,var(--braid-seam) 75%,transparent);pointer-events:none}
+html[data-braid-form="1"] .message-compact[data-braid-run="end"]>.message-body{border-bottom:1px solid var(--braid-line);border-bottom-left-radius:var(--braid-r);border-bottom-right-radius:var(--braid-r);padding-bottom:.5625rem;margin-bottom:.5rem}
+/* the only separator inside a run: a small centered dotted seam */
+html[data-braid-form="1"] .message-compact>.message-body::before,
+html[data-braid-form="1"] .message[data-braid-cont="1"]>.message-row>.message-body::before{content:'';position:absolute;left:50%;transform:translateX(-50%);width:min(7rem,45%);top:0;border-top:1px dotted color-mix(in srgb,var(--braid-seam) 75%,transparent);pointer-events:none}
+/* a .message continuing another author-run: no repeated avatar/header —
+   the gutter keeps its width, and the post's own time shows there on hover */
+html[data-braid-form="1"] .message[data-braid-cont="1"]{position:relative}
+html[data-braid-form="1"] .message[data-braid-cont="1"] .message-avatar,
+html[data-braid-form="1"] .message[data-braid-cont="1"] .message-avatar-img{visibility:hidden}
+html[data-braid-form="1"] .message[data-braid-cont="1"]>.message-row>.message-body>.message-header{display:none}
+html[data-braid-form="1"] .message[data-braid-cont="1"]:hover::before{content:attr(data-time-short);position:absolute;left:.625rem;top:.5rem;width:2.25rem;text-align:center;font-size:.5625rem;line-height:1.2;color:var(--text-muted);pointer-events:none}
 html[data-braid-form="1"] .message>.message-row>.message-body:hover,
 html[data-braid-form="1"] .message-compact>.message-body:hover{background:color-mix(in srgb,var(--bg-active) 40%,var(--braid-bub))}
 html[data-braid-form="1"] .message-user-sep{border-top:0!important;padding-top:0!important}
@@ -641,6 +783,46 @@ html[data-braid-layout="1"] .settings-section select,
 html[data-braid-layout="1"] .settings-section input[type="text"],
 html[data-braid-layout="1"] .settings-section input[type="password"],
 html[data-braid-layout="1"] .settings-section input[type="number"]{border-radius:.625rem!important;border:1px solid var(--border)!important;background:var(--bg-input)!important;padding:.5rem .75rem!important}
+
+/* ── Haven logo glow-up ── the brand hexagon breathes in the accent */
+@keyframes braid-logo-breathe{
+0%,100%{filter:drop-shadow(0 0 2px color-mix(in srgb,var(--accent) 45%,transparent)) drop-shadow(0 0 7px color-mix(in srgb,var(--accent) 22%,transparent))}
+50%{filter:drop-shadow(0 0 4px color-mix(in srgb,var(--accent) 70%,transparent)) drop-shadow(0 0 14px color-mix(in srgb,var(--accent) 38%,transparent))}
+}
+html[data-braid-layout="1"] .brand .logo-sm,
+html[data-braid-layout="1"] .sidebar-header .logo-sm{color:var(--accent)!important;animation:braid-logo-breathe 3.6s ease-in-out infinite;transition:transform .45s cubic-bezier(.16,1,.3,1);display:inline-block}
+html[data-braid-layout="1"] .brand:hover .logo-sm{transform:rotate(120deg) scale(1.12)}
+@media (prefers-reduced-motion: reduce){
+html[data-braid-layout="1"] .brand .logo-sm,html[data-braid-layout="1"] .sidebar-header .logo-sm{animation:none!important;filter:drop-shadow(0 0 4px color-mix(in srgb,var(--accent) 40%,transparent))}
+}
+
+/* ── Hexagonal loading indicator ── a mint hex ring that spins while a
+   solid core hexagon pulses inside it; also reskins the setup wizard's
+   stock circular spinner. */
+@keyframes braid-hex-spin{to{transform:rotate(360deg)}}
+@keyframes braid-hex-pulse{0%,100%{transform:scale(.55);opacity:.5}50%{transform:scale(.8);opacity:1}}
+html[data-braid-layout="1"] .braid-hex-loader{position:relative;width:2.75rem;height:2.75rem;display:inline-block}
+html[data-braid-layout="1"] .braid-hex-loader::before{content:'';position:absolute;inset:0;background:conic-gradient(from 0deg,transparent 0 40%,var(--accent) 78%,transparent 78.5%);clip-path:polygon(50% 0,93.3% 25%,93.3% 75%,50% 100%,6.7% 75%,6.7% 25%,50% 0,50% 12%,17% 31%,17% 69%,50% 88%,83% 69%,83% 31%,50% 12%);animation:braid-hex-spin 1.1s linear infinite}
+html[data-braid-layout="1"] .braid-hex-loader::after{content:'';position:absolute;inset:0;background:var(--accent);clip-path:polygon(50% 0,93.3% 25%,93.3% 75%,50% 100%,6.7% 75%,6.7% 25%);animation:braid-hex-pulse 1.4s ease-in-out infinite}
+html[data-braid-layout="1"] #braid-hex-overlay{position:absolute;inset:0;z-index:30;display:grid;place-items:center;background:color-mix(in srgb,var(--bg-primary) 55%,transparent);backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px);opacity:1;transition:opacity .2s ease}
+html[data-braid-layout="1"] #braid-hex-overlay.braid-fade{opacity:0}
+html[data-braid-layout="1"] .wizard-spinner{border:0!important;border-radius:0!important;width:2.75rem!important;height:2.75rem!important;background:conic-gradient(from 0deg,transparent 0 40%,var(--accent) 78%,transparent 78.5%);clip-path:polygon(50% 0,93.3% 25%,93.3% 75%,50% 100%,6.7% 75%,6.7% 25%,50% 0,50% 12%,17% 31%,17% 69%,50% 88%,83% 69%,83% 31%,50% 12%);animation:braid-hex-spin 1.1s linear infinite!important}
+@media (prefers-reduced-motion: reduce){
+html[data-braid-layout="1"] .braid-hex-loader::before,html[data-braid-layout="1"] .braid-hex-loader::after,html[data-braid-layout="1"] .wizard-spinner{animation:none!important}
+}
+
+/* ── Text size sliders ── two continuous scales layered over rem zoom:
+   chat text and UI chrome text, both live-adjustable from Settings. */
+html[data-braid-layout="1"] .message-text,
+html[data-braid-layout="1"] .message-content{font-size:calc(.9375rem*var(--braid-chat-scale,1))!important}
+html[data-braid-layout="1"] .message-header .message-author{font-size:calc(.875rem*var(--braid-chat-scale,1))!important}
+html[data-braid-layout="1"] .channel-name{font-size:calc(.875rem*var(--braid-ui-scale,1))!important}
+html[data-braid-layout="1"] .brand-text{font-size:calc(1rem*var(--braid-ui-scale,1))!important}
+html[data-braid-layout="1"] #channel-header-name{font-size:calc(.90625rem*var(--braid-ui-scale,1))!important}
+html[data-braid-layout="1"] .section-label{font-size:calc(.625rem*var(--braid-ui-scale,1))!important}
+html[data-braid-layout="1"] .settings-nav-item{font-size:calc(.8125rem*var(--braid-ui-scale,1))!important}
+html[data-braid-layout="1"] .current-user{font-size:calc(.8125rem*var(--braid-ui-scale,1))!important}
+html[data-braid-layout="1"] .user-item,html[data-braid-layout="1"] .member-item{font-size:calc(.8125rem*var(--braid-ui-scale,1))}
 `;
 
 BraidLayout._MOTION_CSS = `

--- a/server.js
+++ b/server.js
@@ -4097,6 +4097,12 @@ if (useSSL) {
     // Timeout to prevent Slowloris on redirect server
     httpRedirectServer.headersTimeout = 5000;
     httpRedirectServer.requestTimeout = 5000;
+    // The redirect listener is a nicety — if its port is taken (or
+    // binding it needs elevation), warn and carry on with HTTPS alone
+    // rather than letting the bind error become an uncaught exception.
+    httpRedirectServer.on('error', (err) => {
+      console.warn(`⚠️  HTTP→HTTPS redirect server could not bind port ${HTTP_REDIRECT_PORT} (${(err && err.code) || err}). HTTPS continues on port ${safePort}.`);
+    });
     httpRedirectServer.listen(HTTP_REDIRECT_PORT, process.env.HOST || '0.0.0.0', () => {
       console.log(`â†ªï¸  HTTP redirect running on port ${HTTP_REDIRECT_PORT} → HTTPS`);
     });
@@ -4797,6 +4803,29 @@ server.headersTimeout = 15000;     // 15s to send all headers
 server.requestTimeout = 3600000;   // 1h max to finish sending a request body (large restore uploads)
 server.keepAliveTimeout = 65000;   // slightly above typical ALB/LB timeout
 server.timeout = 120000;           // 2 min socket inactivity timeout (resets on I/O)
+
+// ── Fatal listen errors must be loud ─────────────────────
+// A failed bind (port already taken, no permission) surfaces as an
+// async 'error' event.  Without this handler it falls through to the
+// global uncaughtException keep-alive below, which writes it to
+// crash.log and keeps a process alive that never got its socket —
+// to the user that is a silent crash on launch: no banner, no error,
+// no exit, and the stale port-holder makes launch scripts think the
+// server came up.  Bind failures are fatal: say why, then exit.
+server.on('error', (err) => {
+  if (err && (err.code === 'EADDRINUSE' || err.code === 'EACCES' || err.code === 'EADDRNOTAVAIL')) {
+    const why = err.code === 'EADDRINUSE'
+      ? `port ${PORT} is already in use — is another Haven instance (or other app) running?`
+      : err.code === 'EADDRNOTAVAIL'
+        ? `this machine has no network interface with address ${HOST} — check HOST in your .env`
+        : `no permission to bind port ${PORT} (ports below 1024 need elevation)`;
+    console.error(`\n❌ Haven could not start: ${why}`);
+    console.error(`   Stop the other process or change PORT in your .env, then start Haven again.`);
+    logCrash('Fatal listen error (exiting)', err);
+    process.exit(1);
+  }
+  logCrash('HTTP server error (server kept alive)', err);
+});
 
 server.listen(PORT, HOST, () => {
   console.log(`

--- a/themes/braid-light.theme.css
+++ b/themes/braid-light.theme.css
@@ -1,0 +1,171 @@
+/**
+ * @name        Braid Light
+ * @description Braid's airy light look — white surfaces, deep green accent, soft rounded corners. Pairs with the Braid Layout plugin.
+ * @author      Amnibro
+ * @version     1.0
+ * @icon        🍃
+ */
+
+/*
+  Braid — light. Palette is 1:1 with Haven-Mobile's BRAID_LIGHT preset
+  (deep green #00875a on white, radius scale 1.6). File themes load on
+  the stable "haven" layout base, so tokens live on :root and win over
+  style.css by cascade order. Sizes are rem so the interface Zoom
+  slider scales Braid chrome together with everything else.
+*/
+
+:root {
+  /* ── Backgrounds ───────────────────────────────── */
+  --bg-primary:    #f7f7f8;
+  --bg-secondary:  #ffffff;
+  --bg-tertiary:   #efeff1;
+  --bg-hover:      #eaeaed;
+  --bg-active:     #e0e0e4;
+  --bg-input:      #ffffff;
+  --bg-card:       #ffffff;
+
+  /* ── Accent ────────────────────────────────────── */
+  --accent:        #00875a;
+  --accent-hover:  #0a8f63;
+  --accent-dim:    #00694a;
+  --accent-glow:   rgba(0, 135, 90, .22);
+
+  /* ── Text ──────────────────────────────────────── */
+  --text-primary:  #09090b;
+  --text-secondary:#3f3f46;
+  --text-muted:    #71717a;
+  --text-link:     #00875a;
+
+  /* ── Borders ───────────────────────────────────── */
+  --border:        #e4e4e7;
+  --border-light:  #d4d4d8;
+
+  /* ── Status ────────────────────────────────────── */
+  --success:       #15803d;
+  --danger:        #dc2626;
+  --warning:       #b45309;
+  --led-on:        #15803d;
+  --led-off:       #d4d4d8;
+  --led-glow:      rgba(21, 128, 61, .3);
+
+  /* ── Typography ────────────────────────────────── */
+  --font-main:     -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, Inter, sans-serif;
+  --font-heading:  -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+  --font-mono:     ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* ── Shape (the Braid signature: 1.6× rounder) ─── */
+  --radius:        .875rem;
+  --radius-sm:     .75rem;
+  --braid-r:       .875rem;
+  --braid-shadow:  0 1px 2px rgba(0, 0, 0, .04), 0 8px 24px -12px rgba(0, 0, 0, .1);
+
+  --theme-logo:    "⬡";
+  --msg-glow:      none;
+  --scanline:      none;
+}
+
+/* ── Base type & chrome ──────────────────────────── */
+html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; background: var(--bg-primary); }
+body { background: var(--bg-primary) !important; color: var(--text-primary) !important; font: 400 .9375rem/1.5 var(--font-main); letter-spacing: -.011em; }
+:focus-visible { outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent); outline-offset: 2px; border-radius: .5rem; }
+::-webkit-scrollbar { width: .5rem; height: .5rem; }
+::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 999px; border: 2px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-muted); background-clip: padding-box; border: 2px solid transparent; }
+
+/* ── Server rail ─────────────────────────────────── */
+.server-bar { background: var(--bg-tertiary) !important; border-right: 1px solid var(--border) !important; padding: 1rem 0; gap: .625rem; }
+.server-icon { width: 2.75rem !important; height: 2.75rem !important; border-radius: var(--braid-r) !important; background: var(--bg-tertiary); box-shadow: none !important; transition: background .15s, border-radius .15s, transform .12s; border: 0; }
+.server-icon:hover { border-radius: var(--braid-r) !important; background: var(--bg-hover) !important; transform: none; }
+.server-icon.home { background: var(--accent) !important; box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent) !important; border: 0 !important; }
+.server-icon.home:hover { background: var(--accent-hover) !important; }
+.server-icon.add-server, .server-icon.manage-servers, .server-icon.sync-servers { border: 1px solid var(--border-light) !important; background: transparent !important; }
+.server-icon.add-server:hover, .server-icon.manage-servers:hover, .server-icon.sync-servers:hover { border-color: color-mix(in srgb, var(--accent) 50%, var(--border)) !important; background: var(--bg-hover) !important; }
+.server-separator { width: 1.75rem; height: 1px; background: var(--border); margin: .25rem 0; border-radius: 1px; }
+
+/* ── Sidebar ─────────────────────────────────────── */
+.sidebar { background: var(--bg-secondary) !important; border-right: 1px solid var(--border) !important; box-shadow: none !important; }
+.sidebar-header { padding: 1rem .875rem .875rem !important; border-bottom: 1px solid var(--border) !important; background: color-mix(in srgb, var(--bg-secondary) 90%, transparent) !important; backdrop-filter: saturate(180%) blur(16px); -webkit-backdrop-filter: saturate(180%) blur(16px); }
+.brand { gap: .5rem; margin-bottom: .625rem; }
+.brand-text { font-size: 1rem !important; font-weight: 650 !important; letter-spacing: -.03em !important; text-transform: none !important; text-shadow: none !important; -webkit-text-fill-color: unset !important; background: none !important; color: var(--text-primary) !important; }
+.user-bar { padding: .625rem .75rem; background: var(--bg-tertiary) !important; border: 1px solid var(--border) !important; border-radius: var(--braid-r) !important; }
+.current-user { font-size: .8125rem; font-weight: 600; letter-spacing: -.01em; }
+.icon-btn { width: 2.125rem; height: 2.125rem; padding: 0; border-radius: .625rem; color: var(--text-muted); }
+.icon-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.section-label { font-size: .625rem; font-weight: 650; letter-spacing: .13em; margin: .875rem .625rem .5rem; color: var(--text-muted); }
+.channel-item { margin: 2px .625rem !important; padding: .625rem .75rem !important; border-radius: var(--radius-sm) !important; gap: .5rem; }
+.channel-item:hover { background: var(--bg-hover); }
+.channel-item.active { background: var(--bg-active); }
+.channel-item.active::before { display: none !important; }
+.channel-name { font-size: .875rem !important; font-weight: 550 !important; letter-spacing: -.015em !important; }
+.channel-voice-user { margin: 0 .5rem 0 1.75rem; padding: .25rem .5rem; border-radius: .5rem; }
+.input-row input { padding: .5rem .75rem; border-radius: .625rem; background: var(--bg-input); border: 1px solid var(--border); font-size: .8125rem; }
+.input-row input:focus { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent); }
+.btn-sm { border-radius: .625rem; padding: .5rem .75rem; font-weight: 550; }
+
+/* ── Chat area ───────────────────────────────────── */
+.main, .main-content, .chat-area, #chat-area, .center-panel { background: var(--bg-primary) !important; }
+.chat-header, .channel-header, #channel-header { min-height: 3.25rem !important; border-bottom: 1px solid var(--border) !important; background: color-mix(in srgb, var(--bg-secondary) 90%, transparent) !important; backdrop-filter: saturate(180%) blur(16px); -webkit-backdrop-filter: saturate(180%) blur(16px); box-shadow: none !important; }
+.channel-header h2, .chat-header h2, .channel-title, #channel-header-name { font-size: .9375rem !important; font-weight: 650 !important; letter-spacing: -.02em !important; }
+.header-actions-box { border: 1px solid var(--border) !important; border-radius: .75rem !important; background: var(--bg-tertiary) !important; padding: .25rem .5rem !important; }
+.messages { padding: 1.5rem 1.75rem .75rem !important; gap: .25rem; width: 100%; box-sizing: border-box; }
+.message { border-radius: var(--braid-r) !important; }
+.message:hover { background: rgba(0, 0, 0, .03) !important; box-shadow: none !important; }
+.message-row { gap: .875rem !important; padding: .5rem .75rem !important; }
+.message-avatar, .message-avatar-img { width: 2.375rem !important; height: 2.375rem !important; border-radius: .75rem !important; border: 0 !important; box-shadow: none !important; }
+.message-author, .message-username { font-weight: 650; letter-spacing: -.01em; }
+.message-text, .message-content { font-size: .9375rem !important; line-height: 1.58 !important; letter-spacing: -.01em; color: var(--text-primary); text-shadow: none !important; }
+.message-input-area, .message-input-container { padding: .875rem 1.375rem 1.125rem !important; background: color-mix(in srgb, var(--bg-secondary) 92%, transparent) !important; border-top: 1px solid var(--border) !important; backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); gap: .5rem; border-radius: 0 !important; }
+.message-input-area textarea, .message-input-container textarea { padding: .875rem 1rem !important; border-radius: 1.25rem !important; background: var(--bg-card) !important; border: 1px solid var(--border-light) !important; font-size: .96875rem !important; line-height: 1.45 !important; box-shadow: var(--braid-shadow) !important; transition: border-color .15s, box-shadow .15s; }
+.message-input-area textarea:focus, .message-input-container textarea:focus { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)) !important; box-shadow: var(--braid-shadow), 0 0 0 4px color-mix(in srgb, var(--accent) 12%, transparent) !important; }
+.btn-send, .thread-send-btn { width: 2.5rem !important; height: 2.5rem !important; border-radius: var(--braid-r) !important; background: var(--accent) !important; color: #ffffff !important; box-shadow: none !important; border: 0 !important; }
+.btn-send:hover, .thread-send-btn:hover { background: var(--accent-hover) !important; transform: scale(.98); filter: none !important; }
+
+/* ── Right sidebar / members ─────────────────────── */
+.right-sidebar { background: var(--bg-secondary) !important; border-left: 1px solid var(--border) !important; }
+.user-item, .member-item { margin: 2px .625rem; padding: .625rem .75rem; border-radius: var(--radius-sm); }
+.user-item:hover, .member-item:hover { background: var(--bg-hover); }
+
+/* ── Modals, menus, popups ───────────────────────── */
+.modal, .modal-content, .settings-modal, .dialog, .settings-panel { border-radius: 1.125rem !important; border: 1px solid var(--border) !important; box-shadow: 0 16px 48px -12px rgba(0, 0, 0, .18), var(--braid-shadow) !important; background: var(--bg-card) !important; }
+.modal-header, .settings-header { border-bottom: 1px solid var(--border) !important; background: transparent !important; }
+.settings-tab, .settings-nav-item, .sound-tab { border-radius: .625rem !important; }
+.settings-tab.active, .settings-nav-item.active, .sound-tab.active { background: color-mix(in srgb, var(--accent) 16%, var(--bg-tertiary)) !important; color: var(--accent) !important; border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent) !important; }
+.btn-primary, .btn-accent, .profile-dm-btn, .btn-admin-save { border-radius: .75rem !important; font-weight: 600 !important; letter-spacing: -.01em; box-shadow: none !important; }
+.btn-secondary, .btn.secondary { border-radius: .75rem !important; border: 1px solid var(--border-light) !important; background: var(--bg-tertiary) !important; }
+.context-menu, .dropdown-menu, .msg-toolbar { border-radius: var(--braid-r) !important; border: 1px solid var(--border) !important; box-shadow: var(--braid-shadow) !important; background: var(--bg-card) !important; }
+.profile-popup, .profile-card { border-radius: 1rem !important; border: 1px solid var(--border) !important; box-shadow: var(--braid-shadow) !important; }
+.theme-btn { border-radius: .75rem !important; }
+.reaction, .reaction-chip, .reaction-badge { border-radius: 999px !important; }
+.toast, .notification-toast, .chip-toast { border-radius: 999px !important; backdrop-filter: blur(10px); }
+.jump-to-bottom { border-radius: 999px !important; border: 1px solid var(--border-light) !important; box-shadow: var(--braid-shadow) !important; }
+.inline-code, code { border-radius: .375rem !important; background: var(--bg-tertiary) !important; border: 1px solid var(--border) !important; }
+.mention { border-radius: .375rem !important; }
+
+/* ── Voice ───────────────────────────────────────── */
+.voice-bar, .voice-panel, .vc-bar, .voice-status-bar { border-top: 1px solid var(--border) !important; background: var(--bg-secondary) !important; box-shadow: none !important; }
+.btn-voice, .voice-panel-btn, .voice-header-btn { border-radius: .75rem !important; border: 1px solid var(--border) !important; background: var(--bg-tertiary) !important; color: var(--text-secondary) !important; box-shadow: none !important; }
+.btn-voice:hover, .voice-panel-btn:hover, .voice-header-btn:hover { background: var(--bg-hover) !important; color: var(--text-primary) !important; }
+.btn-voice.active, .voice-panel-btn.active, .voice-header-btn.active { background: color-mix(in srgb, var(--accent) 18%, var(--bg-tertiary)) !important; color: var(--accent) !important; border-color: color-mix(in srgb, var(--accent) 35%, var(--border)) !important; }
+.btn-voice.btn-danger, .voice-panel-leave, .voice-header-leave { border-radius: .75rem !important; background: color-mix(in srgb, var(--danger) 12%, var(--bg-tertiary)) !important; color: var(--danger) !important; border: 1px solid color-mix(in srgb, var(--danger) 30%, var(--border)) !important; }
+.channel-voice-indicator { color: var(--success); }
+.music-panel { border-bottom: 1px solid var(--border) !important; background: var(--bg-secondary) !important; border-radius: 0; }
+.music-panel-controls button, .music-btn { border-radius: .625rem !important; }
+
+/* ── Login page ──────────────────────────────────── */
+.auth-page { background: var(--bg-primary) !important; background-image: none !important; }
+.auth-card { border-radius: 1.25rem !important; border: 1px solid var(--border) !important; box-shadow: var(--braid-shadow) !important; background: var(--bg-card) !important; padding: 2.5rem 2.25rem !important; }
+.auth-header .logo { font-size: 2.5rem; width: 4rem; height: 4rem; margin: 0 auto .5rem; display: grid; place-items: center; border-radius: 1.125rem; background: color-mix(in srgb, var(--accent) 12%, var(--bg-tertiary)); border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border)); color: var(--accent); }
+.auth-header h1 { font-size: 1.375rem !important; font-weight: 680 !important; letter-spacing: -.04em !important; text-transform: none; }
+.auth-header .tagline { font-size: .84375rem !important; color: var(--text-muted) !important; margin-top: .375rem !important; }
+.auth-tabs { background: var(--bg-tertiary) !important; border: 1px solid var(--border); border-radius: .75rem !important; padding: .25rem !important; }
+.auth-tab { border-radius: .625rem !important; font-weight: 550; }
+.auth-tab.active { background: var(--accent) !important; color: #ffffff !important; }
+.form-group label { font-size: .6875rem !important; letter-spacing: .06em !important; color: var(--text-muted) !important; }
+.form-group input, .form-select { border-radius: .75rem !important; padding: .75rem .875rem !important; border: 1px solid var(--border) !important; background: var(--bg-input) !important; }
+.form-group input:focus, .form-select:focus { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)) !important; box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent); }
+
+@media (max-width: 56.25rem) {
+  .messages { padding: 1rem .875rem .625rem !important; max-width: none; }
+  .message-input-area, .message-input-container { padding: .625rem .75rem .875rem !important; }
+  .auth-card { padding: 1.75rem 1.25rem !important; }
+}

--- a/themes/braid-light.theme.css
+++ b/themes/braid-light.theme.css
@@ -64,6 +64,21 @@
   --scanline:      none;
 }
 
+
+/* == Type & color enforcement == make the Braid type stack and palette
+   land everywhere, over style.css's own per-element declarations. */
+body, button, input, textarea, select { font-family: var(--font-main) !important; }
+h1, h2, h3, h4, h5, h6, .brand-text, .auth-header h1 { font-family: var(--font-heading) !important; }
+::selection { background: color-mix(in srgb, var(--accent) 30%, transparent); color: var(--text-primary); }
+::placeholder { color: var(--text-muted) !important; opacity: 1; }
+a, .text-link { color: var(--text-link); }
+.message-time, .msg-time, .message-header .msg-time, .timestamp { color: var(--text-muted) !important; }
+.message-text, .message-content { color: var(--text-primary) !important; }
+.message-text a, .message-content a { color: var(--text-link) !important; }
+.section-label, .settings-nav-group-label, .braid-menu-label { color: var(--text-muted) !important; }
+.channel-name, .current-user, #channel-header-name { color: var(--text-primary) !important; }
+.channel-topic-bar { color: var(--text-muted) !important; }
+
 /* ── Base type & chrome ──────────────────────────── */
 html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; background: var(--bg-primary); }
 body { background: var(--bg-primary) !important; color: var(--text-primary) !important; font: 400 .9375rem/1.5 var(--font-main); letter-spacing: -.011em; }

--- a/themes/braid.theme.css
+++ b/themes/braid.theme.css
@@ -1,0 +1,171 @@
+/**
+ * @name        Braid
+ * @description Mint-on-slate with soft rounded corners and a calm, decluttered look. Pairs with the Braid Layout plugin.
+ * @author      Amnibro
+ * @version     1.0
+ * @icon        🪢
+ */
+
+/*
+  Braid — dark. Palette is 1:1 with Haven-Mobile's BRAID preset
+  (mint #00ff9d on slate, radius scale 1.6). File themes load on the
+  stable "haven" layout base, so tokens live on :root and win over
+  style.css by cascade order. Sizes are rem so the interface Zoom
+  slider scales Braid chrome together with everything else.
+*/
+
+:root {
+  /* ── Backgrounds ───────────────────────────────── */
+  --bg-primary:    #0b0d12;
+  --bg-secondary:  #161a22;
+  --bg-tertiary:   #10131a;
+  --bg-hover:      #1c212b;
+  --bg-active:     #232936;
+  --bg-input:     #0e1218;
+  --bg-card:       #131720;
+
+  /* ── Accent ────────────────────────────────────── */
+  --accent:        #00ff9d;
+  --accent-hover:  #2ce8a0;
+  --accent-dim:    #00c97c;
+  --accent-glow:   rgba(0, 255, 157, .32);
+
+  /* ── Text ──────────────────────────────────────── */
+  --text-primary:  #eef1f6;
+  --text-secondary:#c8d0dc;
+  --text-muted:    #9aa3b2;
+  --text-link:     #7ec8ff;
+
+  /* ── Borders ───────────────────────────────────── */
+  --border:        #2a3140;
+  --border-light:  #3a4254;
+
+  /* ── Status ────────────────────────────────────── */
+  --success:       #3dd68c;
+  --danger:        #ff6b6b;
+  --warning:       #e3b341;
+  --led-on:        #3dd68c;
+  --led-off:       #3a4254;
+  --led-glow:      rgba(61, 214, 140, .35);
+
+  /* ── Typography ────────────────────────────────── */
+  --font-main:     -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, Inter, sans-serif;
+  --font-heading:  -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+  --font-mono:     ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* ── Shape (the Braid signature: 1.6× rounder) ─── */
+  --radius:        .875rem;
+  --radius-sm:     .75rem;
+  --braid-r:       .875rem;
+  --braid-shadow:  0 1px 2px rgba(0, 0, 0, .35), 0 8px 24px -12px rgba(0, 0, 0, .55);
+
+  --theme-logo:    "⬡";
+  --msg-glow:      none;
+  --scanline:      none;
+}
+
+/* ── Base type & chrome ──────────────────────────── */
+html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; background: var(--bg-primary); }
+body { background: var(--bg-primary) !important; color: var(--text-primary) !important; font: 400 .9375rem/1.5 var(--font-main); letter-spacing: -.011em; }
+:focus-visible { outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent); outline-offset: 2px; border-radius: .5rem; }
+::-webkit-scrollbar { width: .5rem; height: .5rem; }
+::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 999px; border: 2px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-muted); background-clip: padding-box; border: 2px solid transparent; }
+
+/* ── Server rail ─────────────────────────────────── */
+.server-bar { background: var(--bg-primary) !important; border-right: 1px solid var(--border) !important; padding: 1rem 0; gap: .625rem; }
+.server-icon { width: 2.75rem !important; height: 2.75rem !important; border-radius: var(--braid-r) !important; background: var(--bg-tertiary); box-shadow: none !important; transition: background .15s, border-radius .15s, transform .12s; border: 0; }
+.server-icon:hover { border-radius: var(--braid-r) !important; background: var(--bg-hover) !important; transform: none; }
+.server-icon.home { background: color-mix(in srgb, var(--accent) 88%, #000) !important; box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent) !important; border: 0 !important; }
+.server-icon.home:hover { background: var(--accent-hover) !important; }
+.server-icon.add-server, .server-icon.manage-servers, .server-icon.sync-servers { border: 1px solid var(--border-light) !important; background: transparent !important; }
+.server-icon.add-server:hover, .server-icon.manage-servers:hover, .server-icon.sync-servers:hover { border-color: color-mix(in srgb, var(--accent) 50%, var(--border)) !important; background: var(--bg-hover) !important; }
+.server-separator { width: 1.75rem; height: 1px; background: var(--border); margin: .25rem 0; border-radius: 1px; }
+
+/* ── Sidebar ─────────────────────────────────────── */
+.sidebar { background: var(--bg-secondary) !important; border-right: 1px solid var(--border) !important; box-shadow: none !important; }
+.sidebar-header { padding: 1rem .875rem .875rem !important; border-bottom: 1px solid var(--border) !important; background: color-mix(in srgb, var(--bg-secondary) 90%, transparent) !important; backdrop-filter: saturate(180%) blur(16px); -webkit-backdrop-filter: saturate(180%) blur(16px); }
+.brand { gap: .5rem; margin-bottom: .625rem; }
+.brand-text { font-size: 1rem !important; font-weight: 650 !important; letter-spacing: -.03em !important; text-transform: none !important; text-shadow: none !important; -webkit-text-fill-color: unset !important; background: none !important; color: var(--text-primary) !important; }
+.user-bar { padding: .625rem .75rem; background: var(--bg-tertiary) !important; border: 1px solid var(--border) !important; border-radius: var(--braid-r) !important; }
+.current-user { font-size: .8125rem; font-weight: 600; letter-spacing: -.01em; }
+.icon-btn { width: 2.125rem; height: 2.125rem; padding: 0; border-radius: .625rem; color: var(--text-muted); }
+.icon-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.section-label { font-size: .625rem; font-weight: 650; letter-spacing: .13em; margin: .875rem .625rem .5rem; color: var(--text-muted); }
+.channel-item { margin: 2px .625rem !important; padding: .625rem .75rem !important; border-radius: var(--radius-sm) !important; gap: .5rem; }
+.channel-item:hover { background: var(--bg-hover); }
+.channel-item.active { background: var(--bg-active); }
+.channel-item.active::before { display: none !important; }
+.channel-name { font-size: .875rem !important; font-weight: 550 !important; letter-spacing: -.015em !important; }
+.channel-voice-user { margin: 0 .5rem 0 1.75rem; padding: .25rem .5rem; border-radius: .5rem; }
+.input-row input { padding: .5rem .75rem; border-radius: .625rem; background: var(--bg-input); border: 1px solid var(--border); font-size: .8125rem; }
+.input-row input:focus { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent); }
+.btn-sm { border-radius: .625rem; padding: .5rem .75rem; font-weight: 550; }
+
+/* ── Chat area ───────────────────────────────────── */
+.main, .main-content, .chat-area, #chat-area, .center-panel { background: var(--bg-primary) !important; }
+.chat-header, .channel-header, #channel-header { min-height: 3.25rem !important; border-bottom: 1px solid var(--border) !important; background: color-mix(in srgb, var(--bg-secondary) 90%, transparent) !important; backdrop-filter: saturate(180%) blur(16px); -webkit-backdrop-filter: saturate(180%) blur(16px); box-shadow: none !important; }
+.channel-header h2, .chat-header h2, .channel-title, #channel-header-name { font-size: .9375rem !important; font-weight: 650 !important; letter-spacing: -.02em !important; }
+.header-actions-box { border: 1px solid var(--border) !important; border-radius: .75rem !important; background: var(--bg-tertiary) !important; padding: .25rem .5rem !important; }
+.messages { padding: 1.5rem 1.75rem .75rem !important; gap: .25rem; width: 100%; box-sizing: border-box; }
+.message { border-radius: var(--braid-r) !important; }
+.message:hover { background: color-mix(in srgb, var(--bg-hover) 80%, transparent) !important; box-shadow: none !important; }
+.message-row { gap: .875rem !important; padding: .5rem .75rem !important; }
+.message-avatar, .message-avatar-img { width: 2.375rem !important; height: 2.375rem !important; border-radius: .75rem !important; border: 0 !important; box-shadow: none !important; }
+.message-author, .message-username { font-weight: 650; letter-spacing: -.01em; }
+.message-text, .message-content { font-size: .9375rem !important; line-height: 1.58 !important; letter-spacing: -.01em; color: var(--text-primary); text-shadow: none !important; }
+.message-input-area, .message-input-container { padding: .875rem 1.375rem 1.125rem !important; background: color-mix(in srgb, var(--bg-secondary) 92%, transparent) !important; border-top: 1px solid var(--border) !important; backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); gap: .5rem; border-radius: 0 !important; }
+.message-input-area textarea, .message-input-container textarea { padding: .875rem 1rem !important; border-radius: 1.25rem !important; background: var(--bg-card) !important; border: 1px solid var(--border-light) !important; font-size: .96875rem !important; line-height: 1.45 !important; box-shadow: var(--braid-shadow) !important; transition: border-color .15s, box-shadow .15s; }
+.message-input-area textarea:focus, .message-input-container textarea:focus { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)) !important; box-shadow: var(--braid-shadow), 0 0 0 4px color-mix(in srgb, var(--accent) 12%, transparent) !important; }
+.btn-send, .thread-send-btn { width: 2.5rem !important; height: 2.5rem !important; border-radius: var(--braid-r) !important; background: var(--accent) !important; color: #041006 !important; box-shadow: none !important; border: 0 !important; }
+.btn-send:hover, .thread-send-btn:hover { background: var(--accent-hover) !important; transform: scale(.98); filter: none !important; }
+
+/* ── Right sidebar / members ─────────────────────── */
+.right-sidebar { background: var(--bg-secondary) !important; border-left: 1px solid var(--border) !important; }
+.user-item, .member-item { margin: 2px .625rem; padding: .625rem .75rem; border-radius: var(--radius-sm); }
+.user-item:hover, .member-item:hover { background: var(--bg-hover); }
+
+/* ── Modals, menus, popups ───────────────────────── */
+.modal, .modal-content, .settings-modal, .dialog, .settings-panel { border-radius: 1.125rem !important; border: 1px solid var(--border) !important; box-shadow: 0 16px 48px -12px rgba(0, 0, 0, .45), var(--braid-shadow) !important; background: var(--bg-card) !important; }
+.modal-header, .settings-header { border-bottom: 1px solid var(--border) !important; background: transparent !important; }
+.settings-tab, .settings-nav-item, .sound-tab { border-radius: .625rem !important; }
+.settings-tab.active, .settings-nav-item.active, .sound-tab.active { background: color-mix(in srgb, var(--accent) 16%, var(--bg-tertiary)) !important; color: var(--accent) !important; border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent) !important; }
+.btn-primary, .btn-accent, .profile-dm-btn, .btn-admin-save { border-radius: .75rem !important; font-weight: 600 !important; letter-spacing: -.01em; box-shadow: none !important; }
+.btn-secondary, .btn.secondary { border-radius: .75rem !important; border: 1px solid var(--border-light) !important; background: var(--bg-tertiary) !important; }
+.context-menu, .dropdown-menu, .msg-toolbar { border-radius: var(--braid-r) !important; border: 1px solid var(--border) !important; box-shadow: var(--braid-shadow) !important; background: var(--bg-card) !important; }
+.profile-popup, .profile-card { border-radius: 1rem !important; border: 1px solid var(--border) !important; box-shadow: var(--braid-shadow) !important; }
+.theme-btn { border-radius: .75rem !important; }
+.reaction, .reaction-chip, .reaction-badge { border-radius: 999px !important; }
+.toast, .notification-toast, .chip-toast { border-radius: 999px !important; backdrop-filter: blur(10px); }
+.jump-to-bottom { border-radius: 999px !important; border: 1px solid var(--border-light) !important; box-shadow: var(--braid-shadow) !important; }
+.inline-code, code { border-radius: .375rem !important; background: var(--bg-tertiary) !important; border: 1px solid var(--border) !important; }
+.mention { border-radius: .375rem !important; }
+
+/* ── Voice ───────────────────────────────────────── */
+.voice-bar, .voice-panel, .vc-bar, .voice-status-bar { border-top: 1px solid var(--border) !important; background: var(--bg-secondary) !important; box-shadow: none !important; }
+.btn-voice, .voice-panel-btn, .voice-header-btn { border-radius: .75rem !important; border: 1px solid var(--border) !important; background: var(--bg-tertiary) !important; color: var(--text-secondary) !important; box-shadow: none !important; }
+.btn-voice:hover, .voice-panel-btn:hover, .voice-header-btn:hover { background: var(--bg-hover) !important; color: var(--text-primary) !important; }
+.btn-voice.active, .voice-panel-btn.active, .voice-header-btn.active { background: color-mix(in srgb, var(--accent) 18%, var(--bg-tertiary)) !important; color: var(--accent) !important; border-color: color-mix(in srgb, var(--accent) 35%, var(--border)) !important; }
+.btn-voice.btn-danger, .voice-panel-leave, .voice-header-leave { border-radius: .75rem !important; background: color-mix(in srgb, var(--danger) 12%, var(--bg-tertiary)) !important; color: var(--danger) !important; border: 1px solid color-mix(in srgb, var(--danger) 30%, var(--border)) !important; }
+.channel-voice-indicator { color: var(--success); }
+.music-panel { border-bottom: 1px solid var(--border) !important; background: var(--bg-secondary) !important; border-radius: 0; }
+.music-panel-controls button, .music-btn { border-radius: .625rem !important; }
+
+/* ── Login page ──────────────────────────────────── */
+.auth-page { background: var(--bg-primary) !important; background-image: none !important; }
+.auth-card { border-radius: 1.25rem !important; border: 1px solid var(--border) !important; box-shadow: var(--braid-shadow) !important; background: var(--bg-card) !important; padding: 2.5rem 2.25rem !important; }
+.auth-header .logo { font-size: 2.5rem; width: 4rem; height: 4rem; margin: 0 auto .5rem; display: grid; place-items: center; border-radius: 1.125rem; background: color-mix(in srgb, var(--accent) 12%, var(--bg-tertiary)); border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border)); color: var(--accent); }
+.auth-header h1 { font-size: 1.375rem !important; font-weight: 680 !important; letter-spacing: -.04em !important; text-transform: none; }
+.auth-header .tagline { font-size: .84375rem !important; color: var(--text-muted) !important; margin-top: .375rem !important; }
+.auth-tabs { background: var(--bg-tertiary) !important; border: 1px solid var(--border); border-radius: .75rem !important; padding: .25rem !important; }
+.auth-tab { border-radius: .625rem !important; font-weight: 550; }
+.auth-tab.active { background: var(--accent) !important; color: #041006 !important; }
+.form-group label { font-size: .6875rem !important; letter-spacing: .06em !important; color: var(--text-muted) !important; }
+.form-group input, .form-select { border-radius: .75rem !important; padding: .75rem .875rem !important; border: 1px solid var(--border) !important; background: var(--bg-input) !important; }
+.form-group input:focus, .form-select:focus { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)) !important; box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent); }
+
+@media (max-width: 56.25rem) {
+  .messages { padding: 1rem .875rem .625rem !important; max-width: none; }
+  .message-input-area, .message-input-container { padding: .625rem .75rem .875rem !important; }
+  .auth-card { padding: 1.75rem 1.25rem !important; }
+}

--- a/themes/braid.theme.css
+++ b/themes/braid.theme.css
@@ -64,6 +64,21 @@
   --scanline:      none;
 }
 
+
+/* == Type & color enforcement == make the Braid type stack and palette
+   land everywhere, over style.css's own per-element declarations. */
+body, button, input, textarea, select { font-family: var(--font-main) !important; }
+h1, h2, h3, h4, h5, h6, .brand-text, .auth-header h1 { font-family: var(--font-heading) !important; }
+::selection { background: color-mix(in srgb, var(--accent) 30%, transparent); color: var(--text-primary); }
+::placeholder { color: var(--text-muted) !important; opacity: 1; }
+a, .text-link { color: var(--text-link); }
+.message-time, .msg-time, .message-header .msg-time, .timestamp { color: var(--text-muted) !important; }
+.message-text, .message-content { color: var(--text-primary) !important; }
+.message-text a, .message-content a { color: var(--text-link) !important; }
+.section-label, .settings-nav-group-label, .braid-menu-label { color: var(--text-muted) !important; }
+.channel-name, .current-user, #channel-header-name { color: var(--text-primary) !important; }
+.channel-topic-bar { color: var(--text-muted) !important; }
+
 /* ── Base type & chrome ──────────────────────────── */
 html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; background: var(--bg-primary); }
 body { background: var(--bg-primary) !important; color: var(--text-primary) !important; font: 400 .9375rem/1.5 var(--font-main); letter-spacing: -.011em; }


### PR DESCRIPTION
## Silent crash on launch — root cause and fix

Since 3.33.0 the global `uncaughtException` "keep alive" handler swallows **async bind failures**: `server.listen` has no `error` listener, so `EADDRINUSE`/`EACCES` falls through to the keep-alive, gets one line in `crash.log`, and the process lives on **with no listening socket** — no banner, no exit code, nothing on screen. Worse, `Start Haven.bat`'s netstat readiness probe is satisfied by whatever stale process still holds the port, so it prints "Haven is LIVE" while the new server is a zombie. Every retry stacks another invisible zombie. To users this presents as *Haven silently crashing on launch* (several of us hit it after upgrading; my own `crash.log` had the swallowed `EADDRINUSE` twice).

**Fix:** an `error` handler on the main listener makes bind failures fatal and self-explanatory (which port, why, what to do) before `exit 1`; all other server errors keep today's keep-alive behaviour. The HTTP→HTTPS redirect listener (`PORT+1`) gets a warn-and-continue handler so it can't feed the same silent path.

**Also: Node 24 refusal.** `Start Haven.bat` hard-blocks Node ≥24 with "Haven requires Node 18-22" — but Node 24 is the current LTS that new users install, and better-sqlite3 12.10.0 ships working prebuilds for it (verified end-to-end on 24.14: install, boot, DB ops). The bat now verifies compatibility honestly — `node -e "require('better-sqlite3')"` after `npm install` — and only warns on ≥25. `engines` widened to `>=18 <25` (lockfile version also synced from stale 3.31.2).

Repro (before → after):
```
# terminal 1                      # terminal 2
node server.js                    node server.js
# ...HAVEN is running...          # before: prints startup lines, then hangs forever, port dead
                                  # after:  ❌ Haven could not start: port 3000 is already in use — ...
                                  #         exit code 1
```

## Braid themes + Braid Layout plugin (pure opt-ins, zero core-file edits)

Ports the Braid look from the Amni-Haven mobile app onto the rails this repo already ships:

- **`themes/braid.theme.css` / `braid-light.theme.css`** — the mobile BRAID / BRAID_LIGHT palettes (mint on slate / deep green on white) with the 1.6×-rounder shape language. Unpublished by default; admins opt in per server via **Settings → Custom Themes**, like any file theme.
- **`plugins/BraidLayout.plugin.js`** — a "two edges only" simplified layout: folds the server rail (including manage/sync) into a strip atop the sidebar, gives messages the full width, and tucks header extras into a kebab menu. **Every stock feature stays reachable** — the kebab proxies search/pins/gallery/channel-code/encryption/settings and adds People, Soundboard, Status bar, and app-download entries for the chrome it hides. A separate **variable-driven shape layer** (radii/blur/focus rings, no hardcoded colors) applies the Braid format on top of *any* active theme — Matrix keeps its rain and green, Nord stays Nord, just braided. `stop()` fully restores DOM, styles, listeners, and localStorage (verified through enable→disable→re-enable). The MutationObserver is childList-only and mutates only styles/attributes, so it can't observe its own writes. All sizes are rem so the interface Zoom slider scales Braid chrome with everything else; `prefers-reduced-motion` disables the motion layer.

## Validation

- `node --check` across all 58 repo JS files; `scripts/validate-locales.js` passes
- Fresh-server boot, admin registration, theme publish + picker injection, plugin enable/disable/re-enable — all exercised in a real browser on 3.39.0
- `Start Haven.bat` chain boots on Node 24.14 (`/api/health` verified)
