### PR TITLE
Eliminate channel context menu divider

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -3303,7 +3303,7 @@
     <hr class="channel-ctx-sep">
     <button class="channel-ctx-item" data-action="leave-channel">🚪 <span data-i18n="context_menu.channel.leave">Leave Channel</span></button>
     <button class="channel-ctx-item" data-action="hide-channel" style="display:none">🙈 <span data-i18n="context_menu.channel.hide">Hide Channel</span></button>
-    <hr class="channel-ctx-sep">
+    <hr class="channel-ctx-sep rename-or-createSub">
     <button class="channel-ctx-item mod-only" data-action="rename-channel">✏️ <span data-i18n="context_menu.channel.rename">Rename Channel</span></button>
     <button class="channel-ctx-item mod-only" data-action="create-sub-channel">📁 <span data-i18n="context_menu.channel.create_sub">Create Sub-channel</span></button>
     <hr class="channel-ctx-sep admin-only">

--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -456,8 +456,8 @@ _openChannelCtxMenu(code, btnEl) {
   // this eliminates a double divider being displayed when both of these buttons are not displayed
   const renameOrCreateSubDivider = menu.querySelector('[class="channel-ctx-sep rename-or-createSub"]');
   if (renameOrCreateSubDivider && ch) {
-    const renameCtxBtn_visible = renameCtxBtn && renameCtxBtn.style.display !== None;
-    const createSubBtn_visible = createSubBtn && createSubBtn.style.display !== None;
+    const renameCtxBtn_visible = renameCtxBtn && renameCtxBtn.style.display !== 'none';
+    const createSubBtn_visible = createSubBtn && createSubBtn.style.display !== 'none';
     renameOrCreateSubDivider.style.display = (renameCtxBtn_visible || createSubBtn_visible) ? '' : 'none';
   }
   // Hide "Leave Channel" for admins (always in all channels)

--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -452,6 +452,14 @@ _openChannelCtxMenu(code, btnEl) {
     const canRename = isMod || this._hasPerm(renamePerm);
     renameCtxBtn.style.display = canRename ? '' : 'none';
   }
+  // Only display the divider when the "rename-channel" and/or "create-sub-channel" buttons are visible.
+  // this eliminates a double divider being displayed when both of these buttons are not displayed
+  const renameOrCreateSubDivider = menu.querySelector('[class="channel-ctx-sep rename-or-createSub"]');
+  if (renameOrCreateSubDivider && ch) {
+    const renameCtxBtn_visible = renameCtxBtn && renameCtxBtn.style.display !== None;
+    const createSubBtn_visible = createSubBtn && createSubBtn.style.display !== None;
+    renameOrCreateSubDivider.style.display = (renameCtxBtn_visible || createSubBtn_visible) ? '' : 'none';
+  }
   // Hide "Leave Channel" for admins (always in all channels)
   const leaveBtn = menu.querySelector('[data-action="leave-channel"]');
   if (leaveBtn) leaveBtn.style.display = isAdmin ? 'none' : '';


### PR DESCRIPTION
This prevents the double divider that can occur when both "Rename Channel" and "Create Sub-channel" options are not available in the channel context menu.

Double divider
<img width="183" height="312" alt="image" src="https://github.com/user-attachments/assets/79196b4d-da7c-4596-b692-04dd873ea087" />

Fixed (single divider)
<img width="180" height="305" alt="image" src="https://github.com/user-attachments/assets/8e2f91fd-cc9a-44bd-97a6-a42a359730cf" />

Divider still displayed when the options are available.
<img width="192" height="410" alt="image" src="https://github.com/user-attachments/assets/1feb740c-d1cb-4198-a7ec-7068a44f413b" />

Related to: #5492