### PR TITLE
Refuse to boot when a stale pre-split module file shadows a module folder

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,6 +14,41 @@ if (nodeMajor < 22 || nodeMajor > 26) {
 // Bootstrap .env into the data directory if it doesn't exist yet
 const fs = require('fs');
 const path = require('path');
+
+// ── Stale-install guard ───────────────────────────────────
+// Updating by unzipping/copying a release over an existing install leaves
+// behind files that newer versions deleted. That is normally harmless — until
+// the deleted file is a module that was split into a folder of the same name
+// (src/socketHandlers.js became src/socketHandlers/ in 2.9.8): require()
+// resolves the leftover FILE before the directory, so the server silently
+// runs months-old module code no matter how current every other file is, and
+// eventually dies somewhere unrelated. A real self-host crashed on boot with
+// "Cannot read properties of undefined (reading 'activity')" because a
+// pre-2.9.8 socketHandlers.js was still shadowing the folder — after months
+// of its socket layer being frozen at the old version while "fully updated".
+// Catch the pattern generically and say exactly which file to delete.
+{
+  const srcDir = path.join(__dirname, 'src');
+  let entries = [];
+  try { entries = fs.readdirSync(srcDir, { withFileTypes: true }); } catch { /* no src = other problems */ }
+  const dirNames = new Set(entries.filter(e => e.isDirectory()).map(e => e.name));
+  const stale = entries.filter(e =>
+    e.isFile() && e.name.endsWith('.js') && dirNames.has(e.name.slice(0, -3)) &&
+    fs.existsSync(path.join(srcDir, e.name.slice(0, -3), 'index.js'))
+  ).map(e => path.join('src', e.name));
+  if (stale.length > 0) {
+    console.error('\n❌ Stale file(s) from an older Haven install detected:\n');
+    for (const f of stale) console.error(`     ${f}`);
+    console.error('\n  Each file above is left over from an old version and hides the');
+    console.error('  module folder of the same name, so this server would run with');
+    console.error('  outdated code and fail in confusing ways.');
+    console.error('  Fix: delete the file(s) listed above (the folders contain the');
+    console.error('  current code), or update by replacing the whole Haven folder');
+    console.error('  instead of copying new files over an old install. Your data is');
+    console.error(`  safe — it lives in ${DATA_DIR}, not in the install folder.\n`);
+    process.exit(1);
+  }
+}
 if (!fs.existsSync(ENV_PATH)) {
   const example = path.join(__dirname, '.env.example');
   if (fs.existsSync(example)) {


### PR DESCRIPTION
## The crash (community report, v3.47.0)

```
/home/raidenphantom/Haven/server.js:4427
}).activity;
   ^
TypeError: Cannot read properties of undefined (reading 'activity')
```

Same self-hoster as the role-editor thread. His server.js **is** current — line 4427 is `activityRef.engine = setupSocketHandlers(...).activity`. The crash means `setupSocketHandlers()` returned `undefined`… which the current module can't do. It returns `{ activity }`.

## Root cause: a deleted file from 2.9.7 still on disk

`src/socketHandlers.js` was split into the `src/socketHandlers/` folder in **2.9.8**. His update style is copying new files over the existing install — which never deletes anything — so the pre-split monolith is still there. Node resolves `require('./src/socketHandlers')` to the **file** before the **directory**, the monolith exports the same `{ setupSocketHandlers, sanitizeText }` shape, its `setupSocketHandlers` registers all the ancient handlers and **returns nothing** → `undefined.activity`.

The nasty part is what happened *before* the crash: with his old server.js (which never read `.activity`), this booted fine — meaning his server's **entire socket layer has been frozen at ≤2.9.7 for months** while every file around it was current. That one stale file retroactively explains his whole support history: the Admin-role Save doing nothing (`update-admin-role-display`, added 3.44.0, never loaded), embed reactions behaving differently than the public Haven server, the desktop app finding API paths missing. Any self-hoster who installed ≤2.9.7 and updates by unzip-over-the-top has this same landmine.

## Fix

A startup guard right after the Node version check: scan `src/` for any `<name>.js` file that shadows a `<name>/index.js` folder, and exit with the exact file list and instructions (delete the file / update by replacing the folder; data in the data dir is safe) instead of booting mixed-version code. Generic, so a future file→folder split is covered automatically.

## Verified

- Dropped the 2.9.7 `socketHandlers.js` (`git show fad2a5d~1:src/socketHandlers.js`) into a current tree: **reproduces the reported crash byte-for-byte** (same line 4427, same TypeError).
- With the guard: same stale tree now prints the file name + fix instructions and exits 1.
- Clean tree: boots normally, `/api/health` OK. `node --check server.js` passes.

## For the reporter

Immediate unblock, no new release needed: `rm /home/raidenphantom/Haven/src/socketHandlers.js` (on both of his installs), then start the current server.js. Worth re-checking the embed-reaction behavior after that — his server will be running its first current socket layer since April.