### PR TITLE
Fixes trailing slash issues for oidc sources that require it.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,3 +91,6 @@ ADMIN_USERNAME=admin
 # If you choose to leave this feature disabled, Haven will default to Unicode standard 16.0 which is bundled with the server
 # Uncomment to enable this feature
 # UNICODE_EMOJI_AUTO_UPDATE=true
+
+# Your client secret as defined by your OIDC provider. The client secret must be set as an env var if using OIDC.
+#   OIDC_CLIENT_SECRET=changeme-client-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       # - VAPID_EMAIL=mailto:you@example  # Optional: email for push notifications
       # - TURN_URL=turn:your-server:3478  # Optional: TURN relay for voice over internet
       # - TURN_SECRET=your-secret         # Shared secret (coturn --use-auth-secret)
+      # - OIDC_CLIENT_SECRET=client-secret # The client secret as defined by your OIDC provider.
     # Uncomment to load settings from a .env file:
     # env_file: .env
     restart: unless-stopped

--- a/src/oidc.js
+++ b/src/oidc.js
@@ -53,7 +53,7 @@ function _setting(key) {
  * ride along inside one. (Same reasoning as JWT_SECRET.)
  */
 function getOidcConfig() {
-  const issuer = _setting('oidc_issuer_url').replace(/\/+$/, '');
+  const issuer = _setting('oidc_issuer_url'); // don't try to alter thet issuer url uppon fetching.
   const clientId = _setting('oidc_client_id');
   const clientSecret = process.env.OIDC_CLIENT_SECRET || '';
   const scopes = _setting('oidc_scopes') || 'openid profile email';
@@ -109,8 +109,10 @@ async function discover(issuer) {
   _assertSafeIssuer(issuer);
   const hit = _discoveryCache.get(issuer);
   if (hit && Date.now() - hit.at < DISCOVERY_TTL_MS) return hit.doc;
-
-  const doc = await _fetchJson(`${issuer}/.well-known/openid-configuration`);
+  
+  // remove trailing slash if present to construct the openid-config path
+  const normalized_issuer = issuer.replace(/\/+$/, '');
+  const doc = await _fetchJson(`${normalized_issuer}/.well-known/openid-configuration`);
 
   // The issuer inside the document is authoritative and must match what the
   // admin configured, or we could be talking to a provider that impersonates


### PR DESCRIPTION
Reported by @jesjhoward in #12
and @RCCore in #5501 

The OIDC issuer URL was getting the trailing slash removed. Some OIDC issuers, like Authentik, require the trailing slash in order to work properly, due to havens exact match requirement.

This PR implements changes which eliminates alteration of the issuer url as entered in the settings.
Also builds out the openid-config path correctly regardless of weather or not the trailing slash is present.

Tested to be working with my Authentik instance.


https://github.com/user-attachments/assets/c8cee26a-fd7f-4f16-9953-ff0413db5f17

