### PR TITLE
Fix subchannel restrictions

### DIFF
--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -383,6 +383,7 @@ _openChannelCtxMenu(code, btnEl) {
   // used to show the entry everywhere once you held the permission anywhere.
   const ch = this.channels.find(c => c.code === code);
   const canManageSettings = isAdmin || !!(ch && ch.canManageSettings);
+  const canManageSubs = isAdmin || !!(ch && ch.canManageSubs);
   const isMod = isAdmin || this._canModerate();
   menu.querySelectorAll('.admin-only').forEach(el => {
     el.style.display = canManageChannels ? '' : 'none';
@@ -472,12 +473,11 @@ _openChannelCtxMenu(code, btnEl) {
   if (moveToBtn && ch) {
     const hasChildren = this.channels.some(c => c.parent_channel_id === ch.id);
     // Can move if: admin, not a DM, and has no children (can't nest 2 levels)
-    moveToBtn.style.display = (canManageChannels && !ch.is_dm && !hasChildren) ? '' : 'none';
+    moveToBtn.style.display = (canManageSubs && !ch.is_dm && !hasChildren) ? '' : 'none';
   }
   // Show "Promote to Channel" only for sub-channels
   const promoteBtn = menu.querySelector('[data-action="promote-channel"]');
   if (promoteBtn && ch) {
-    const canManageSub = isAdmin || canManageSettings || !!(ch && ch.canManageSubs);
     promoteBtn.style.display = (canManageSub && ch.parent_channel_id) ? '' : 'none';
   }
   // Update Channel Functions panel with current channel values

--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -477,7 +477,8 @@ _openChannelCtxMenu(code, btnEl) {
   // Show "Promote to Channel" only for sub-channels
   const promoteBtn = menu.querySelector('[data-action="promote-channel"]');
   if (promoteBtn && ch) {
-    promoteBtn.style.display = (canManageChannels && ch.parent_channel_id) ? '' : 'none';
+    const canManageSub = isAdmin || canManageSettings || !!(ch && ch.canManageSubs);
+    promoteBtn.style.display = (canManageSub && ch.parent_channel_id) ? '' : 'none';
   }
   // Update Channel Functions panel with current channel values
   if (canManageSettings) this._updateChannelFunctionsPanel(ch);

--- a/src/socketHandlers/channels.js
+++ b/src/socketHandlers/channels.js
@@ -1314,6 +1314,9 @@ module.exports = function register(socket, ctx) {
     try {
       if (newParentCode === null || newParentCode === undefined) {
         if (!channel.parent_channel_id) return socket.emit('error-msg', 'Channel is already top-level');
+        if (!_canManageSubsScoped(channel.parent_channel_id)) {
+          return socket.emit('error-msg', 'You don\'t have permission to promote this channel');
+        }
         const maxPos = db.prepare('SELECT MAX(position) as mp FROM channels WHERE parent_channel_id IS NULL AND is_dm = 0').get();
         const position = (maxPos && maxPos.mp != null) ? maxPos.mp + 1 : 0;
         db.prepare('UPDATE channels SET parent_channel_id = NULL, position = ?, category = NULL WHERE id = ?').run(position, channel.id);

--- a/src/socketHandlers/channels.js
+++ b/src/socketHandlers/channels.js
@@ -89,6 +89,17 @@ module.exports = function register(socket, ctx) {
     socket.user.isAdmin ||
     userHasPermission(socket.user.id, 'manage_channel_settings', channelId);
 
+  // (#5492) Nesting a channel *under* a parent adds a child to that parent's
+  // structure, so it must require authority over that specific parent: admin
+  // or a channel-scoped manage_sub_channels grant. Unlike _canManageSubsOf,
+  // the server-wide create_channel permission is deliberately NOT enough here.
+  // Otherwise anyone who can create a channel could make a top-level channel
+  // and move it under a parent they don't moderate, sidestepping
+  // manage_sub_channels entirely.
+  const _canManageSubsScoped = (parentId) =>
+    socket.user.isAdmin ||
+    (!!parentId && userHasPermission(socket.user.id, 'manage_sub_channels', parentId));
+
   // ── Get user's channels ─────────────────────────────────
   socket.on('get-channels', () => {
     const channels = getEnrichedChannels(
@@ -1320,7 +1331,9 @@ module.exports = function register(socket, ctx) {
         if (channel.parent_channel_id === newParent.id) return socket.emit('error-msg', 'Channel is already under that parent');
         // (#5424) A sub-channel manager of the destination parent (or the
         // channel's current parent) may re-nest an existing sub-channel.
-        if (!_canManageSubsOf(newParent.id) && !_canManageSubsOf(channel.parent_channel_id)) {
+        // (#5492) Authority here is channel-scoped only — server-wide
+        // create_channel does not let you nest under a parent you don't manage.
+        if (!_canManageSubsScoped(newParent.id) && !_canManageSubsScoped(channel.parent_channel_id)) {
           return socket.emit('error-msg', 'You don\'t have permission to move channels');
         }
         const maxPos = db.prepare('SELECT MAX(position) as mp FROM channels WHERE parent_channel_id = ?').get(newParent.id);

--- a/src/socketHandlers/channels.js
+++ b/src/socketHandlers/channels.js
@@ -1335,8 +1335,8 @@ module.exports = function register(socket, ctx) {
         // (#5424) A sub-channel manager of the destination parent (or the
         // channel's current parent) may re-nest an existing sub-channel.
         // (#5492) Authority here is channel-scoped only — server-wide
-        // create_channel does not let you nest under a parent you don't manage.
-        if (!_canManageSubsScoped(newParent.id) && !_canManageSubsScoped(channel.parent_channel_id)) {
+        // create_channel does not let you nest under, or move from, a parent you don't manage.
+        if (!_canManageSubsScoped(newParent.id) || !_canManageSubsScoped(channel.parent_channel_id)) {
           return socket.emit('error-msg', 'You don\'t have permission to move channels');
         }
         const maxPos = db.prepare('SELECT MAX(position) as mp FROM channels WHERE parent_channel_id = ?').get(newParent.id);


### PR DESCRIPTION
Users could still move a subchannel from a channel, or to a channel where they don't have the manage-subchannel permissions; They could also promote these subchannels.

This PR fixes these problems by adding the permission gate for these actions. Also hides the options in the channel context menu when not permitted.

refs: #5492