### PR TITLE
Braid Layout: restore Join / Create a Channel, and fix the dead Encryption entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haven",
-  "version": "3.41.0",
+  "version": "3.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haven",
-      "version": "3.41.0",
+      "version": "3.47.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -2,7 +2,7 @@
  * @name Braid Layout
  * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, docks the full voice controls bottom-left, tucks header extras into a kebab menu, merges message runs into cards, and calms the chrome. One-key toggle (Ctrl+Shift+B) between Braid and the classic layout. Suspends itself while Mod Mode edits the layout. Pairs with the Braid / Braid Light themes, and respects every other theme: cosmetic shape rules use :where() so any [data-theme] override wins.
  * @author Amnibro
- * @version 1.6
+ * @version 1.7
  */
 class BraidLayout {
   start() {
@@ -298,9 +298,13 @@ class BraidLayout {
   _collapseJoinCreate() {
     if (localStorage.getItem('haven_join_collapsed') === null) this._setLS('haven_join_collapsed', '1');
     if (localStorage.getItem('haven_create_collapsed') === null) this._setLS('haven_create_collapsed', '1');
+    // Only the stock `.collapsed` class may drive visibility here. A second,
+    // Braid-owned class used to hide the body as well, and because nothing ever
+    // removed it, the stock toggle could flip `.collapsed` all it liked and the
+    // section stayed shut — Join a Channel and Create Channel were unreachable
+    // for as long as the layout was on.
     document.querySelectorAll('#join-section-body, #create-section-body').forEach((el) => this._addClass(el, 'collapsed'));
     document.querySelectorAll('#join-section-arrow, #create-section-arrow').forEach((el) => this._addClass(el, 'collapsed'));
-    document.querySelectorAll('.sidebar-section[data-mod-id="join"], #admin-controls').forEach((s) => this._addClass(s, 'braid-collapsed'));
   }
 
   _hideEdgeChrome() {
@@ -444,7 +448,18 @@ class BraidLayout {
     addProxy('gallery-toggle-btn', I.media, 'Files & media');
     addProxy('copy-code-btn', I.copy, 'Copy code');
     addProxy('channel-code-settings-btn', I.code, 'Code settings');
-    addProxy('e2e-menu-btn', I.lock, 'Encryption');
+    // Not `e2e-menu-btn`: that only opens a dropdown living inside the header
+    // wrapper, which is display:none outside a DM and hidden by this layout
+    // inside one — so the entry did nothing at all. Proxy the three actions
+    // instead; each opens its own modal. They are marked so the open handler
+    // can show them only where encryption applies.
+    ['e2e-verify-btn::Verify encryption', 'e2e-recover-btn::Recover keys', 'e2e-reset-btn::Reset keys'].forEach((spec) => {
+      const [id, label] = spec.split('::');
+      const src = document.getElementById(id);
+      if (!src) return;
+      addItem(I.lock, label, () => src.click());
+      menu.lastElementChild.dataset.braidE2e = '1';
+    });
     addLabel('View');
     addItem(I.people, 'People & voice', () => this._setPeopleOpen(!document.documentElement.classList.contains('braid-people-open')));
     addItem(I.sound, 'Soundboard', () => toggleHtmlClass('braid-sound-open'));
@@ -479,6 +494,13 @@ class BraidLayout {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       const opening = !menu.classList.contains('open');
+      // The menu is built once, so anything channel-dependent has to be
+      // resolved here rather than at build time.
+      if (opening) {
+        const wrapper = document.getElementById('e2e-menu-wrapper');
+        const e2eOn = !!wrapper && getComputedStyle(wrapper).display !== 'none';
+        menu.querySelectorAll('[data-braid-e2e]').forEach((el) => { el.style.display = e2eOn ? '' : 'none'; });
+      }
       menu.classList.toggle('open', opening);
       wrap.classList.toggle('open', opening);
       btn.setAttribute('aria-expanded', opening ? 'true' : 'false');
@@ -810,8 +832,6 @@ html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"] .section-label,
 html[data-braid-layout="1"] .sidebar-section#admin-controls .section-label{font-size:.71875rem!important;letter-spacing:0!important;text-transform:none!important;font-weight:550!important;color:var(--text-muted)!important;margin:2px 0!important;padding:.4375rem .5rem;border-radius:.625rem}
 html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"] .section-label:hover,
 html[data-braid-layout="1"] .sidebar-section#admin-controls .section-label:hover{background:var(--bg-hover);color:var(--text-primary)}
-html[data-braid-layout="1"] .sidebar-section[data-mod-id="join"].braid-collapsed .collapsible-section-body,
-html[data-braid-layout="1"] .sidebar-section#admin-controls.braid-collapsed .collapsible-section-body,
 html[data-braid-layout="1"] #join-section-body.collapsed,
 html[data-braid-layout="1"] #create-section-body.collapsed{display:none!important}
 html[data-braid-layout="1"] .sidebar-split{flex:1;min-height:0;display:flex;flex-direction:column;border:0!important}


### PR DESCRIPTION
Reported by **birdycrazy**: the Braid layout "seems to completely remove the ability to join or create channels", and the **Encryption** menu entry does nothing.

Both reproduce. Join and Create were not merely collapsed — **they could not be reopened at all.**

### Join / Create were unreachable

`_collapseJoinCreate()` added a Braid-owned `braid-collapsed` class to the *section*, on top of the stock `.collapsed` class on the *body*, and the stylesheet hid `.braid-collapsed .collapsible-section-body` with `!important`. Nothing ever removed that class, so the stock toggle kept flipping `.collapsed` underneath while the body stayed hidden.

Traced on a live server, clicking the section header:

| | body classes | section classes | computed display |
|---|---|---|---|
| initial | `collapsible-section-body` | `sidebar-section braid-collapsed` | `none` |
| after 1st click | `… collapsed` | `sidebar-section braid-collapsed` | `none` |
| after 2nd click | `collapsible-section-body` | `sidebar-section braid-collapsed` | `none` |
| `braid-collapsed` removed by hand | `collapsible-section-body` | `sidebar-section` | **`block`** |

The stock toggle works perfectly; the Braid class simply outranks it forever. Net effect: an admin could not create a channel and nobody could join one while the layout was on.

Visibility is now driven only by the stock class, which the collapse helper still sets — so the sections keep opening collapsed, and the header reopens them. Verified after the fix: Join expands to a usable code field and Join button, Create expands to the name field and create button.

### The Encryption entry could never have worked

It proxied a click to `#e2e-menu-btn`, whose handler only toggles `#e2e-dropdown`. That dropdown lives inside `#e2e-menu-wrapper`, which `app-channels.js` sets to `display:none` outside a DM — so in a normal channel the entry was present and did precisely nothing. Confirmed live: `e2e-menu-wrapper` computed `display:none`, `e2e-menu-btn` not visible, entry still listed in the menu.

Inside a DM it would have fared no better — this layout hides the header chrome the dropdown anchors to, and the original click keeps bubbling to the document handler that closes the dropdown again.

Proxying the three actions directly avoids all of it, since each opens its own modal and none depend on the dropbox being visible:

- Verify encryption
- Recover keys
- Reset keys

The menu is built once, so these are tagged and resolved at open time — shown where encryption applies, hidden elsewhere. Verified: hidden in a channel, `display:flex` once the wrapper is shown as a DM does, and a click on the entry reaches the real `#e2e-verify-btn` handler.

### Testing

Live server, Braid theme published and the plugin enabled, checked as both a non-admin member and an admin. `node --check` passes. No other `braid-collapsed` references remain in the plugin.