### PR TITLE
[fix] Misc QOL improvements

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9510,6 +9510,13 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   user-select: auto;
 }
 
+/* Custom emoji render as <img>, which `color: transparent` can't hide, so
+   they'd otherwise show through an unrevealed text spoiler. Keep them laid
+   out (the blur box stays the right size) but invisible until revealed. */
+.spoiler:not(.revealed) .custom-emoji {
+  visibility: hidden;
+}
+
 /* Spoiler images (sender marked the image as a spoiler) — blurred behind a
    label until clicked. The inner .chat-image is the actual image. */
 .spoiler-media {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9538,6 +9538,32 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   visibility: hidden;
 }
 
+/* Inline code sets its own color and background, so `color: transparent`
+   can't hide it and it would show through an unrevealed spoiler. It's a
+   single line, so the spoiler's own bar covers it — just hide the element
+   (keeping its layout box) until revealed. */
+.spoiler:not(.revealed) .inline-code {
+  visibility: hidden;
+}
+
+/* Fenced code blocks are tall block-level boxes, but .spoiler is an inline
+   span whose background only paints the first and last line — the middle of
+   the block would be hidden-but-uncovered (transparent) instead of showing a
+   spoiler bar. So rather than hide the block, repaint it as the bar itself:
+   the muted background, transparent text, no border, and no language tag,
+   until revealed. */
+.spoiler:not(.revealed) .code-block {
+  background: var(--text-muted);
+  border-color: transparent;
+  color: transparent;
+}
+.spoiler:not(.revealed) .code-block code {
+  color: transparent;
+}
+.spoiler:not(.revealed) .code-block-lang {
+  visibility: hidden;
+}
+
 /* Spoiler images (sender marked the image as a spoiler) — blurred behind a
    label until clicked. The inner .chat-image is the actual image. */
 .spoiler-media {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9568,6 +9568,29 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   display: none;
 }
 
+/* A link wrapped in a || spoiler || carries the spoiler onto its embed card:
+   blur the card behind the shared spoiler tag until it's clicked to reveal.
+   Only the children are blurred and made click-through, so the card itself
+   catches the reveal click — same mechanic as .spoiler-media above. */
+.link-preview.lp-spoiler {
+  position: relative;
+  cursor: pointer;
+}
+.link-preview.lp-spoiler:not(.revealed) {
+  overflow: hidden;
+}
+.link-preview.lp-spoiler:not(.revealed) > *:not(.spoiler-media-tag) {
+  filter: blur(22px);
+  transform: scale(1.02);
+  pointer-events: none;
+}
+.link-preview.lp-spoiler.revealed {
+  cursor: default;
+}
+.link-preview.lp-spoiler.revealed > .spoiler-media-tag {
+  display: none;
+}
+
 /* Hidden image placeholder (viewer chose "Hide Image") — a compact pill that
    restores the image when clicked. */
 .hidden-image {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -8892,6 +8892,27 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   font-size: 0.85em;
 }
 
+/* Persona autocomplete (::Name) avatar — scale/crop to a small circle the way
+   the sent-message avatar does, rather than showing the raw, oversized image. */
+.persona-dd-avatar {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+}
+.persona-dd-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-tertiary, var(--bg-secondary));
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
 /* :emoji autocomplete dropdown */
 .emoji-dropdown {
   position: absolute;

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2262,7 +2262,13 @@ _checkEmojiTrigger(inputEl) {
     if (ch === ' ' || ch === '\n') break; // stop at whitespace
   }
 
-  if (colonIdx === -1) { this._hideEmojiDropdown(); return; }
+  // No emoji token under the cursor — bail and close any open dropdown. A
+  // leading "::" counts as "no token": it's the persona trigger, and since no
+  // emoji shortcode starts with ':', that colon can only belong to a persona.
+  if (colonIdx === -1 || (colonIdx === 1 && text.startsWith('::'))) {
+    this._hideEmojiDropdown();
+    return;
+  }
 
   const query = text.substring(colonIdx + 1, cursor).toLowerCase();
   if (query.length < 2) { this._hideEmojiDropdown(); return; }

--- a/public/js/modules/app-messages.js
+++ b/public/js/modules/app-messages.js
@@ -1522,6 +1522,7 @@ _fetchLinkPreviews(containerEl) {
         // in the query string. That was the whole reason for same-origin.
         `<div class="lp-content"><div class="link-preview-yt"><iframe src="https://www.youtube.com/embed/${this._escapeHtml(ytVideoId)}?rel=0" width="100%" height="270" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div></div>`;
       this._wireEmbedControls(wrapper, url);
+      this._applyEmbedSpoiler(wrapper, link);
       msgContent.appendChild(wrapper);
       if (this._coupledToBottom) this._scrollToBottom(true);
       return; // skip generic link preview for YouTube
@@ -1637,6 +1638,7 @@ _fetchLinkPreviews(containerEl) {
             stats +
           '</div>';
         this._wireEmbedControls(card, url);
+        this._applyEmbedSpoiler(card, link);
 
         const wasAtBottom = this._coupledToBottom;
         msgContent.appendChild(card);
@@ -1709,6 +1711,21 @@ _runLinkPreviewTask(task) {
 // _applyEmbedSize live in app-media.js); the per-card ⤢ button is a quick cycle
 // through Full→Medium→Small (Off stays Settings-only so the button can't hide
 // itself), and the ▾/▸ caret collapses a single embed for this session.
+
+// A link wrapped in a || spoiler || carries that spoiler onto its embed
+// card: the card is blurred behind the same tag used for spoiler images
+// until it is clicked to reveal (handled by _maybeRevealConcealed). We read
+// the rendered DOM — the <a> sits inside the .spoiler span — so detection
+// stays in sync with however the message was marked up (auto-link, masked
+// [text](url), YouTube, etc.).
+_applyEmbedSpoiler(embedEl, link) {
+  if (!link || !link.closest('.spoiler')) return;
+  embedEl.classList.add('lp-spoiler');
+  const tag = document.createElement('span');
+  tag.className = 'spoiler-media-tag';
+  tag.textContent = '\u{1F441}\u{FE0F} ' + ((typeof t === 'function' && t('app.messages.spoiler')) || 'Spoiler');
+  embedEl.appendChild(tag);
+},
 
 /** Header row markup: site name (accent), size cycle button, collapse caret. */
 _embedHeaderHtml(siteName, collapsed) {

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -1996,6 +1996,9 @@ _setupUI() {
   document.getElementById('messages').addEventListener('contextmenu', (e) => {
     // Images have their own Save/Copy/Open menu (handled above) — leave them.
     if (e.target.closest('.chat-image')) return;
+    // Inside the inline message-edit box, defer to the browser's native menu
+    // so spell-check suggestions work — none of our items apply while editing.
+    if (e.target.closest('.edit-textarea')) return;
     // Don't hijack right-click while picking messages to move.
     if (this._moveSelectionActive) return;
     const msgEl = e.target.closest('.message, .message-compact');

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -6310,6 +6310,15 @@ _maybeRevealConcealed(e) {
     sp.classList.add('revealed');
     return true;
   }
+  // Spoilered link embed (the link was wrapped in ||spoiler||) → reveal the
+  // card in place; blurred children have pointer-events disabled, so the
+  // click lands on the card and this consumes it before the embed's own
+  // controls or link fire.
+  const lp = e.target.closest && e.target.closest('.link-preview.lp-spoiler');
+  if (lp && !lp.classList.contains('revealed')) {
+    lp.classList.add('revealed');
+    return true;
+  }
   return false;
 },
 

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -3730,7 +3730,20 @@ _startEditMessage(msgEl, msgId) {
     e.stopPropagation();
     e.preventDefault();
     let newContent = textarea.value.trim();
-    if (!newContent) return cancel();
+    if (!newContent) {
+      // Discord-style: clearing the whole message and confirming the edit
+      // offers to delete the message rather than silently cancelling it.
+      // Enter confirms the prompt via the shared confirm modal.
+      cancel();
+      if (await this._showConfirmModal(t('confirm.delete_message'), '', { danger: true, confirmLabel: t('msg_toolbar.delete') })) {
+        const pip = msgEl.closest('#dm-pip-messages') ? this._activeDMPip : null;
+        const attachments = this._getMessageAttachments?.(msgId);
+        this.socket.emit('delete-message', pip
+          ? { messageId: msgId, channelCode: pip, attachments }
+          : { messageId: msgId, attachments });
+      }
+      return;
+    }
     if (newContent === rawText) return cancel();
 
     // E2E: encrypt edited DM content. The PiP can edit a DM that isn't


### PR DESCRIPTION
## Misc quality of life improvements

Four small, self-contained fixes to message editing, spoilers, and the persona picker.

### Prompt to delete a message when its edit is cleared
Clearing a message during an edit and confirming used to silently cancel the edit. Now it offers to delete the message, matching Discord. It reuses the existing confirm modal, so Enter confirms the deletion.

### Hide custom emoji inside an unrevealed spoiler
A text spoiler hides its content with `color: transparent`, which works for text and standard emoji but not custom emoji, since those render as an `<img>` that color can't touch. The custom emoji showed through the spoiler. It's now hidden until the spoiler is revealed, keeping its layout box so the covered area stays the right size.

### Carry a link's spoiler onto its embed
A link wrapped in `||spoiler||` hid its own text but its embed card still showed the title, description, and image in full. The embed now inherits the spoiler: it renders blurred behind the same tag used for spoiler images, and a click reveals it. Detection reads the rendered DOM so it covers every way a link can be marked up, and both embed paths are wired (the generic rich card and YouTube), so it applies to all links that embed rather than one type.

### Hide code blocks inside an unrevealed spoiler
An inline codeblock and multi-line codeblock also had the same bug with spoilers not applying properly.

### Stop the persona picker and emoji autocomplete from colliding
Typing `::` to start a persona message also tripped the `:emoji` autocomplete, so the two dropdowns fought over the same input. Since no emoji shortcode starts with a colon, a leading `::` can only be a persona, so the emoji autocomplete now leaves that token alone. Also scaled the persona avatar in the picker, which had no styling and rendered at full size and cut off, cropping it to a small circle the way the avatar shows once the message is sent.

### Let the browser's spell-check menu show inside the message editor
The message-row right-click handler opened Haven's custom context menu
(reply / quote / pin / delete) over everything in #messages, including
the inline edit textarea — so right-clicking a misspelled word there hid
the browser's spell-check suggestions. Defer to the native menu when the
target is inside .edit-textarea, where none of the menu items apply.