### PR TITLE
[feat+fix] Jump down behavior + GIF window Escape fix

### DIFF
--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -892,11 +892,7 @@ _setupSocketListeners() {
 
     // Jump-to-bottom click handler
     if (jumpBtn) {
-      jumpBtn.addEventListener('click', () => {
-        this._scrollToBottom(true);
-        this._coupledToBottom = true;
-        jumpBtn.classList.remove('visible');
-      });
+      jumpBtn.addEventListener('click', () => this._jumpToLatest());
     }
 
     this._historyDebounce = 0; // timestamp of last history request

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -1801,8 +1801,34 @@ _setupUI() {
       // restore runs, and only when it's open so Escape can't open it.
       const emojiPicker = document.getElementById('emoji-picker');
       if (emojiPicker && emojiPicker.style.display === 'flex') this._toggleEmojiPicker();
+      // Close the GIF picker too, matching the emoji picker's Escape behavior.
+      const gifPicker = document.getElementById('gif-picker');
+      if (gifPicker && gifPicker.style.display === 'flex') gifPicker.style.display = 'none';
     }
   });
+
+  // Escape (no modifiers) with nothing else to close → jump to the latest
+  // message, same as the jump-to-bottom button. Runs in the CAPTURE phase so it
+  // inspects overlays/dropdowns *before* the bubble-phase handlers above (and
+  // the message-input dropdown handlers) close them. If any closeable UI is
+  // open we bail and let those handlers run, so Escape never both dismisses a
+  // popup and jumps. Gated on an active channel with the message view visible.
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape' || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+    if (!this.currentChannel) return;
+    const msgArea = document.getElementById('message-area');
+    if (!msgArea || msgArea.style.display === 'none') return;
+    // getClientRects().length is 0 for hidden/display:none nodes — same popup
+    // detection the type-to-focus guard uses above.
+    const somethingOpen = [...document.querySelectorAll(
+      '.modal-overlay, #quick-switcher-overlay, #theme-popup, #search-container, ' +
+      '#search-results-panel, #image-lightbox, .image-lightbox, #emoji-picker, ' +
+      '#gif-picker, .context-menu, #emoji-dropdown, #slash-dropdown, ' +
+      '#mention-dropdown, #channel-dropdown, #persona-dropdown, #gif-slash-picker'
+    )].some(el => el.getClientRects().length > 0);
+    if (somethingOpen) return;
+    this._jumpToLatest();
+  }, true);
 
   // Theme popup toggle
   document.getElementById('theme-popup-toggle')?.addEventListener('click', () => {

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -944,6 +944,40 @@ _scrollToBottom(force) {
   }
 },
 
+// Jump to the newest message. Shared by the jump-to-bottom button and the
+// Escape hotkey. When the DOM window has been trimmed (_noMoreFuture === false)
+// the newest messages aren't loaded, so re-fetch from the present; otherwise a
+// plain scroll reaches the true bottom instantly.
+_jumpToLatest() {
+  document.getElementById('jump-to-bottom')?.classList.remove('visible');
+  if (this._noMoreFuture === false) {
+    this._reloadChannelFromPresent();
+  } else {
+    this._scrollToBottom(true);
+    this._coupledToBottom = true;
+  }
+},
+
+// Snap the feed back to the live present by re-running the fresh channel load.
+// Needed when the DOM window has been trimmed (newest messages aren't in the
+// DOM, i.e. _noMoreFuture === false) — a plain _scrollToBottom only reaches the
+// artificial bottom of the loaded window. This mirrors the reset the own-message
+// and tab-resync paths already use, so message-history renders the initial-load
+// branch and _renderMessages lands at the true bottom.
+_reloadChannelFromPresent() {
+  if (!this.currentChannel || !this.socket?.connected) return;
+  this._coupledToBottom = true;
+  this._oldestMsgId = null;
+  this._noMoreHistory = false;
+  this._loadingHistory = false;
+  this._historyBefore = null;
+  this._newestMsgId = null;
+  this._noMoreFuture = true;
+  this._loadingFuture = false;
+  this._historyAfter = null;
+  this.socket.emit('get-messages', { code: this.currentChannel });
+},
+
 // Debounced version used by image/media load handlers. Multiple images in the
 // same batch (e.g. 5 photos loaded from history) all collapse into a single
 // scroll call instead of firing an individual hard-snap per image, which is


### PR DESCRIPTION
## What this does

Fixes the "jump to bottom" button and adds Escape as a shortcut for it.

### The button bug

The messages DOM is limited to 100 messages at a time. Once you scroll up
far enough, the latest messages get trimmed out, so the "bottom" of the DOM
isn't the real bottom of the channel anymore. The button scrolls to
that fake bottom, which triggers a fetch of the next page. This means
if you've scrolled up hundreds of messages (like clicking a pinned message link), 
you'd need to press the jump button many times to get to the real bottom.

Now the button checks whether the latest messages are actually loaded. If
they've been trimmed (`_noMoreFuture === false`), it re-fetches from the
present using the same path switching channels already uses, so one click
lands you at the real latest message.

### Escape shortcut

Escape now jumps to the latest message too, while a channel is open. It runs
in the capture phase, ahead of the other Escape handlers, and backs off if
anything is open that Escape should close instead (modals, search, the emoji
or GIF picker, autocomplete dropdowns, the image lightbox, context menus). So
it only jumps when Escape has nothing else to do, and never closes a
popup and jumps at the same time.

### GIF picker

While wiring the guard I noticed the GIF picker never closed on Escape, unlike
the emoji picker. Escape now closes it too, for consistency.

Both the button and the shortcut go through one shared `_jumpToLatest` helper.

## Testing

- Scroll to the top of a busy channel (click an old, pinned message), click the button once, land at the
  newest message.
- Press Escape in a channel with nothing open, same result.
- Press Escape with a modal, search box, GIF picker, or autocomplete dropdown
  open and confirm it only closes that and does not jump.