### PR TITLE
Keep file themes from inheriting the previous theme's effects and CSS

### DIFF
--- a/public/js/plugin-loader.js
+++ b/public/js/plugin-loader.js
@@ -175,6 +175,16 @@ window.HavenPluginLoader = (function () {
   function setEnabledThemes(list) {
     localStorage.setItem('haven_enabled_themes', JSON.stringify(list));
   }
+  // Published themes are what the theme picker offers, so only one can be
+  // active at a time. Unpublished ones are additive CSS tweaks that stack on
+  // top of whatever theme is selected.
+  function isPublishedTheme(file) {
+    return !!loadedThemes.get(file)?.meta?.published;
+  }
+  function getActiveFileTheme() {
+    const saved = localStorage.getItem('haven_theme') || '';
+    return saved.startsWith('file:') ? saved.slice(5) : null;
+  }
 
   // ── Load a single plugin ──
   async function loadPlugin(meta) {
@@ -255,7 +265,11 @@ window.HavenPluginLoader = (function () {
   // ── Load a theme ──
   function loadTheme(meta) {
     if (loadedThemes.has(meta.file)) return;
-    const enabled = getEnabledThemes().includes(meta.file);
+    // A published theme is only injected when it is the selected one; leaving a
+    // previously-selected one in the enabled list must not stack it on top of
+    // whatever theme is active now.
+    const enabled = getEnabledThemes().includes(meta.file)
+      && (!meta.published || getActiveFileTheme() === meta.file);
     let linkEl = null;
     if (enabled) {
       linkEl = document.createElement('link');
@@ -270,6 +284,12 @@ window.HavenPluginLoader = (function () {
   function enableTheme(file) {
     const t = loadedThemes.get(file);
     if (!t || t.enabled) return;
+    // A published theme is one of the picker's choices, not a stackable tweak —
+    // turning it on means selecting it, so the two surfaces stay in agreement.
+    if (t.meta.published) {
+      applyFileTheme(file);
+      return;
+    }
     t.enabled = true;
     const linkEl = document.createElement('link');
     linkEl.rel = 'stylesheet';
@@ -290,7 +310,28 @@ window.HavenPluginLoader = (function () {
     document.getElementById(`haven-theme-${file}`)?.remove();
     const list = getEnabledThemes().filter(f => f !== file);
     setEnabledThemes(list);
+    // Turning off the selected published theme deselects it, which means falling
+    // back to the built-in default rather than leaving the picker pointing at a
+    // stylesheet that is no longer loaded.
+    if (t.meta.published && getActiveFileTheme() === file) selectBuiltinTheme('haven');
     renderPluginUI();
+  }
+
+  // Switch back to a built-in data-theme, mirroring what a theme-picker button
+  // does in theme.js (which isn't reachable from here as a function).
+  function selectBuiltinTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('haven_theme', theme);
+    document.querySelectorAll('.theme-btn').forEach(b => {
+      b.classList.toggle('active', b.dataset.theme === theme);
+    });
+    if (window.havenSocket && window.havenSocket.connected) {
+      window.havenSocket.emit('set-preference', { key: 'theme', value: theme });
+    }
+    if (typeof applyEffects === 'function') {
+      applyEffects(typeof _getStoredEffectMode === 'function' ? _getStoredEffectMode() : 'auto');
+    }
+    if (typeof showEffectEditorIfDynamic === 'function') showEffectEditorIfDynamic(theme);
   }
 
 
@@ -478,16 +519,39 @@ window.HavenPluginLoader = (function () {
       b.classList.toggle('active', b.dataset.theme === `file:${file}`);
     });
 
+    // Selecting a published theme deselects any other one, so drop the others
+    // from the enabled list — otherwise the Settings toggles claim a theme is
+    // on while the picker shows a different one as active.
+    const kept = getEnabledThemes().filter(f => f !== file && !isPublishedTheme(f));
+    setEnabledThemes([file, ...kept]);
+
     // Re-inject user-enabled custom CSS tweaks (non-published themes) on top of the new base.
-    // The check below skips the file we just injected since it's already in the DOM.
-    reapplyEnabledThemes();
+    reapplyEnabledThemes(file);
+    renderPluginUI();
+
+    // Built-in theme buttons re-run the effect layer on every switch; file themes
+    // have to do the same or the previous theme's overlays (FFX water, Matrix rain,
+    // Nord snow…) keep running on top of the new one. Guarded because theme.js
+    // isn't guaranteed to be loaded wherever the loader runs.
+    if (typeof applyEffects === 'function') {
+      const fxMode = typeof _getStoredEffectMode === 'function' ? _getStoredEffectMode() : 'auto';
+      applyEffects(fxMode);
+    }
+    if (typeof showEffectEditorIfDynamic === 'function') {
+      showEffectEditorIfDynamic(`file:${file}`);
+    }
   }
 
-  // Re-inject all user-enabled themes that are missing from the DOM.
+  // Re-inject the user-enabled CSS tweaks that are missing from the DOM.
   // Called after any theme switch that removes haven-theme-* links.
-  function reapplyEnabledThemes() {
+  // The active theme is skipped (it was just injected, and re-adding it would
+  // move it after the tweaks meant to override it) and so is every other
+  // published theme, which is a selectable theme rather than an overlay.
+  function reapplyEnabledThemes(activeFile = getActiveFileTheme()) {
     const enabledList = getEnabledThemes();
     for (const file of enabledList) {
+      if (file === activeFile) continue;
+      if (isPublishedTheme(file)) continue;
       if (document.getElementById(`haven-theme-${file}`)) continue; // already present
       const linkEl = document.createElement('link');
       linkEl.rel = 'stylesheet';


### PR DESCRIPTION
Two bugs in how `.theme.css` file themes are applied, both hit while switching between built-in themes and file themes. One file changed, `public/js/plugin-loader.js`.

## 1. Effects survived the switch

Every built-in theme button re-runs `applyEffects(_getStoredEffectMode())` after it switches (`theme.js`, `initThemeSwitcher`), so picking a new theme tears down the previous theme's overlays. The theme buttons injected for published file themes go through `applyFileTheme()` instead, which never touched the effect layer — so the FFX water and wave, the Matrix rain, the Nord snowfall and the rest kept running on top of the file theme.

Repro on `main`: pick **FFX**, then pick any published file theme.

```js
localStorage.haven_theme        // "file:mytheme.theme.css"
[...document.querySelectorAll('[id^="fx-"]')].map(e => e.id)
// ["fx-ffx-water", "fx-layers", "fx-ffx-wave"]   ← still there
```

With a light file theme this is very visible: a blue wash down the sidebar and a wave band across the bottom of a white UI.

`applyFileTheme()` now re-applies the stored effect mode the same way the built-in buttons do, plus `showEffectEditorIfDynamic()` so the per-effect sliders stay in sync. Both calls are `typeof`-guarded, since `plugin-loader.js` does not depend on `theme.js` being present.

## 2. An enabled published theme overrode the selected one

Settings → Themes lists **every** `.theme.css` with an on/off toggle, published ones included, and toggling one on adds it to `haven_enabled_themes`. `applyFileTheme()` ended with `reapplyEnabledThemes()`, which re-appends every enabled file *after* the theme that was just selected — so an enabled published theme won the cascade over whatever the picker had active.

Repro on `main`, with a dark theme and a light theme both published:

```js
HavenPluginLoader.enableTheme('mytheme-dark.theme.css');   // Settings → Themes toggle
document.querySelector('.theme-btn[data-theme="file:mytheme-light.theme.css"]').click();

[...document.querySelectorAll('link[id^="haven-theme"]')].map(l => l.id)
// ["haven-theme-mytheme-light.theme.css", "haven-theme-mytheme-dark.theme.css"]
getComputedStyle(document.documentElement).getPropertyValue('--bg-primary')
// the dark theme's value — selecting the light theme changed nothing on screen
```

It persists across reloads too, since `loadTheme()` re-injects from the same list on init.

Published themes are what the picker offers, so they are now treated as mutually exclusive selections rather than stackable overlays:

- `reapplyEnabledThemes(activeFile)` skips the active theme and any *other* published theme, so it does what its comment always said: re-inject the unpublished CSS tweaks on top of the active theme.
- Selecting a published theme drops the others from the enabled list, and `loadTheme()` only injects a published theme when it is the selected one, so a stale entry can't resurface after a reload.
- Toggling a published theme on in Settings selects it, and toggling the active one off falls back to the built-in default rather than leaving the picker pointing at a stylesheet that is no longer loaded — the toggle list and the picker can no longer disagree.

Unpublished themes are untouched and still stack on top of whatever theme is selected.

## Verification

Run against a local server with a fresh `HAVEN_DATA_DIR`, two published themes (one dark, one light) and one unpublished tweak theme:

| case | before | after |
|---|---|---|
| FFX → file theme | `fx-ffx-water`, `fx-ffx-wave` still mounted | effect layers torn down |
| dark published theme enabled in Settings, then light one picked | `--bg-primary` = dark theme's | `--bg-primary` = light theme's |
| same, after reload | still dark | still light |
| unpublished tweak + file theme | works | works, tweak still last in the cascade |
| file theme → built-in FFX | works | works, FFX effects re-arm |
| Settings toggle states | active theme shown unchecked | active theme checked, the other published one unchecked |

Also `node --check` over all 58 tracked JS files and `scripts/validate-locales.js` (6/6 pass).
