### PR TITLE
fix: upgrade adm-zip to 0.6.0 (CVE-2026-39244)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "haven",
-  "version": "3.39.0",
+  "version": "3.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haven",
-      "version": "3.39.0",
+      "version": "3.40.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "archiver": "^7.0.1",
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^12.10.0",
@@ -196,11 +196,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "haven",
   "version": "3.40.0",
   "description": "Haven - self-hosted private chat for your server, your rules",
@@ -12,7 +12,7 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "adm-zip": "^0.5.16",
+    "adm-zip": "^0.6.0",
     "archiver": "^7.0.1",
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## Summary
Upgrade adm-zip from 0.5.16 to 0.6.0 to fix CVE-2026-39244.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-39244 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-39244` |
| **File** | `package-lock.json` (dependency: `adm-zip`) |
| **Assessment** | Likely exploitable |

**Description**: adm-zip: adm-zip: Denial of Service via crafted ZIP file leading to excessive memory allocation

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-39244` flagged this pattern.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
