### PR TITLE
[fix] Last.FM album art incorrect subdomain

### DIFF
--- a/src/activity.js
+++ b/src/activity.js
@@ -114,6 +114,7 @@ const ALLOWED_IMAGE_HOSTS = new Set([
   'i.ytimg.com',
   'img.youtube.com',
   'lastfm.freetls.fastly.net',
+  'lastfm-img.freetls.fastly.net',
 ]);
 
 function safeImage(url) {


### PR DESCRIPTION
Last.fm serves album art from the lastfm-img subdomain, but the image host allowlist only had lastfm.freetls.fastly.net, so safeImage rejected every current artwork URL and the listening card showed no image.