### PR TITLE
Add Invitation Buttons

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -591,7 +591,7 @@
         <!-- Invite users button pinned under user list -->
         <div class="panel sidebar-invite-panel" id="sidebar-invite-panel" style="display:none">
           <button class="panel btn-invite-popout" id="right-btn-invite-popout" data-i18n-title="app.actions.invite" title="Invite Users">
-            <svg width="16" height="16" viewBox="0 0 32 32" class="invite-icon">
+            <svg width="16" height="16" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
               <circle cx="14" cy="11" r="6"/>
               <path d="M5,26c0-4.971,4.029-9,9-9 c1.864,0,3.596,0.567,5.032,1.537"/>
               <circle cx="24" cy="24" r="7"/>

--- a/public/app.html
+++ b/public/app.html
@@ -588,6 +588,19 @@
             </div>
           </div>
         </div>
+        <!-- Invite users button pinned under user list -->
+        <div class="panel sidebar-invite-panel" style="display:none">
+          <button class="panel btn-invite-popout" id="right-btn-invite-popout" data-i18n-title="app.actions.invite" title="Invite Users">
+            <svg width="16" height="16" viewBox="0 0 32 32" class="invite-icon">
+              <circle cx="14" cy="11" r="6"/>
+              <path d="M5,26c0-4.971,4.029-9,9-9 c1.864,0,3.596,0.567,5.032,1.537"/>
+              <circle cx="24" cy="24" r="7"/>
+              <line x1="24" y1="28" x2="24" y2="20"/>
+              <line x1="20" y1="24" x2="28" y2="24"/>
+            </svg>
+            <span data-i18n="app.actions.invite">Invite Users</span>
+          </button>
+        </div>
         <!-- Voice settings sub-panel (slides up above controls) -->
         <div id="voice-settings-panel" class="voice-settings-panel" style="display:none">
           <div class="voice-settings-section-label">🎧 <span data-i18n="voice_settings.audio_devices">Audio Devices</span></div>
@@ -3149,6 +3162,7 @@
       </div>
       <div class="modal-actions" style="justify-content:space-between;flex-wrap:wrap;gap:6px">
         <div style="display:flex;gap:6px;flex-wrap:wrap">
+          <button class="btn-sm btn-accent" id="aml-view-invite-btn" style="display:none">➕ <span data-i18n="settings.admin.view_invite-btn">Invite Users</span></button>
           <button class="btn-sm btn-accent" id="aml-view-bans-btn" style="display:none">📋 <span data-i18n="settings.admin.view_bans_btn">View Bans</span></button>
           <button class="btn-sm btn-accent" id="aml-view-deleted-btn" style="display:none">🗑️ <span data-i18n="settings.admin.view_deleted_btn">View Deleted Users</span></button>
           <button class="btn-sm btn-danger-fill" id="aml-bulk-cleanup-btn" style="display:none">🧹 <span data-i18n="settings.admin.bulk_cleanup_btn">Cleanup</span></button>

--- a/public/app.html
+++ b/public/app.html
@@ -588,6 +588,19 @@
             </div>
           </div>
         </div>
+        <!-- Invite users button pinned under user list -->
+        <div class="panel sidebar-invite-panel" id="sidebar-invite-panel" style="display:none">
+          <button class="panel btn-invite-popout" id="right-btn-invite-popout" data-i18n-title="app.actions.invite" title="Invite Users">
+            <svg width="16" height="16" viewBox="0 0 32 32" class="invite-icon">
+              <circle cx="14" cy="11" r="6"/>
+              <path d="M5,26c0-4.971,4.029-9,9-9 c1.864,0,3.596,0.567,5.032,1.537"/>
+              <circle cx="24" cy="24" r="7"/>
+              <line x1="24" y1="28" x2="24" y2="20"/>
+              <line x1="20" y1="24" x2="28" y2="24"/>
+            </svg>
+            <span data-i18n="app.actions.invite">Invite Users</span>
+          </button>
+        </div>
         <!-- Voice settings sub-panel (slides up above controls) -->
         <div id="voice-settings-panel" class="voice-settings-panel" style="display:none">
           <div class="voice-settings-section-label">🎧 <span data-i18n="voice_settings.audio_devices">Audio Devices</span></div>
@@ -3149,6 +3162,7 @@
       </div>
       <div class="modal-actions" style="justify-content:space-between;flex-wrap:wrap;gap:6px">
         <div style="display:flex;gap:6px;flex-wrap:wrap">
+          <button class="btn-sm btn-accent" id="aml-view-invite-btn" style="display:none">➕ <span data-i18n="settings.admin.view_invite-btn">Invite Users</span></button>
           <button class="btn-sm btn-accent" id="aml-view-bans-btn" style="display:none">📋 <span data-i18n="settings.admin.view_bans_btn">View Bans</span></button>
           <button class="btn-sm btn-accent" id="aml-view-deleted-btn" style="display:none">🗑️ <span data-i18n="settings.admin.view_deleted_btn">View Deleted Users</span></button>
           <button class="btn-sm btn-danger-fill" id="aml-bulk-cleanup-btn" style="display:none">🧹 <span data-i18n="settings.admin.bulk_cleanup_btn">Cleanup</span></button>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1349,13 +1349,19 @@
 [data-theme="win95"] .icon-btn:active { border: 2px inset #808080; }
 
 /* Win95 settings button */
-[data-theme="win95"] .btn-settings-popout {
+[data-theme="win95"] .btn-settings-popout,
+[data-theme="win95"] .btn-invite-popout {
   background: #bfbfbf; color: #000; border: 3px outset #fff;
   border-radius: 0 !important;
 }
-[data-theme="win95"] .btn-settings-popout:hover { background: #dfdfdf; color: #000; }
-[data-theme="win95"] .btn-settings-popout:active { border: 3px inset #808080; }
-[data-theme="win95"] .btn-settings-popout svg { color: #000; }
+[data-theme="win95"] .btn-settings-popout:hover,
+[data-theme="win95"] .btn-invite-popout:hover {background: #dfdfdf; color: #000; }
+
+[data-theme="win95"] .btn-settings-popout:active,
+[data-theme="win95"] .btn-invite-popout:active { border: 3px inset #808080; }
+
+[data-theme="win95"] .btn-settings-popout svg,
+[data-theme="win95"] .btn-invite-popout svg { color: #000; }
 
 /* Win95 status picker dot — beveled */
 [data-theme="win95"] .status-picker-dot { border: 2px outset #fff; border-radius: 0 !important; }
@@ -10582,14 +10588,16 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   border-color: var(--accent);
 }
 
-.sidebar-settings-panel {
+.sidebar-settings-panel,
+.sidebar-invite-panel {
   flex-shrink: 0;
   border-top: 1px solid var(--border);
   border-bottom: none;
   padding: 0.625rem 1rem;
 }
 
-.btn-settings-popout {
+.btn-settings-popout,
+.btn-invite-popout {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -10604,16 +10612,21 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   font-weight: 500;
   transition: all 0.15s ease;
 }
-.btn-settings-popout:hover {
+.btn-settings-popout:hover,
+.btn-invite-popout:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
   border-color: var(--accent);
 }
-.btn-settings-popout svg {
+.btn-settings-popout svg,
+.btn-invite-popout svg {
   flex-shrink: 0;
   opacity: 0.7;
 }
-.btn-settings-popout:hover svg { opacity: 1; }
+.btn-settings-popout:hover svg,
+.btn-invite-popout:hover svg { 
+  opacity: 1;
+}
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
    ADMIN MEMBER LIST

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -362,6 +362,9 @@ class HavenApp {
     if (this.user.isAdmin || this._hasPerm('manage_roles') || this._hasPerm('manage_server')) {
       document.getElementById('admin-mod-panel').style.display = 'block';
     }
+    if (this.user.isAdmin || this._hasGlobalPerm('invite_users')) {
+      document.getElementById('sidebar-invite-panel').style.display = 'block';
+    }
     const organizeBtn = document.getElementById('organize-channels-btn');
     if (organizeBtn) organizeBtn.style.display = '';
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -362,7 +362,7 @@ class HavenApp {
     if (this.user.isAdmin || this._hasPerm('manage_roles') || this._hasPerm('manage_server')) {
       document.getElementById('admin-mod-panel').style.display = 'block';
     }
-    if (this.user.isAdmin || this._hasGlobalPerm('invite_users')) {
+    if (this.user.isAdmin || this._hasGlobalPerm('invite_users') || this._hasPerm('manage_server')) {
       document.getElementById('sidebar-invite-panel').style.display = 'block';
     }
     const organizeBtn = document.getElementById('organize-channels-btn');

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2157,6 +2157,7 @@ _openMemberChannelPicker(userId, username, mode) {
 _openInviteLinksModal() {
   const modal = document.getElementById('invite-links-modal');
   if (!modal) return;
+  if (!this.user.isAdmin && !this._hasGlobalPerm('invite_users')) return this.socket.emit('error-msg', 'You don\'t have permission to manage invite links');
   if (typeof this._renderInviteCreateChannels === 'function') {
     try { this._renderInviteCreateChannels(true); } catch { /* non-critical */ }
   }

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2157,7 +2157,7 @@ _openMemberChannelPicker(userId, username, mode) {
 _openInviteLinksModal() {
   const modal = document.getElementById('invite-links-modal');
   if (!modal) return;
-  if (!this.user.isAdmin && !this._hasGlobalPerm('invite_users')) return this._showToast('You don\'t have permission to manage invite links', 'error');
+  if (!this.user.isAdmin && !this._hasGlobalPerm('manage_server') && !this._hasGlobalPerm('invite_users')) return this._showToast('You don\'t have permission to manage invite links', 'error');
   if (typeof this._renderInviteCreateChannels === 'function') {
     try { this._renderInviteCreateChannels(true); } catch { /* non-critical */ }
   }

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2157,7 +2157,7 @@ _openMemberChannelPicker(userId, username, mode) {
 _openInviteLinksModal() {
   const modal = document.getElementById('invite-links-modal');
   if (!modal) return;
-  if (!this.user.isAdmin && !this._hasGlobalPerm('invite_users')) return this.socket.emit('error-msg', 'You don\'t have permission to manage invite links');
+  if (!this.user.isAdmin && !this._hasGlobalPerm('invite_users')) return this._showToast('You don\'t have permission to manage invite links', 'error');
   if (typeof this._renderInviteCreateChannels === 'function') {
     try { this._renderInviteCreateChannels(true); } catch { /* non-critical */ }
   }

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -1637,9 +1637,11 @@ _openAllMembersModal() {
     document.getElementById('all-members-count').textContent = `(${res.total})`;
     // Toggle moderator-only nav buttons (View Bans / View Deleted) based on perms.
     // Server-side handlers re-validate, so DOM tampering can't reveal data.
+    const inviteBtn = document.getElementById('aml-view-invite-btn');
     const banBtn = document.getElementById('aml-view-bans-btn');
     const delBtn = document.getElementById('aml-view-deleted-btn');
     const cleanupBtn = document.getElementById('aml-bulk-cleanup-btn');
+    if (inviteBtn) inviteBtn.style.display = (this._allMembersPerms.canInvite || this._allMembersPerms.isAdmin) ? '' : 'none';
     if (banBtn) banBtn.style.display = (this._allMembersPerms.canBan || this._allMembersPerms.isAdmin) ? '' : 'none';
     if (delBtn) delBtn.style.display = this._allMembersPerms.isAdmin ? '' : 'none';
     if (cleanupBtn) cleanupBtn.style.display = this._allMembersPerms.isAdmin ? '' : 'none';
@@ -2146,6 +2148,20 @@ _openMemberChannelPicker(userId, username, mode) {
     // Refresh after a short delay
     setTimeout(() => this._openAllMembersModal(), 800);
   });
+},
+
+// ═══════════════════════════════════════════════════════
+// INVITE LINKS
+// ═══════════════════════════════════════════════════════
+
+_openInviteLinksModal() {
+  const modal = document.getElementById('invite-links-modal');
+  if (!modal) return;
+  if (typeof this._renderInviteCreateChannels === 'function') {
+    try { this._renderInviteCreateChannels(true); } catch { /* non-critical */ }
+  }
+  if (this.socket?.connected) { try { this.socket.emit('get-invite-codes'); } catch { /* non-critical */ } }
+  modal.style.display = 'flex';
 },
 
 // ═══════════════════════════════════════════════════════

--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -92,9 +92,11 @@ _setupSocketListeners() {
     // Refresh UI to reflect new permissions
     const canModerate = this.user.isAdmin || this.user.effectiveLevel >= 25;
     const canCreateChannel = this.user.isAdmin || this._hasGlobalPerm('create_channel');
+    const canCreateInvites = this.user.isAdmin || this._hasGlobalPerm('invite_users');
     document.getElementById('admin-controls').style.display = canCreateChannel ? 'block' : 'none';
     document.getElementById('admin-mod-panel').style.display = (canModerate || this._hasPerm('manage_emojis') || this._hasPerm('manage_stickers') || this._hasPerm('manage_soundboard') || this._hasPerm('view_audit_log')) ? 'block' : 'none';
     document.getElementById('sidebar-members-btn').style.display = (this.user.isAdmin || canModerate || this._hasPerm('view_all_members') || this._hasPerm('view_channel_members')) ? '' : 'none';
+    document.getElementById('sidebar-invite-panel').style.display = canCreateInvites ? 'block' : 'none';
     this._showToast(t('toasts.roles_updated'), 'info');
   });
 

--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -92,7 +92,7 @@ _setupSocketListeners() {
     // Refresh UI to reflect new permissions
     const canModerate = this.user.isAdmin || this.user.effectiveLevel >= 25;
     const canCreateChannel = this.user.isAdmin || this._hasGlobalPerm('create_channel');
-    const canCreateInvites = this.user.isAdmin || this._hasGlobalPerm('invite_users');
+    const canCreateInvites = this.user.isAdmin || this._hasGlobalPerm('manage_server') || this._hasGlobalPerm('invite_users');
     document.getElementById('admin-controls').style.display = canCreateChannel ? 'block' : 'none';
     document.getElementById('admin-mod-panel').style.display = (canModerate || this._hasPerm('manage_emojis') || this._hasPerm('manage_stickers') || this._hasPerm('manage_soundboard') || this._hasPerm('view_audit_log')) ? 'block' : 'none';
     document.getElementById('sidebar-members-btn').style.display = (this.user.isAdmin || canModerate || this._hasPerm('view_all_members') || this._hasPerm('view_channel_members')) ? '' : 'none';

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -4545,13 +4545,13 @@ _setupUI() {
   // Invite Links popout — open/close. Refresh the list and create-form channels
   // on open so the modal always reflects current state.
   document.getElementById('open-invite-links-btn')?.addEventListener('click', () => {
-    const modal = document.getElementById('invite-links-modal');
-    if (!modal) return;
-    if (typeof this._renderInviteCreateChannels === 'function') {
-      try { this._renderInviteCreateChannels(true); } catch { /* non-critical */ }
-    }
-    if (this.socket?.connected) { try { this.socket.emit('get-invite-codes'); } catch { /* non-critical */ } }
-    modal.style.display = 'flex';
+    this._openInviteLinksModal();
+  });
+  document.getElementById('right-btn-invite-popout')?.addEventListener('click', () => {
+    this._openInviteLinksModal();
+  });
+  document.getElementById('aml-view-invite-btn')?.addEventListener('click', () => {
+    this._openInviteLinksModal();
   });
   document.getElementById('close-invite-links-btn')?.addEventListener('click', () => {
     const modal = document.getElementById('invite-links-modal');

--- a/src/socketHandlers/admin.js
+++ b/src/socketHandlers/admin.js
@@ -1021,6 +1021,7 @@ module.exports = function register(socket, ctx) {
           canPromote: isAdmin || userHasPermission(socket.user.id, 'promote_user'),
           canKick: isAdmin || userHasPermission(socket.user.id, 'kick_user'),
           canBan: isAdmin || userHasPermission(socket.user.id, 'ban_user'),
+          canInvite: isAdmin || userHasPermission(socket.user.id, 'invite_users'),
         }
       });
     } catch (err) {

--- a/src/socketHandlers/admin.js
+++ b/src/socketHandlers/admin.js
@@ -1021,7 +1021,7 @@ module.exports = function register(socket, ctx) {
           canPromote: isAdmin || userHasPermission(socket.user.id, 'promote_user'),
           canKick: isAdmin || userHasPermission(socket.user.id, 'kick_user'),
           canBan: isAdmin || userHasPermission(socket.user.id, 'ban_user'),
-          canInvite: isAdmin || userHasPermission(socket.user.id, 'invite_users'),
+          canInvite: isAdmin || userHasPermission(socket.user.id, 'invite_users') || userHasPermission(socket.user.id, 'manage_server'),
         }
       });
     } catch (err) {


### PR DESCRIPTION
This Pull Request adds two buttons that open up the `invite-links-modal`. 
One Button is under the user list, the other is in the "All Members" window.

The buttons are only displayed when the user is admin, or has the "Invite Users" permission globally.

These buttons make it more apparent to the user that they have the ability to create invites, as well as eliminating the need to open/have-access-to the admin settings to create invites.
 
Demo Vid:

https://github.com/user-attachments/assets/100c64c8-ceec-44cb-9045-d75337ccf818



Refs #5470 

