### PR TITLE
[feat] Display Name moderation

### DIFF
--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -5,7 +5,7 @@ const ALL_PERMS = [
   'rename_channel', 'rename_sub_channel', 'set_channel_topic', 'manage_sub_channels',
   'create_channel', 'create_temp_channel', 'upload_files', 'use_voice', 'use_tts', 'manage_webhooks', 'mention_everyone', 'view_history',
   'view_all_members', 'view_channel_members', 'manage_emojis', 'manage_stickers', 'manage_soundboard', 'manage_music_queue', 'promote_user',
-  'manage_roles', 'manage_server', 'delete_channel', 'read_only_override', 'view_audit_log'
+  'manage_roles', 'manage_server', 'delete_channel', 'read_only_override', 'view_audit_log', 'manage_display_names'
 ];
 //Similarly flavored solution to perm labels
 const PERM_LABELS = {
@@ -41,7 +41,8 @@ const PERM_LABELS = {
   get manage_server() { return t('permissions.manage_server'); },
   get delete_channel() { return t('permissions.delete_channel'); },
   get read_only_override() { return t('permissions.read_only_override'); },
-  get view_audit_log() { return t('permissions.view_audit_log'); }
+  get view_audit_log() { return t('permissions.view_audit_log'); },
+  get manage_display_names() { return t('permissions.manage_display_names'); }
 };
 
 export default {
@@ -1667,7 +1668,7 @@ _renderAllMembers(members) {
       let btns = '';
       // Always-available: DM and Nickname
       btns += `<button class="aml-action-btn aml-btn-dm" data-uid="${m.id}" data-uname="${this._escapeHtml(m.displayName)}" title="${t('users.direct_message')}">💬</button>`;
-      btns += `<button class="aml-action-btn aml-btn-nick" data-uid="${m.id}" data-uname="${this._escapeHtml(m.username)}" title="${t('users.set_nickname')}">🏷️</button>`;
+      btns += `<button class="aml-action-btn aml-btn-nick" data-uid="${m.id}" data-uname="${this._escapeHtml(m.username)}" data-dname="${this._escapeHtml(m.displayName)}" title="${t('users.set_nickname')}">🏷️</button>`;
       if (perms.canPromote && !m.banned) {
         btns += `<button class="aml-action-btn aml-btn-role" data-uid="${m.id}" data-uname="${this._escapeHtml(m.username)}" title="${t('users.gear_menu.assign_role')}">👑</button>`;
       }
@@ -1733,7 +1734,8 @@ _bindMemberListActions(container) {
       e.stopPropagation();
       const uid = parseInt(btn.dataset.uid);
       const uname = btn.dataset.uname;
-      self._showNicknameDialog(uid, uname);
+      const dname = btn.dataset.dname;
+      self._showNicknameDialog(uid, uname, dname);
     });
   });
 

--- a/public/js/modules/app-context.js
+++ b/public/js/modules/app-context.js
@@ -98,7 +98,7 @@ _showUserContextMenu(e, targetUserId) {
   nickBtn.innerHTML = `🏷️ ${t('users.set_nickname')}`;
   nickBtn.addEventListener('click', () => {
     this._hideUserContextMenu();
-    this._showNicknameDialog(targetUserId, targetName);
+    this._showNicknameDialog(targetUserId, targetName, targetName);
   });
   menu.appendChild(nickBtn);
 

--- a/public/js/modules/app-users.js
+++ b/public/js/modules/app-users.js
@@ -768,7 +768,7 @@ _showProfilePopup(profile) {
     : '';
   const actionsHtml = isSelf
     ? `<button class="profile-popup-action-btn profile-edit-btn" id="profile-popup-edit-btn">✏️ ${t('users.edit_profile')}</button><button class="profile-popup-action-btn profile-dm-btn" data-dm-uid="${profile.id}" title="Notes to self">📝 Notes to self</button>`
-    : `<button class="profile-popup-action-btn profile-dm-btn" data-dm-uid="${profile.id}">💬 ${t('users.message_btn')}</button><button class="profile-popup-action-btn profile-nick-btn" data-nick-uid="${profile.id}" data-nick-uname="${this._escapeHtml(profile.username)}">${nickBtnLabel}</button>${gearBtnHtml}`;
+    : `<button class="profile-popup-action-btn profile-dm-btn" data-dm-uid="${profile.id}">💬 ${t('users.message_btn')}</button><button class="profile-popup-action-btn profile-nick-btn" data-nick-uid="${profile.id}" data-nick-uname="${this._escapeHtml(profile.username)}" data-nick-dname="${this._escapeHtml(profile.displayName)}">${nickBtnLabel}</button>${gearBtnHtml}`;
 
   const popup = document.createElement('div');
   popup.id = 'profile-popup';
@@ -856,8 +856,9 @@ _showProfilePopup(profile) {
     nickBtnEl.addEventListener('click', () => {
       const uid = parseInt(nickBtnEl.dataset.nickUid);
       const uname = nickBtnEl.dataset.nickUname;
+      const dname = nickBtnEl.dataset.nickDname;
       this._closeProfilePopup();
-      this._showNicknameDialog(uid, uname);
+      this._showNicknameDialog(uid, uname, dname);
     });
   }
 
@@ -1371,8 +1372,12 @@ _setNickname(userId, nickname) {
   }
 },
 
-_showNicknameDialog(userId, currentUsername) {
+_showNicknameDialog(userId, currentUsername, currentDisplayName) {
   const existing = this._nicknames[userId] || '';
+  const displayName = currentDisplayName || currentUsername;
+  // Members with Manage Display Names can flip this modal into editing the
+  // target's real (server-wide) display name instead of a private nickname.
+  const canManageNames = userId !== this.user?.id && this._hasPerm('manage_display_names');
   const dialog = document.createElement('div');
   dialog.className = 'modal-overlay';
   dialog.style.display = 'flex';
@@ -1382,8 +1387,15 @@ _showNicknameDialog(userId, currentUsername) {
       <h3 style="margin-top:0">${t('users.set_nickname_title')}</h3>
       <p class="muted-text" style="margin:0 0 12px">${t('users.nickname_hint', { name: `<strong>${this._escapeHtml(currentUsername)}</strong>` })}</p>
       <input type="text" id="nickname-input" class="modal-input" value="${this._escapeHtml(existing)}" placeholder="${this._escapeHtml(currentUsername)}" maxlength="32" style="width:100%;box-sizing:border-box">
+      ${canManageNames ? `
+      <label class="toggle-row" style="margin-top:12px">
+        <span>${t('users.edit_display_name_toggle')}</span>
+        <input type="checkbox" id="nickname-global-toggle">
+      </label>
+      <p class="muted-text" id="nickname-global-note" style="display:none;margin:8px 0 0;padding:8px 10px;border-radius:6px;background:var(--bg-tertiary);border:1px solid var(--border-light);color:var(--text-secondary)">${t('users.edit_display_name_note')}</p>
+      ` : ''}
       <div class="modal-actions" style="margin-top:12px">
-        ${existing ? `<button class="btn-sm" id="nickname-clear">${t('users.nickname_clear_btn')}</button>` : ''}
+        <button class="btn-sm" id="nickname-clear" style="${existing ? '' : 'display:none'}">${t('users.nickname_clear_btn')}</button>
         <button class="btn-sm" id="nickname-cancel">${t('modals.common.cancel')}</button>
         <button class="btn-sm btn-accent" id="nickname-save">${t('modals.common.save')}</button>
       </div>
@@ -1398,24 +1410,52 @@ _showNicknameDialog(userId, currentUsername) {
   dialog.querySelector('#nickname-cancel').addEventListener('click', close);
   dialog.addEventListener('click', (e) => { if (e.target === dialog) close(); });
 
+  const globalToggle = dialog.querySelector('#nickname-global-toggle');
+  const globalNote = dialog.querySelector('#nickname-global-note');
   const clearBtn = dialog.querySelector('#nickname-clear');
-  if (clearBtn) {
-    clearBtn.addEventListener('click', () => {
-      this._setNickname(userId, null);
-      this._refreshNicknameDisplays();
-      this._showToast(t('users.nickname_cleared'), 'info');
-      close();
+  const isGlobal = () => !!(globalToggle && globalToggle.checked);
+
+  if (globalToggle) {
+    globalToggle.addEventListener('change', () => {
+      const on = globalToggle.checked;
+      // Checked: prefill the target's current display name and reveal the
+      // warning. Unchecked: fall back to the private nickname exactly as before.
+      input.value = on ? displayName : existing;
+      input.maxLength = on ? 20 : 32;
+      globalNote.style.display = on ? '' : 'none';
+      clearBtn.style.display = (on || existing) ? '' : 'none';
+      clearBtn.textContent = on ? t('users.display_name_reset_btn') : t('users.nickname_clear_btn');
+      input.focus();
+      input.select();
     });
   }
 
+  clearBtn.addEventListener('click', () => {
+    if (isGlobal()) {
+      // Reset the target's display name back to their username
+      this.socket.emit('rename-user-global', { targetId: userId, displayName: '' });
+      this._showToast(t('users.display_name_reset'), 'info');
+    } else {
+      this._setNickname(userId, null);
+      this._refreshNicknameDisplays();
+      this._showToast(t('users.nickname_cleared'), 'info');
+    }
+    close();
+  });
+
   dialog.querySelector('#nickname-save').addEventListener('click', () => {
     const val = input.value.trim();
-    this._setNickname(userId, val || null);
-    this._refreshNicknameDisplays();
-    if (val) {
-      this._showToast(t('users.nickname_set', { name: val }), 'success');
+    if (isGlobal()) {
+      this.socket.emit('rename-user-global', { targetId: userId, displayName: val });
+      this._showToast(t('users.display_name_updated', { name: val || displayName }), 'success');
     } else {
-      this._showToast(t('users.nickname_cleared'), 'info');
+      this._setNickname(userId, val || null);
+      this._refreshNicknameDisplays();
+      if (val) {
+        this._showToast(t('users.nickname_set', { name: val }), 'success');
+      } else {
+        this._showToast(t('users.nickname_cleared'), 'info');
+      }
     }
     close();
   });

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -431,7 +431,8 @@
     "manage_server": "Manage Server",
     "delete_channel": "Delete Channels",
     "read_only_override": "Read-Only Override",
-    "view_audit_log": "View Audit Log"
+    "view_audit_log": "View Audit Log",
+    "manage_display_names": "Manage Display Names"
   },
   "slowmode": {
     "wait": "Slow mode — wait {{seconds}}s before sending another message",
@@ -589,6 +590,11 @@
     "set_nickname_title": "Set Nickname",
     "nickname_hint": "Only you will see this nickname for {{name}}.",
     "nickname_clear_btn": "Clear",
+    "edit_display_name_toggle": "Edit Display Name (Global)",
+    "edit_display_name_note": "You are now editing the Display Name of this user. This change will be visible to every member in the server.",
+    "display_name_reset_btn": "Reset to Username",
+    "display_name_reset": "Display name reset",
+    "display_name_updated": "Display name updated to \"{{name}}\"",
     "edit_profile_modal_title": "Edit Profile",
     "bio_label": "Bio",
     "bio_max_hint": "(max 190 chars)",

--- a/src/socketHandlers/helpers.js
+++ b/src/socketHandlers/helpers.js
@@ -54,7 +54,7 @@ const VALID_ROLE_PERMS = [
   'create_channel', 'create_temp_channel', 'upload_files', 'use_voice', 'use_tts', 'manage_webhooks', 'mention_everyone', 'view_history',
   'view_all_members', 'view_channel_members', 'manage_emojis', 'manage_stickers', 'manage_soundboard', 'manage_music_queue',
   'promote_user', 'transfer_admin', 'manage_roles', 'manage_server', 'delete_channel', 'read_only_override',
-  'view_audit_log'
+  'view_audit_log', 'manage_display_names'
 ];
 
 module.exports = { utcStamp, isString, isInt, sanitizeText, isValidUploadPath, VALID_ROLE_PERMS };

--- a/src/socketHandlers/users.js
+++ b/src/socketHandlers/users.js
@@ -734,6 +734,116 @@ module.exports = function register(socket, ctx) {
     }
   });
 
+  // ── Global display name (Manage Display Names permission) ──
+  // Lets a moderator change another member's real display name — the one
+  // everyone sees — reusing the same validation and broadcast path as a
+  // self-rename. A blank displayName resets the target back to their username.
+  socket.on('rename-user-global', (data) => {
+    if (!data || typeof data !== 'object') return;
+    if (!socket.user.isAdmin && !userHasPermission(socket.user.id, 'manage_display_names')) {
+      return socket.emit('error-msg', 'You do not have permission to manage display names');
+    }
+    const targetId = parseInt(data.targetId, 10);
+    if (!Number.isFinite(targetId) || targetId <= 0) return;
+
+    const target = db.prepare('SELECT id, username, display_name FROM users WHERE id = ?').get(targetId);
+    if (!target) return socket.emit('error-msg', 'User not found');
+
+    const raw = typeof data.displayName === 'string' ? data.displayName.trim().replace(/\s+/g, ' ') : '';
+    const oldName = target.display_name || target.username;
+
+    let newName, newDisplayCol;
+    if (raw) {
+      if (raw.length < 2 || raw.length > 20) {
+        return socket.emit('error-msg', 'Display name must be 2-20 characters');
+      }
+      if (!/^[a-zA-Z0-9_ ]+$/.test(raw)) {
+        return socket.emit('error-msg', 'Letters, numbers, underscores, and spaces only');
+      }
+      try {
+        const conflict = db.prepare(`
+          SELECT id FROM users
+          WHERE id != ?
+            AND (LOWER(display_name) = LOWER(?)
+                 OR (display_name IS NULL AND LOWER(username) = LOWER(?)))
+          LIMIT 1
+        `).get(targetId, raw, raw);
+        if (conflict) {
+          return socket.emit('error-msg', 'That display name is already taken on this server');
+        }
+      } catch (err) {
+        console.error('Display name conflict check failed:', err);
+      }
+      newName = raw;
+      newDisplayCol = raw;
+    } else {
+      // Reset back to the login username
+      newName = target.username;
+      newDisplayCol = null;
+    }
+
+    try {
+      db.prepare('UPDATE users SET display_name = ? WHERE id = ?').run(newDisplayCol, targetId);
+    } catch (err) {
+      console.error('Global rename error:', err);
+      return socket.emit('error-msg', 'Failed to update display name');
+    }
+
+    // Refresh presence maps silently — no user-renamed system message, since a
+    // moderator changing someone's name shouldn't announce itself in-channel.
+    for (const [code, users] of channelUsers) {
+      if (users.has(targetId)) {
+        users.get(targetId).username = newName;
+        emitOnlineUsers(code);
+      }
+    }
+    for (const [code, users] of voiceUsers) {
+      if (users.has(targetId)) {
+        users.get(targetId).username = newName;
+        broadcastVoiceUsers(code);
+      }
+    }
+
+    // Update the target's own connected sessions (token + UI) as if they renamed
+    for (const [, s] of io.sockets.sockets) {
+      if (s.user && s.user.id === targetId) {
+        s.user.displayName = newName;
+        const newToken = generateToken({ id: s.user.id, username: s.user.username, isAdmin: s.user.isAdmin, displayName: newName });
+        s.emit('renamed', {
+          token: newToken,
+          user: { id: s.user.id, username: s.user.username, isAdmin: s.user.isAdmin, displayName: newName },
+          oldName
+        });
+      }
+    }
+
+    // Notify DM partners so their sidebars update
+    try {
+      const dmPartners = db.prepare(`
+        SELECT DISTINCT cm2.user_id FROM channel_members cm1
+        JOIN channels c ON c.id = cm1.channel_id AND c.is_dm = 1
+        JOIN channel_members cm2 ON cm2.channel_id = c.id AND cm2.user_id != ?
+        WHERE cm1.user_id = ?
+      `).all(targetId, targetId);
+      for (const partner of dmPartners) {
+        for (const [, s] of io.sockets.sockets) {
+          if (s.user && s.user.id === partner.user_id) {
+            s.emit('dm-name-updated', { userId: targetId, newName });
+          }
+        }
+      }
+    } catch (err) {
+      console.error('DM name update broadcast error:', err);
+    }
+
+    console.log(`✏️  ${socket.user.username} set display name of ${target.username} to ${newName}`);
+    if (oldName !== newName) {
+      _audit({ actor: socket.user, action: 'user_rename',
+        target_type: 'user', target_id: targetId, target_name: newName,
+        details: { oldName, newName } });
+    }
+  });
+
   socket.on('set-nicknames-bulk', (data) => {
     if (!data || typeof data !== 'object') return;
     const map = data.nicknames;


### PR DESCRIPTION
Adds a new permission called "Manage Display names". 

Members who hold the permission get a new "Edit Display Name" toggle in the existing Edit Nickname modal. 

Checking the toggle changes the mode of the modal. While checked, the modal will now change the target's Display Name which is visible to the entire server. A theme-aware note is also displayed to inform moderators of the mode change. 

Unchecking the toggle restores the modal to its original functionality, and will change the target's private nickname, which is only visible to the user making the edit. 

The rename updates the member list silently without posting an in-channel rename message, and is still recorded in the audit log.