### PR TITLE
Fix: refresh channel lists after deleting a main channel

### DIFF
--- a/src/socketHandlers/channels.js
+++ b/src/socketHandlers/channels.js
@@ -714,6 +714,7 @@ module.exports = function register(socket, ctx) {
       db.prepare('DELETE FROM channels WHERE id = ?').run(chId);
     });
     deleteAll(channel.id);
+    broadcastChannelLists();
 
     // The same file can be linked from more than one message (a copy-pasted
     // image URL), so only relocate the ones nothing else points at anymore.


### PR DESCRIPTION
## The Problem:
When a main channel that contained subchannels was deleted; The subchannels of the parent disappeared for all current client sessions until the client was refreshed, or another channel action such as (create, join, delete) was performed that pushed a channel list refresh. 

## The Cause
`socket.on('delete-channel'` did not perform a `broadcastChannelLists();` when the channel was deleted, so the clients did not receive the updated channel list.

## The Fix
Added  `broadcastChannelLists();` after channel deletion. 
Clients will now receive the updated channel list immediately when a channel is deleted, and the child subchannels show up as main channels for all clients.