### PR TITLE
GIF search: add Tenor as the primary provider (GIPHY no longer issues API keys)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,7 +57,10 @@ ADMIN_USERNAME=admin
 # TURN_USERNAME=haven
 # TURN_PASSWORD=your-password
 
-# Optional: GIPHY API key (free — get one at https://developers.giphy.com/dashboard/)
+# Optional: Tenor API key for GIF search (free — enable the Tenor API and create
+# an API key at https://console.cloud.google.com/)
+# TENOR_API_KEY=
+# Optional: GIPHY API key (legacy — GIPHY no longer issues keys to new apps)
 # GIPHY_API_KEY=
 
 # ── Dynamic DNS auto-updater ─────────────────────────────

--- a/public/app.html
+++ b/public/app.html
@@ -515,7 +515,7 @@
                 <button type="button" class="gif-tab" data-gif-tab="favorites" data-i18n="gifs.tab_favorites">★ Favorites</button>
               </div>
               <div class="gif-picker-header">
-                <input type="text" id="gif-search-input" data-i18n-placeholder="header.gif_search_placeholder" placeholder="Search GIPHY..." maxlength="100" autocomplete="off">
+                <input type="text" id="gif-search-input" data-i18n-placeholder="header.gif_search_placeholder" placeholder="Search GIFs..." maxlength="100" autocomplete="off">
               </div>
               <div class="gif-picker-grid" id="gif-grid"></div>
               <div class="gif-picker-footer" data-i18n="header.powered_by_giphy">Powered by GIPHY</div>

--- a/public/index.html
+++ b/public/index.html
@@ -411,7 +411,7 @@
         default.</p>
         <p>8.3. Haven does not transmit data to third-party analytics,
         advertising, or tracking services. API calls to third-party services
-        (e.g., GIPHY) are made only when explicitly triggered by user action.</p>
+        (e.g., Tenor or GIPHY) are made only when explicitly triggered by user action.</p>
         <p>8.4. You consent to the collection and storage of your IP address,
         username, and agreement acceptance records for the purposes of
         security, abuse prevention, and legal compliance.</p>

--- a/public/js/modules/app-messages.js
+++ b/public/js/modules/app-messages.js
@@ -1471,6 +1471,7 @@ _fetchLinkPreviews(containerEl) {
     // Skip image URLs (already rendered inline) and internal URLs
     if (/\.(jpg|jpeg|png|gif|webp)(\?.*)?$/i.test(url)) return;
     if (/^https:\/\/media\d*\.giphy\.com\//i.test(url)) return;
+    if (/^https:\/\/(media|c)\.tenor\.com\//i.test(url)) return;
     if (url.startsWith(window.location.origin)) return;
 
     // ── Inline YouTube embed (wrapped in the shared embed chrome) ──

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -293,8 +293,9 @@ _isImageUrl(str) {
   if (trimmed.startsWith('e2e-img:')) return true;
   if (/^\/uploads\/(stickers\/)?[\w\-.]+\.(jpg|jpeg|png|gif|webp|svg)$/i.test(trimmed)) return true;
   if (/^https?:\/\/.+\.(jpg|jpeg|png|gif|webp|svg)(\?[^"'<>]*)?$/i.test(trimmed)) return true;
-  // GIPHY GIF URLs (may not have file extensions)
+  // GIPHY / Tenor GIF URLs (may not have file extensions)
   if (/^https:\/\/media\d*\.giphy\.com\/.+/i.test(trimmed)) return true;
+  if (/^https:\/\/(media|c)\.tenor\.com\/.+/i.test(trimmed)) return true;
   return false;
 },
 
@@ -594,7 +595,8 @@ _formatContent(str) {
       const safeUrl = url.replace(/['"<>]/g, '');
       const idx = autoLinks.length;
       if (/\.(jpg|jpeg|png|gif|webp)(\?[^"'<>]*)?$/i.test(safeUrl) ||
-          /^https:\/\/media\d*\.giphy\.com\//i.test(safeUrl)) {
+          /^https:\/\/media\d*\.giphy\.com\//i.test(safeUrl) ||
+          /^https:\/\/(media|c)\.tenor\.com\//i.test(safeUrl)) {
         autoLinks.push((this._isImageHidden && this._isImageHidden(safeUrl))
           ? this._hiddenImagePlaceholder(safeUrl)
           : `<img src="${safeUrl}" class="chat-image" alt="image" loading="lazy">`);
@@ -1710,6 +1712,14 @@ _switchGifTab(tab) {
   }
 },
 
+// The proxy reports which provider served the batch — keep the picker
+// footer honest ("Powered by Tenor" vs "Powered by GIPHY").
+_setGifFooter(provider) {
+  if (!provider) return;
+  const footer = document.querySelector('.gif-picker-footer');
+  if (footer) footer.textContent = provider === 'tenor' ? 'Powered by Tenor' : 'Powered by GIPHY';
+},
+
 _loadTrendingGifs() {
   const grid = document.getElementById('gif-grid');
   grid.innerHTML = '<div class="gif-picker-empty">Loading...</div>';
@@ -1727,6 +1737,7 @@ _loadTrendingGifs() {
         grid.innerHTML = `<div class="gif-picker-empty">${this._escapeHtml(data.error)}</div>`;
         return;
       }
+      this._setGifFooter(data.provider);
       this._renderGifGrid(data.results || []);
     })
     .catch(() => {
@@ -1757,6 +1768,7 @@ _searchGifs(query) {
         grid.innerHTML = `<div class="gif-picker-empty">${t('gifs.no_results')}</div>`;
         return;
       }
+      this._setGifFooter(data.provider);
       this._renderGifGrid(results);
     })
     .catch(() => {
@@ -1768,29 +1780,50 @@ _searchGifs(query) {
 _showGifSetupGuide(grid) {
   const isAdmin = this.user && this.user.isAdmin;
   if (isAdmin) {
-    grid.innerHTML = `
-      <div class="gif-setup-guide">
-        <h3>🎞️ ${t('gifs.setup.title')}</h3>
-        <p>${t('gifs.setup.powered_by')}</p>
+    // Tenor steps render by default — GIPHY stopped issuing API keys to
+    // new applications, so it is kept only as the legacy choice for
+    // admins who already hold a working key.
+    const guides = {
+      tenor: `<p>${t('gifs.setup.tenor_powered_by')}</p>
+        <ol>
+          <li>${t('gifs.setup.tenor_step_1')}</li>
+          <li>${t('gifs.setup.tenor_step_2')}</li>
+          <li>${t('gifs.setup.tenor_step_3')}</li>
+        </ol>`,
+      giphy: `<p>${t('gifs.setup.powered_by')}</p>
         <ol>
           <li>${t('gifs.setup.step_1')}</li>
           <li>${t('gifs.setup.step_2')}</li>
           <li>${t('gifs.setup.step_3')}</li>
           <li>${t('gifs.setup.step_4')}</li>
           <li>${t('gifs.setup.step_5')}</li>
-        </ol>
+        </ol>`,
+    };
+    grid.innerHTML = `
+      <div class="gif-setup-guide">
+        <h3>🎞️ ${t('gifs.setup.title')}</h3>
+        <div id="gif-setup-steps">${guides.tenor}</div>
         <div class="gif-setup-input-row">
-          <input type="text" id="gif-giphy-key-input" placeholder="${t('gifs.setup.key_placeholder')}" spellcheck="false" autocomplete="off" />
-          <button id="gif-giphy-key-save">${t('gifs.setup.save_btn')}</button>
+          <select id="gif-provider-select" title="${t('gifs.setup.provider')}">
+            <option value="tenor">Tenor</option>
+            <option value="giphy">GIPHY</option>
+          </select>
+          <input type="text" id="gif-provider-key-input" placeholder="${t('gifs.setup.key_placeholder')}" spellcheck="false" autocomplete="off" />
+          <button id="gif-provider-key-save">${t('gifs.setup.save_btn')}</button>
         </div>
         <p class="gif-setup-note">💡 ${t('gifs.setup.note')}</p>
       </div>`;
-    const saveBtn = document.getElementById('gif-giphy-key-save');
-    const input = document.getElementById('gif-giphy-key-input');
+    const saveBtn = document.getElementById('gif-provider-key-save');
+    const input = document.getElementById('gif-provider-key-input');
+    const select = document.getElementById('gif-provider-select');
+    select.addEventListener('change', () => {
+      document.getElementById('gif-setup-steps').innerHTML = guides[select.value] || guides.tenor;
+    });
     saveBtn.addEventListener('click', () => {
       const key = input.value.trim();
       if (!key) return;
-      this.socket.emit('update-server-setting', { key: 'giphy_api_key', value: key });
+      const settingKey = select.value === 'giphy' ? 'giphy_api_key' : 'tenor_api_key';
+      this.socket.emit('update-server-setting', { key: settingKey, value: key });
       grid.innerHTML = `<div class="gif-picker-empty">${t('gifs.setup.saved')}</div>`;
       setTimeout(() => this._loadTrendingGifs(), 500);
     });
@@ -1972,7 +2005,7 @@ _showGifSlashResults(query) {
     .then(r => r.json())
     .then(data => {
       if (data.error === 'gif_not_configured') {
-        picker.innerHTML = '<div class="gif-slash-loading">GIF search not configured — an admin needs to set up the GIPHY API key (use the GIF button 🎞️)</div>';
+        picker.innerHTML = '<div class="gif-slash-loading">GIF search not configured — an admin needs to set up a Tenor (or GIPHY) API key (use the GIF button 🎞️)</div>';
         return;
       }
       if (data.error) { picker.innerHTML = `<div class="gif-slash-loading">${this._escapeHtml(data.error)}</div>`; return; }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -468,7 +468,7 @@
     "uploading": "Uploading...",
     "cancel_reply": "Cancel reply",
     "message_placeholder_commands": "Type a message... (/ for commands)",
-    "gif_search_placeholder": "Search GIPHY...",
+    "gif_search_placeholder": "Search GIFs...",
     "powered_by_giphy": "Powered by GIPHY",
     "search_results_one": "{{count}} result for \"{{query}}\"",
     "search_results_other": "{{count}} results for \"{{query}}\"",
@@ -1802,18 +1802,23 @@
     "search_failed": "Search failed",
     "setup": {
       "title": "Set Up GIF Search",
+      "provider": "GIF provider",
+      "tenor_powered_by": "GIF search is powered by <strong>Tenor</strong> and needs a free API key. (GIPHY no longer issues new keys — pick it below only if you already have one.)",
+      "tenor_step_1": "Go to <a href=\"https://console.cloud.google.com/\" target=\"_blank\" rel=\"noopener\">console.cloud.google.com</a> and create (or pick) a project",
+      "tenor_step_2": "Enable the <b>Tenor API</b>, then open <b>Credentials</b> → <b>Create credentials</b> → <b>API key</b>",
+      "tenor_step_3": "Copy the API key and paste it below",
       "powered_by": "GIF search is powered by <strong>GIPHY</strong> and needs a free API key.",
       "step_1": "Go to <a href=\"https://developers.giphy.com/\" target=\"_blank\" rel=\"noopener\">developers.giphy.com</a>",
       "step_2": "Create an account (or sign in)",
       "step_3": "Click <b>Create an App</b> → choose <b>API</b>",
       "step_4": "Name it anything (e.g. \"Haven Chat\")",
       "step_5": "Copy the API key and paste it below",
-      "key_placeholder": "Paste your GIPHY API key…",
+      "key_placeholder": "Paste your API key…",
       "save_btn": "Save",
-      "note": "No payment required — GIPHY's free tier is generous enough for a private server.",
+      "note": "No payment required — the free tiers are generous enough for a private server.",
       "saved": "Saved! Loading GIFs…",
       "unavailable_title": "GIF Search Not Available",
-      "unavailable_desc": "An admin needs to set up the GIPHY API key before GIF search can work."
+      "unavailable_desc": "An admin needs to set up a GIF provider API key before GIF search can work."
     }
   }
 }

--- a/server.js
+++ b/server.js
@@ -1796,15 +1796,52 @@ app.delete('/api/stickers/:name', (req, res) => {
   } catch { res.status(500).json({ error: 'Failed to delete sticker' }); }
 });
 
-// ── GIF search proxy (GIPHY API — keeps key server-side) ──
-function getGiphyKey() {
+// ── GIF search proxy (Tenor v2 or GIPHY — keeps keys server-side) ──
+// Tenor is the preferred provider: GIPHY stopped issuing API keys to
+// new applications, so fresh installs can no longer configure it.
+// Existing GIPHY keys keep working unchanged.
+function getGifProvider() {
   // Check database first (set via admin panel), fall back to .env
-  try {
-    const { getDb } = require('./src/database');
-    const row = getDb().prepare("SELECT value FROM server_settings WHERE key = 'giphy_api_key'").get();
-    if (row && row.value) return row.value;
-  } catch { /* DB not ready yet or no key stored */ }
-  return process.env.GIPHY_API_KEY || '';
+  const readSetting = (key) => {
+    try {
+      const { getDb } = require('./src/database');
+      const row = getDb().prepare('SELECT value FROM server_settings WHERE key = ?').get(key);
+      if (row && row.value) return row.value;
+    } catch { /* DB not ready yet or no key stored */ }
+    return '';
+  };
+  const tenorKey = readSetting('tenor_api_key') || process.env.TENOR_API_KEY || '';
+  if (tenorKey) return { provider: 'tenor', key: tenorKey };
+  const giphyKey = readSetting('giphy_api_key') || process.env.GIPHY_API_KEY || '';
+  if (giphyKey) return { provider: 'giphy', key: giphyKey };
+  return null;
+}
+
+// Both providers normalize to the same result shape the client expects:
+// { id, title, tiny (grid thumbnail), full (send URL) }.
+function fetchGifs(kind, q, limit, cfg) {
+  if (cfg.provider === 'tenor') {
+    const base = kind === 'search'
+      ? `https://tenor.googleapis.com/v2/search?q=${encodeURIComponent(q)}&`
+      : 'https://tenor.googleapis.com/v2/featured?';
+    const url = `${base}key=${encodeURIComponent(cfg.key)}&limit=${limit}&media_filter=tinygif,gif&contentfilter=off`;
+    return fetch(url).then(r => r.json()).then(data => (data.results || []).map(g => ({
+      id: g.id,
+      title: g.content_description || g.title || '',
+      tiny: g.media_formats?.tinygif?.url || g.media_formats?.gif?.url || '',
+      full: g.media_formats?.gif?.url || '',
+    })));
+  }
+  const base = kind === 'search'
+    ? `https://api.giphy.com/v1/gifs/search?q=${encodeURIComponent(q)}&lang=en&`
+    : 'https://api.giphy.com/v1/gifs/trending?';
+  const url = `${base}api_key=${encodeURIComponent(cfg.key)}&limit=${limit}&rating=r`;
+  return fetch(url).then(r => r.json()).then(data => (data.data || []).map(g => ({
+    id: g.id,
+    title: g.title || '',
+    tiny: g.images?.fixed_height_small?.url || g.images?.fixed_height?.url || '',
+    full: g.images?.original?.url || '',
+  })));
 }
 
 // ── Server icon upload (admin only, image only, max 2 MB) ──
@@ -2328,21 +2365,14 @@ app.get('/api/gif/search', gifLimiter, (req, res) => {
   const user = token ? verifyToken(token) : null;
   if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
-  const key = getGiphyKey();
-  if (!key) return res.status(501).json({ error: 'gif_not_configured' });
+  const cfg = getGifProvider();
+  if (!cfg) return res.status(501).json({ error: 'gif_not_configured' });
   const q = (req.query.q || '').trim().slice(0, 100);
   if (!q) return res.status(400).json({ error: 'Missing search query' });
   const limit = Math.min(parseInt(req.query.limit) || 20, 50);
-  const url = `https://api.giphy.com/v1/gifs/search?api_key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=${limit}&rating=r&lang=en`;
-  fetch(url).then(r => r.json()).then(data => {
-    const results = (data.data || []).map(g => ({
-      id: g.id,
-      title: g.title || '',
-      tiny: g.images?.fixed_height_small?.url || g.images?.fixed_height?.url || '',
-      full: g.images?.original?.url || '',
-    }));
-    res.json({ results });
-  }).catch(() => res.status(502).json({ error: 'GIPHY API error' }));
+  fetchGifs('search', q, limit, cfg)
+    .then(results => res.json({ provider: cfg.provider, results }))
+    .catch(() => res.status(502).json({ error: 'GIF provider API error' }));
 });
 
 app.get('/api/gif/trending', gifLimiter, (req, res) => {
@@ -2351,19 +2381,12 @@ app.get('/api/gif/trending', gifLimiter, (req, res) => {
   const user = token ? verifyToken(token) : null;
   if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
-  const key = getGiphyKey();
-  if (!key) return res.status(501).json({ error: 'gif_not_configured' });
+  const cfg = getGifProvider();
+  if (!cfg) return res.status(501).json({ error: 'gif_not_configured' });
   const limit = Math.min(parseInt(req.query.limit) || 20, 50);
-  const url = `https://api.giphy.com/v1/gifs/trending?api_key=${encodeURIComponent(key)}&limit=${limit}&rating=r`;
-  fetch(url).then(r => r.json()).then(data => {
-    const results = (data.data || []).map(g => ({
-      id: g.id,
-      title: g.title || '',
-      tiny: g.images?.fixed_height_small?.url || g.images?.fixed_height?.url || '',
-      full: g.images?.original?.url || '',
-    }));
-    res.json({ results });
-  }).catch(() => res.status(502).json({ error: 'GIPHY API error' }));
+  fetchGifs('trending', '', limit, cfg)
+    .then(results => res.json({ provider: cfg.provider, results }))
+    .catch(() => res.status(502).json({ error: 'GIF provider API error' }));
 });
 
 // ── Link preview (Open Graph metadata) ──────────────────

--- a/src/socketHandlers/admin.js
+++ b/src/socketHandlers/admin.js
@@ -16,7 +16,7 @@ module.exports = function register(socket, ctx) {
   socket.on('get-server-settings', () => {
     const rows = db.prepare('SELECT key, value FROM server_settings').all();
     const settings = {};
-    const sensitiveKeys = ['giphy_api_key', 'server_code', 'registration_token', 'turn_password', 'turnstile_secret_key'];
+    const sensitiveKeys = ['giphy_api_key', 'tenor_api_key', 'server_code', 'registration_token', 'turn_password', 'turnstile_secret_key'];
     rows.forEach(r => {
       if (sensitiveKeys.includes(r.key) && !socket.user.isAdmin) return;
       settings[r.key] = r.value;
@@ -35,7 +35,7 @@ module.exports = function register(socket, ctx) {
 
     const allowedKeys = [
       'member_visibility', 'cleanup_enabled', 'cleanup_max_age_days', 'cleanup_max_size_mb',
-      'giphy_api_key', 'server_name', 'server_title', 'server_icon', 'server_banner', 'permission_thresholds',
+      'giphy_api_key', 'tenor_api_key', 'server_name', 'server_title', 'server_icon', 'server_banner', 'permission_thresholds',
       'tunnel_enabled', 'tunnel_provider', 'server_code', 'max_upload_mb', 'max_poll_options',
       'max_sound_kb', 'max_emoji_kb', 'max_sticker_kb', 'setup_wizard_complete', 'update_banner_admin_only',
       'default_theme', 'published_themes', 'channel_sort_mode', 'channel_cat_order', 'channel_cat_sort',
@@ -86,6 +86,7 @@ module.exports = function register(socket, ctx) {
       if (!parts.every(p => valid.has(p))) return;
     }
     if (key === 'giphy_api_key') { if (value && (value.length < 10 || value.length > 100)) return; }
+    if (key === 'tenor_api_key') { if (value && (value.length < 10 || value.length > 100)) return; }
     if (key === 'server_name') { if (value.length > 32) return; }
     if (key === 'server_title') { if (value.length > 40) return; }
     if (key === 'server_icon') { if (value && !isValidUploadPath(value)) return; }


### PR DESCRIPTION
## Problem

GIF search is dead for new servers: the picker's setup guide walks admins to developers.giphy.com, but **GIPHY no longer issues API keys to new applications** — the flow dead-ends and `/api/gif/*` stays at `gif_not_configured` forever.

## Fix

Add **Tenor (v2)** as the preferred provider; existing GIPHY keys keep working untouched.

- `getGifProvider()` resolves `tenor_api_key` (admin setting or `TENOR_API_KEY` env) first, then the legacy GIPHY key. Both providers normalize to the `{ id, title, tiny, full }` shape the client already consumes — the picker, favorites, and slash-command grid need no changes.
- Responses carry `provider`, and the picker footer reports whoever actually served the batch ("Powered by Tenor" / "Powered by GIPHY").
- The in-picker admin setup guide shows Tenor steps by default (Google Cloud console → enable Tenor API → API key) with a provider selector for admins who still hold a GIPHY key.
- `tenor_api_key` joins the settings allowlist, the sensitive-key redaction list, and gets the same validation as the GIPHY key.
- `media.tenor.com` / `c.tenor.com` join the giphy hosts in the inline-image whitelists so sent GIFs render as images.
- `.env.example` and strings updated; `validate-locales` passes.

## Verified against a live server

| Config | Result |
|---|---|
| `TENOR_API_KEY` set | `{"provider":"tenor","results":[...]}` |
| legacy GIPHY key only | `{"provider":"giphy","results":[...]}` |
| no key | `501 {"error":"gif_not_configured"}` → admin setup guide |
