### PR TITLE
[feat] Referrer-Policy header setting

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -1156,6 +1156,7 @@
           <div class="settings-nav-item settings-nav-admin" data-target="section-update" style="display:none">⬆️ <span data-i18n="settings.nav.server_updates">Server Updates</span></div>
           <div class="settings-nav-item settings-nav-admin" data-target="section-branding" style="display:none">🏠 <span data-i18n="settings.nav.branding">Branding</span></div>
           <div class="settings-nav-item settings-nav-admin" data-target="section-members" style="display:none">👥 <span data-i18n="settings.nav.members">Members</span></div>
+          <div class="settings-nav-item settings-nav-admin" data-target="section-security" style="display:none">🔒 <span data-i18n="settings.nav.security">Security</span></div>
           <div class="settings-nav-item settings-nav-admin" data-target="section-whitelist" style="display:none">🛡️ <span data-i18n="settings.nav.whitelist">Whitelist</span></div>
           <div class="settings-nav-item settings-nav-admin" data-target="section-invite" style="display:none">🌐 <span data-i18n="settings.nav.invite">Invite Code</span></div>
           <div class="settings-nav-item settings-nav-admin" data-target="section-cleanup" style="display:none">🗑️ <span data-i18n="settings.nav.cleanup">Cleanup</span></div>
@@ -2064,6 +2065,34 @@
             <input type="checkbox" id="admin-password-reset-enabled">
           </label>
           <small class="settings-hint" data-i18n="settings.admin.admin_pw_reset_hint">⚠️ When enabled, admins can reset any user's password to a one-time temp value. The user must change it on next login. Resetting a password also wipes that user's E2E DM history (their wrap key derives from the password). The fact that this is enabled is exposed via /api/public-config so users can see whether admins on this server have this power.</small>
+        </div>
+        <div class="admin-settings" id="section-security" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
+          <h5 class="settings-section-subtitle">🔒 <span data-i18n="settings.admin.security_title">Security</span></h5>
+          <small class="settings-group-label" style="margin-top:8px;display:block">🔗 <span data-i18n="settings.admin.referrer_policy_group">Referrer configuration</span></small>
+          <small class="settings-hint" style="display:block" data-i18n="settings.admin.referrer_policy_desc">Sets the Referrer-Policy header Haven sends to browsers, which controls how much of the current page's address is shared when the browser loads resources or follows links to other sites. The recommended options cover almost every server; the advanced policies are standard browser values included for completeness and are left to your discretion.</small>
+          <ul class="settings-hint" style="margin:6px 0 0;padding-left:20px">
+            <li data-i18n-html="settings.admin.referrer_policy_opt_default"><strong>Strict-Origin-When-Cross-Origin (default):</strong> within this server, shares the full address; to other sites, shares only the origin.</li>
+            <li style="margin-top:4px" data-i18n-html="settings.admin.referrer_policy_opt_same"><strong>Same-Origin:</strong> within this server, shares the full address; to other sites, shares nothing.</li>
+            <li style="margin-top:4px" data-i18n-html="settings.admin.referrer_policy_opt_none"><strong>No-Referrer:</strong> shares nothing anywhere — not even within this server.</li>
+          </ul>
+          <small class="settings-hint" style="display:block;margin-top:6px" data-i18n="settings.admin.referrer_policy_note">Same-Origin and No-Referrer send nothing to other sites, so either one fixes embeds whose CDN rejects a cross-origin referrer, such as Twitter/X video. They differ only in what is shared within this server.</small>
+          <label class="select-row" style="margin-top:8px">
+            <span data-i18n="settings.admin.referrer_policy_label">Referrer policy</span>
+            <select id="referrer-policy-select">
+              <optgroup label="Recommended">
+                <option value="strict-origin-when-cross-origin">Strict-Origin-When-Cross-Origin (default)</option>
+                <option value="same-origin">Same-Origin</option>
+                <option value="no-referrer">No-Referrer</option>
+              </optgroup>
+              <optgroup label="Advanced — use at your own discretion">
+                <option value="strict-origin">Strict-Origin</option>
+                <option value="origin">Origin</option>
+                <option value="origin-when-cross-origin">Origin-When-Cross-Origin</option>
+                <option value="no-referrer-when-downgrade">No-Referrer-When-Downgrade</option>
+                <option value="unsafe-url">Unsafe-URL</option>
+              </optgroup>
+            </select>
+          </label>
         </div>
         <div class="admin-settings" id="section-whitelist" style="margin-top:10px; padding-top:10px; border-top:1px solid var(--border);">
           <h5 class="settings-section-subtitle">🛡️ <span data-i18n="settings.admin.whitelist_title">Whitelist</span></h5>

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -312,6 +312,10 @@ _applyServerSettings() {
     if (vis && this.serverSettings.member_visibility) {
       vis.value = this.serverSettings.member_visibility;
     }
+    const refPol = document.getElementById('referrer-policy-select');
+    if (refPol && this.serverSettings.referrer_policy) {
+      refPol.value = this.serverSettings.referrer_policy;
+    }
     const nameInput = document.getElementById('server-name-input');
     if (nameInput && this.serverSettings.server_name !== undefined) {
       nameInput.value = this.serverSettings.server_name || '';
@@ -695,6 +699,7 @@ _snapshotAdminSettings() {
     server_title: this.serverSettings.server_title || '',
     welcome_message: this.serverSettings.welcome_message || '',
     member_visibility: this.serverSettings.member_visibility || 'online',
+    referrer_policy: this.serverSettings.referrer_policy || 'strict-origin-when-cross-origin',
     cleanup_enabled: this.serverSettings.cleanup_enabled || 'false',
     cleanup_max_age_days: this.serverSettings.cleanup_max_age_days || '0',
     cleanup_max_size_mb: this.serverSettings.cleanup_max_size_mb || '0',
@@ -763,6 +768,12 @@ _saveAdminSettings() {
   const vis = document.getElementById('member-visibility-select')?.value;
   if (vis && vis !== snap.member_visibility) {
     this.socket.emit('update-server-setting', { key: 'member_visibility', value: vis });
+    changed = true;
+  }
+
+  const refPol = document.getElementById('referrer-policy-select')?.value;
+  if (refPol && refPol !== snap.referrer_policy) {
+    this.socket.emit('update-server-setting', { key: 'referrer_policy', value: refPol });
     changed = true;
   }
 
@@ -965,6 +976,8 @@ _cancelAdminSettings() {
     if (ti) ti.value = snap.server_title || '';
     const vis = document.getElementById('member-visibility-select');
     if (vis) vis.value = snap.member_visibility;
+    const refPol = document.getElementById('referrer-policy-select');
+    if (refPol) refPol.value = snap.referrer_policy;
     const ce = document.getElementById('cleanup-enabled');
     if (ce) ce.checked = snap.cleanup_enabled === 'true';
     const ca = document.getElementById('cleanup-max-age');

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -701,7 +701,8 @@
       "tunnel": "Tunnel",
       "bots": "Bots",
       "import": "Import",
-      "mod_mode": "Mod Mode"
+      "mod_mode": "Mod Mode",
+      "security": "Security"
     },
     "language_section": {
       "title": "Language",
@@ -870,6 +871,14 @@
     },
     "admin": {
       "title": "Admin",
+      "security_title": "Security",
+      "referrer_policy_group": "Referrer configuration",
+      "referrer_policy_label": "Referrer policy",
+      "referrer_policy_desc": "Sets the Referrer-Policy header Haven sends to browsers, which controls how much of the current page's address is shared when the browser loads resources or follows links to other sites. The recommended options cover almost every server; the advanced policies are standard browser values included for completeness and are left to your discretion.",
+      "referrer_policy_opt_default": "<strong>Strict-Origin-When-Cross-Origin (default):</strong> within this server, shares the full address; to other sites, shares only the origin.",
+      "referrer_policy_opt_same": "<strong>Same-Origin:</strong> within this server, shares the full address; to other sites, shares nothing.",
+      "referrer_policy_opt_none": "<strong>No-Referrer:</strong> shares nothing anywhere — not even within this server.",
+      "referrer_policy_note": "Same-Origin and No-Referrer send nothing to other sites, so either one fixes embeds whose CDN rejects a cross-origin referrer, such as Twitter/X video. They differ only in what is shared within this server.",
       "branding_title": "Server Branding",
       "server_name": "Server Name",
       "login_title": "Login Title",

--- a/server.js
+++ b/server.js
@@ -187,6 +187,15 @@ function userHasPermission(userId, permission) {
   } catch { return false; }
 }
 
+// ── Referrer-Policy (admin-configurable) ─────────────────
+// The Referrer-Policy header is sent on every response by the security-headers
+// middleware below. Admins can change it from Settings → Security; the value is
+// cached in memory (loaded at boot, refreshed when it changes) so we never read
+// the DB per request. Default matches the value helmet used to set.
+const VALID_REFERRER_POLICIES = ['no-referrer', 'no-referrer-when-downgrade', 'origin', 'origin-when-cross-origin', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url'];
+const DEFAULT_REFERRER_POLICY = 'strict-origin-when-cross-origin';
+let currentReferrerPolicy = DEFAULT_REFERRER_POLICY;
+
 // ── Security Headers (helmet) ────────────────────────────
 app.use(helmet({
   contentSecurityPolicy: {
@@ -210,13 +219,14 @@ app.use(helmet({
   crossOriginEmbedderPolicy: false,  // needed for WebRTC
   crossOriginOpenerPolicy: false,    // needed for WebRTC
   hsts: (process.env.FORCE_HTTP || '').toLowerCase() === 'true' ? false : { maxAge: 31536000, includeSubDomains: false }, // force HTTPS for 1 year (disabled when FORCE_HTTP=true)
-  referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+  referrerPolicy: false, // set dynamically from the admin-configurable cache in the middleware below
 }));
 
 // Additional security headers helmet doesn't cover
 app.use((req, res, next) => {
   res.setHeader('Permissions-Policy', 'camera=(self), microphone=(self), geolocation=(), payment=()');
   res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Referrer-Policy', currentReferrerPolicy); // admin-configurable (Settings → Security)
   next();
 });
 
@@ -4188,6 +4198,12 @@ const db = initDatabase();
 // (#5335) Seed starter stickers now that the DB is ready.
 try { seedStarterStickers(); } catch {}
 
+// Load the admin-configured Referrer-Policy into the in-memory cache.
+try {
+  const rp = db.prepare("SELECT value FROM server_settings WHERE key = 'referrer_policy'").get()?.value;
+  if (rp && VALID_REFERRER_POLICIES.includes(rp)) currentReferrerPolicy = rp;
+} catch {}
+
 // ── Admin password reset (one-time, from .env) ───────────
 // Set ADMIN_RESET_PASSWORD in .env, restart, and it resets the admin's password.
 // The variable is removed from .env automatically after use.
@@ -4217,7 +4233,11 @@ if (process.env.ADMIN_RESET_PASSWORD) {
 
 initFcm(DATA_DIR);
 app.set('io', io);   // expose to auth routes (session invalidation on password change)
-activityRef.engine = setupSocketHandlers(io, db, { invalidateIpBanCache }).activity;
+activityRef.engine = setupSocketHandlers(io, db, {
+  invalidateIpBanCache,
+  // Keep the Referrer-Policy cache in sync when an admin changes it.
+  onReferrerPolicyChange: (v) => { if (VALID_REFERRER_POLICIES.includes(v)) currentReferrerPolicy = v; }
+}).activity;
 registerProcessCleanup();
 
 // ── Auto-cleanup interval (runs every 15 minutes) ───────

--- a/src/socketHandlers/admin.js
+++ b/src/socketHandlers/admin.js
@@ -8,7 +8,7 @@ module.exports = function register(socket, ctx) {
     io, db, state, userHasPermission, getUserEffectiveLevel,
     getUserPermissions, getUserRoles, getUserHighestRole,
     emitOnlineUsers, broadcastChannelLists, generateChannelCode,
-    logAudit, fireWebhookEvent
+    logAudit, fireWebhookEvent, onReferrerPolicyChange
   } = ctx;
   const { channelUsers } = state;
 
@@ -49,7 +49,8 @@ module.exports = function register(socket, ctx) {
       'stun_urls', 'turn_url', 'turn_username', 'turn_password', // (#5399) voice connectivity (STUN/TURN)
       'registration_captcha_enabled', 'turnstile_site_key', 'turnstile_secret_key', // opt-in Cloudflare Turnstile on registration
       'registration_rate_limit_enabled', 'registration_rate_limit_per_hour', // opt-in global new-account velocity cap
-      'channel_creator_role' // (#5461) role auto-granted to a non-admin who creates a channel
+      'channel_creator_role', // (#5461) role auto-granted to a non-admin who creates a channel
+      'referrer_policy' // Referrer-Policy header, admin-configurable under Settings → Security
     ];
     if (!allowedKeys.includes(key)) return;
 
@@ -66,6 +67,7 @@ module.exports = function register(socket, ctx) {
     if (key === 'registration_rate_limit_enabled' && !['true', 'false'].includes(value)) return;
     if (key === 'registration_rate_limit_per_hour') { const n = parseInt(value); if (isNaN(n) || n < 1 || n > 100000) return; }
 
+    if (key === 'referrer_policy' && !['no-referrer', 'no-referrer-when-downgrade', 'origin', 'origin-when-cross-origin', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url'].includes(value)) return;
     if (key === 'member_visibility' && !['all', 'online', 'none'].includes(value)) return;
     if (key === 'cleanup_enabled' && !['true', 'false'].includes(value)) return;
     if (key === 'cleanup_max_age_days') { const n = parseInt(value); if (isNaN(n) || n < 0 || n > 3650) return; }
@@ -212,6 +214,7 @@ module.exports = function register(socket, ctx) {
     if (key === 'member_visibility') {
       for (const [code] of channelUsers) { emitOnlineUsers(code); }
     }
+    if (key === 'referrer_policy') onReferrerPolicyChange(value);
   });
 
   // ── Whitelist management ────────────────────────────────

--- a/src/socketHandlers/index.js
+++ b/src/socketHandlers/index.js
@@ -32,6 +32,7 @@ const ADMIN_USERNAME = (process.env.ADMIN_USERNAME || 'admin').toLowerCase();
 // ══════════════════════════════════════════════════════════════
 function setupSocketHandlers(io, db, opts = {}) {
   const invalidateIpBanCache = (typeof opts.invalidateIpBanCache === 'function') ? opts.invalidateIpBanCache : () => {};
+  const onReferrerPolicyChange = (typeof opts.onReferrerPolicyChange === 'function') ? opts.onReferrerPolicyChange : () => {};
 
   // ── Permission helpers (shared across all connections) ───
   const {
@@ -1585,6 +1586,7 @@ function setupSocketHandlers(io, db, opts = {}) {
       transferAdminRef,
       // Audit log
       logAudit,
+      onReferrerPolicyChange,
       // IP-ban cache invalidator (server.js HTTP-side cache)
       invalidateIpBanCache,
       // Constants


### PR DESCRIPTION
## Referrer-Policy header setting
Adds a new Admin menu category "Security", and a new sub-category "Referrer configuration" to manage what Referrer-Policy should apply to all users. This new sub-category contains all eight referrer policies, but only documents three I believe will be the most useful to users while leaving the other options deliberately undocumented. This change inherits the old, hardcoded `strict-origin-when-cross-origin` so everything stays the same unless an admin explicitly changes it after this update.

### Why
Haven hardcoded the Referrer-Policy to strict-origin-when-cross-origin. That sends the site origin on cross-origin requests, and some CDNs reject it like Twitter/X.com. While post information can get through, videos do not.

### How
The value lives in server_settings, cached in memory and applied per response by the security headers middleware (helmet no longer owns the header). It's read at boot and updated the moment it changes, so no restart. Default Referrer-Policy is configured to be the current default, which is strict-origin-when-cross-origin.

The value is validated on the server against the fixed list of eight tokens, so an admin can't set an arbitrary header value. Clients pick up the new policy on their next page load, since it's a response header.

### Testing
Toggled through the policies and confirmed the Referrer-Policy response header changes to match. Verified X/Twitter video plays under Same-Origin and No-Referrer, and 403s under the default.