### PR TITLE
fix(braid): keep main channels out of sub-channel cards

### DIFF
--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -2,7 +2,7 @@
  * @name Braid Layout
  * @description Vastly simplified two-edge layout: folds the server rail into the sidebar, docks the full voice controls bottom-left, tucks header extras into a kebab menu, merges message runs into cards, and calms the chrome. One-key toggle (Ctrl+Shift+B) between Braid and the classic layout. Suspends itself while Mod Mode edits the layout. Pairs with the Braid / Braid Light themes, and respects every other theme: cosmetic shape rules use :where() so any [data-theme] override wins.
  * @author Amnibro
- * @version 1.7
+ * @version 1.8
  */
 class BraidLayout {
   start() {
@@ -752,10 +752,17 @@ class BraidLayout {
       if (cont) { if (el.getAttribute('data-braid-cont') !== '1') el.setAttribute('data-braid-cont', '1'); }
       else if (el.hasAttribute('data-braid-cont')) el.removeAttribute('data-braid-cont');
     }
+    const famOf = (el) => {
+      if (!el || !el.classList || !el.classList.contains('channel-item')) return null;
+      return el.classList.contains('sub-channel-item') ? `sub:${el.dataset.parentId || ''}` : 'main';
+    };
+    const joinsRun = (a, b) => {
+      const fa = famOf(a), fb = famOf(b);
+      if (!fa || !fb) return false;
+      return fa === fb || (fa === 'main' && fb.slice(0, 4) === 'sub:');
+    };
     document.querySelectorAll('.channel-item').forEach((el) => {
-      const prev = el.previousElementSibling;
-      const next = el.nextElementSibling;
-      const v = runOf(!prev || !prev.classList.contains('channel-item'), !next || !next.classList.contains('channel-item'));
+      const v = runOf(!joinsRun(el.previousElementSibling, el), !joinsRun(el, el.nextElementSibling));
       if (el.getAttribute('data-braid-run') !== v) el.setAttribute('data-braid-run', v);
     });
   }

--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -754,12 +754,15 @@ class BraidLayout {
     }
     const famOf = (el) => {
       if (!el || !el.classList || !el.classList.contains('channel-item')) return null;
+      if (el.classList.contains('dm-item')) return 'dm';
       return el.classList.contains('sub-channel-item') ? `sub:${el.dataset.parentId || ''}` : 'main';
     };
     const joinsRun = (a, b) => {
       const fa = famOf(a), fb = famOf(b);
       if (!fa || !fb) return false;
-      return fa === fb || (fa === 'main' && fb.slice(0, 4) === 'sub:');
+      if (fa === 'dm' && fb === 'dm') return true;
+      if (fb.slice(0, 4) !== 'sub:') return false;
+      return fa === fb || fa === 'main';
     };
     document.querySelectorAll('.channel-item').forEach((el) => {
       const v = runOf(!joinsRun(el.previousElementSibling, el), !joinsRun(el, el.nextElementSibling));

--- a/plugins/BraidLayout.plugin.js
+++ b/plugins/BraidLayout.plugin.js
@@ -768,6 +768,12 @@ class BraidLayout {
       const v = runOf(!joinsRun(el.previousElementSibling, el), !joinsRun(el, el.nextElementSibling));
       if (el.getAttribute('data-braid-run') !== v) el.setAttribute('data-braid-run', v);
     });
+    document.querySelectorAll('.channel-item.sub-channel-item').forEach((el) => {
+      const hash = el.querySelector('.channel-hash');
+      const flat = el.hasAttribute('data-sub-tag') && hash && hash.textContent.trim() === '↳';
+      if (flat) { if (el.getAttribute('data-braid-flat') !== '1') el.setAttribute('data-braid-flat', '1'); }
+      else if (el.hasAttribute('data-braid-flat')) el.removeAttribute('data-braid-flat');
+    });
   }
 
   // Own messages get an accent-tinted card, like mobile.
@@ -1020,6 +1026,8 @@ html[data-braid-form="1"] .channel-item[data-braid-run="end"],
 html[data-braid-form="1"] .channel-item[data-braid-run="solo"]{border-bottom-left-radius:.75rem!important;border-bottom-right-radius:.75rem!important;margin-bottom:.25rem!important}
 html[data-braid-form="1"] .channel-item[data-braid-run="mid"]::before,
 html[data-braid-form="1"] .channel-item[data-braid-run="end"]::before{content:'';position:absolute;left:.75rem;right:.75rem;top:0;border-top:1px dashed var(--braid-seam);pointer-events:none}
+html[data-braid-form="1"] .channel-item[data-braid-flat="1"] .channel-hash{visibility:hidden;position:relative}
+html[data-braid-form="1"] .channel-item[data-braid-flat="1"] .channel-hash::after{content:'#';visibility:visible;position:absolute;left:0;top:0}
 html[data-braid-form="1"] .channel-item:hover{background:color-mix(in srgb,var(--text-primary) 10%,var(--bg-secondary))}
 html[data-braid-form="1"] .channel-item.active{background:color-mix(in srgb,var(--accent) 16%,var(--bg-secondary));border-color:var(--accent)!important}
 html[data-braid-form="1"] .channel-item.active::before,


### PR DESCRIPTION
Reported by **birdycrazy** against both the web client and the Android app: main channels that follow another channel's sub-channels get drawn inside the same Braid card as those sub-channels, so they read as belonging to a tag they have no relation to.

In the report the READ-ONLY card holds `↳ Info and Tips` and `↳ Announcements`, which are sub-channels of **Everyone**, and then `Server Administration` and `Automod Log`, which are main channels. One card reads as one family.

### Cause

`_markRuns()` marks `data-braid-run` from "is my neighbour also a `.channel-item`":

```js
const v = runOf(!prev || !prev.classList.contains('channel-item'),
                !next || !next.classList.contains('channel-item'));
```

Parentage never enters into it, so any unbroken run of rows becomes one card and the first main channel after somebody's subs continues that card.

### Fix

A card is a family: siblings under one parent, or a parent followed by its own subs.

| Neighbours | Same card |
|---|---|
| parent → its own sub | yes |
| sub → sub, same parent | yes |
| sub → sub, different parent | no |
| **sub → main** | **no** (the reported case) |
| main → main | yes |

`famOf()` keys a sub row by `dataset.parentId` and a main row by `main`; `joinsRun()` continues a run only inside one key, or from a parent into its own subs. This leans on two facts from `renderChannelItem` in `app-channels.js`: a sub row always carries `dataset.parentId`, and a parent's subs are always rendered directly after it. The tag row (`sub-channel-item sub-tag-label`) carries the same `parentId`, so a tag stays with the subs it labels.

Cosmetic only — no change to channel data, ordering, collapse state or any other plugin behaviour. Version 1.7 → 1.8.

The Android app had the identical defect in its own drawer and ships the same rule in 7.6.1, with unit coverage over the layout from the report.
