### PR TITLE
Harden webhook callback delivery against SSRF

### DIFF
--- a/src/socketHandlers/index.js
+++ b/src/socketHandlers/index.js
@@ -15,6 +15,11 @@ const { socketClientIp } = require('../clientIp');
 const automod = require('../automod');
 const { resolveSpotifyToYouTube, searchYouTube, fetchYouTubePlaylist, extractYouTubeVideoId, resolveMusicMetadata } = require('./musicResolver');
 const createPermissions = require('./permissions');
+const {
+  UnsafeCallbackError,
+  postWebhookCallback,
+  validateCallbackUrl
+} = require('../webhookCallback');
 
 const { createActivity } = require('../activity');
 
@@ -1056,21 +1061,7 @@ function setupSocketHandlers(io, db, opts = {}) {
   }
 
   function isSafeCallbackUrl(urlString) {
-    try {
-      const u = new URL(urlString);
-      const h = u.hostname.toLowerCase();
-      if (!/^https?:$/i.test(u.protocol)) return false;
-      // 169.254.0.0/16 stays blocked even when private callbacks are allowed.
-      // That is where cloud instance metadata (and its credentials) lives, and
-      // nothing anyone would actually run a bot on listens there.
-      if (/^169\.254\./.test(h)) return false;
-      if (ALLOW_PRIVATE_CALLBACKS) return true;
-      if (['localhost','127.0.0.1','[::1]','0.0.0.0','::'].includes(h)) return false;
-      if (h.startsWith('10.') || h.startsWith('192.168.')) return false;
-      if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return false;
-      if (h.endsWith('.local') || h.endsWith('.internal')) return false;
-      return true;
-    } catch { return false; }
+    return validateCallbackUrl(urlString, ALLOW_PRIVATE_CALLBACKS);
   }
 
   // ── Webhook event delivery (3.13.0 expansion) ───────────
@@ -1103,9 +1094,9 @@ function setupSocketHandlers(io, db, opts = {}) {
   // network error. 4xx responses are NOT retried (treated as bot rejection).
   async function _deliverWebhook(bot, payload, headers, attempt = 0) {
     try {
-      const resp = await fetch(bot.callback_url, {
-        method: 'POST', headers, body: payload,
-        signal: AbortSignal.timeout(10000)
+      const resp = await postWebhookCallback(bot.callback_url, payload, headers, {
+        allowPrivateCallbacks: ALLOW_PRIVATE_CALLBACKS,
+        timeoutMs: 10000
       });
       if (resp.ok) {
         _recordWebhookDelivery(bot.id, resp.status, null);
@@ -1118,6 +1109,11 @@ function setupSocketHandlers(io, db, opts = {}) {
       _recordWebhookDelivery(bot.id, resp.status, `HTTP ${resp.status}`);
     } catch (err) {
       const msg = (err && err.message) || String(err);
+      if (err instanceof UnsafeCallbackError || err?.code === 'ERR_UNSAFE_CALLBACK_URL') {
+        _recordWebhookDelivery(bot.id, 0, msg.slice(0, 200));
+        console.warn(`Webhook callback blocked for bot ${bot.id}: ${msg}`);
+        return;
+      }
       if (attempt < 1) {
         setTimeout(() => _deliverWebhook(bot, payload, headers, attempt + 1).catch(() => {}), 5000);
         return;
@@ -1867,9 +1863,9 @@ function setupSocketHandlers(io, db, opts = {}) {
           if (botCmd.callback_secret) {
             headers['X-Haven-Signature'] = require('crypto').createHmac('sha256', botCmd.callback_secret).update(payload).digest('hex');
           }
-          fetch(botCmd.callback_url, {
-            method: 'POST', headers, body: payload,
-            signal: AbortSignal.timeout(10000)
+          postWebhookCallback(botCmd.callback_url, payload, headers, {
+            allowPrivateCallbacks: ALLOW_PRIVATE_CALLBACKS,
+            timeoutMs: 10000
           }).catch(err => {
             console.error(`Bot command callback failed for /${cmd} → ${botCmd.callback_url}: ${err.message}`);
           });

--- a/src/webhookCallback.js
+++ b/src/webhookCallback.js
@@ -1,0 +1,229 @@
+'use strict';
+
+const dns = require('node:dns').promises;
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+
+const alwaysBlocked = new net.BlockList();
+const privateBlocked = new net.BlockList();
+const globalIpv6 = new net.BlockList();
+
+// Link-local, reserved, transition, and documentation ranges are never valid
+// callback destinations, even when private callbacks are explicitly enabled.
+for (const [address, prefix] of [
+  ['0.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['192.0.0.0', 24],
+  ['192.0.2.0', 24],
+  ['198.18.0.0', 15],
+  ['198.51.100.0', 24],
+  ['203.0.113.0', 24],
+  ['224.0.0.0', 4],
+  ['240.0.0.0', 4]
+]) alwaysBlocked.addSubnet(address, prefix, 'ipv4');
+
+// These ranges are available only to self-hosters who explicitly opt in.
+for (const [address, prefix] of [
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['172.16.0.0', 12],
+  ['192.168.0.0', 16]
+]) privateBlocked.addSubnet(address, prefix, 'ipv4');
+
+for (const [address, prefix] of [
+  ['::', 128],
+  ['64:ff9b::', 96],
+  ['64:ff9b:1::', 48],
+  ['100::', 64],
+  ['2001::', 32],
+  ['2001:2::', 48],
+  ['2001:10::', 28],
+  ['2001:20::', 28],
+  ['2001:db8::', 32],
+  ['2002::', 16],
+  ['3fff::', 20],
+  ['fe80::', 10],
+  ['fec0::', 10],
+  ['ff00::', 8]
+]) alwaysBlocked.addSubnet(address, prefix, 'ipv6');
+
+privateBlocked.addSubnet('::1', 128, 'ipv6');
+privateBlocked.addSubnet('fc00::', 7, 'ipv6');
+globalIpv6.addSubnet('2000::', 3, 'ipv6');
+
+class UnsafeCallbackError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'UnsafeCallbackError';
+    this.code = 'ERR_UNSAFE_CALLBACK_URL';
+  }
+}
+
+function parseCallbackUrl(urlString) {
+  let url;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new UnsafeCallbackError('Callback URL is invalid');
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new UnsafeCallbackError('Callback URL must use HTTP or HTTPS');
+  }
+  if (url.username || url.password) {
+    throw new UnsafeCallbackError('Callback URL must not contain credentials');
+  }
+  return url;
+}
+
+function normalizedHostname(url) {
+  return url.hostname.replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase();
+}
+
+function mappedIpv4(address) {
+  const lower = address.toLowerCase();
+  if (!lower.startsWith('::ffff:')) return null;
+  const tail = lower.slice(7);
+  if (net.isIP(tail) === 4) return tail;
+  const groups = tail.split(':');
+  if (groups.length !== 2 || groups.some(group => !/^[a-f0-9]{1,4}$/.test(group))) return null;
+  const high = parseInt(groups[0], 16);
+  const low = parseInt(groups[1], 16);
+  return `${high >> 8}.${high & 255}.${low >> 8}.${low & 255}`;
+}
+
+function isBlockedAddress(address, family, allowPrivateCallbacks = false) {
+  const numericFamily = family === 6 || family === 'IPv6' ? 6 : 4;
+  if (numericFamily === 6) {
+    const embedded = mappedIpv4(address);
+    if (embedded) return isBlockedAddress(embedded, 4, allowPrivateCallbacks);
+  }
+  const type = numericFamily === 6 ? 'ipv6' : 'ipv4';
+  if (alwaysBlocked.check(address, type)) return true;
+  if (numericFamily === 6) {
+    if (globalIpv6.check(address, 'ipv6')) return false;
+    return !(allowPrivateCallbacks && privateBlocked.check(address, 'ipv6'));
+  }
+  return !allowPrivateCallbacks && privateBlocked.check(address, type);
+}
+
+function validateCallbackUrl(urlString, allowPrivateCallbacks = false) {
+  try {
+    const url = parseCallbackUrl(urlString);
+    const hostname = normalizedHostname(url);
+    if (!allowPrivateCallbacks && (hostname === 'localhost' || hostname.endsWith('.localhost') || hostname.endsWith('.local') || hostname.endsWith('.internal'))) {
+      return false;
+    }
+    const family = net.isIP(hostname);
+    return !family || !isBlockedAddress(hostname, family, allowPrivateCallbacks);
+  } catch {
+    return false;
+  }
+}
+
+async function resolveCallbackDestination(urlString, options = {}) {
+  const allowPrivateCallbacks = options.allowPrivateCallbacks === true;
+  const lookup = options.lookup || dns.lookup;
+  const url = parseCallbackUrl(urlString);
+  const hostname = normalizedHostname(url);
+  if (!allowPrivateCallbacks && (hostname === 'localhost' || hostname.endsWith('.localhost') || hostname.endsWith('.local') || hostname.endsWith('.internal'))) {
+    throw new UnsafeCallbackError('Callback URL points to a local hostname');
+  }
+
+  const literalFamily = net.isIP(hostname);
+  const addresses = literalFamily
+    ? [{ address: hostname, family: literalFamily }]
+    : await lookup(hostname, { all: true, verbatim: true });
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    throw new UnsafeCallbackError('Callback hostname did not resolve');
+  }
+  for (const entry of addresses) {
+    const family = entry.address ? net.isIP(entry.address) : 0;
+    if (!family || isBlockedAddress(entry.address, family, allowPrivateCallbacks)) {
+      throw new UnsafeCallbackError('Callback URL resolves to a blocked network');
+    }
+  }
+  const selected = addresses[0];
+  return {
+    url,
+    address: selected.address,
+    family: net.isIP(selected.address)
+  };
+}
+
+function createPinnedLookup(address, family) {
+  return (_hostname, options, callback) => {
+    if (options?.all) callback(null, [{ address, family }]);
+    else callback(null, address, family);
+  };
+}
+
+function withDeadline(promise, deadlineAt, message) {
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) return Promise.reject(new Error(message));
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => { timer = setTimeout(() => reject(new Error(message)), remaining); })
+  ]).finally(() => clearTimeout(timer));
+}
+
+function postResolvedCallback(destination, payload, headers, deadlineAt) {
+  return new Promise((resolve, reject) => {
+    const remaining = deadlineAt - Date.now();
+    if (remaining <= 0) return reject(new Error('Webhook callback exceeded its deadline'));
+    const transport = destination.url.protocol === 'https:' ? https : http;
+    let response;
+    let settled = false;
+    let timer;
+    const finish = (error, result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(result);
+    };
+    const request = transport.request(destination.url, {
+      method: 'POST',
+      agent: false,
+      headers: { ...headers, 'Content-Length': Buffer.byteLength(payload) },
+      lookup: createPinnedLookup(destination.address, destination.family)
+    }, incoming => {
+      response = incoming;
+      incoming.on('error', finish);
+      incoming.on('end', () => finish(null, {
+        ok: incoming.statusCode >= 200 && incoming.statusCode < 300,
+        status: incoming.statusCode
+      }));
+      incoming.resume();
+    });
+    timer = setTimeout(() => {
+      const error = new Error('Webhook callback exceeded its deadline');
+      response?.destroy(error);
+      request.destroy(error);
+    }, remaining);
+    request.on('error', finish);
+    request.end(payload);
+  });
+}
+
+async function postWebhookCallback(urlString, payload, headers, options = {}) {
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : 10000;
+  const deadlineAt = Date.now() + timeoutMs;
+  const destination = await withDeadline(
+    resolveCallbackDestination(urlString, options),
+    deadlineAt,
+    'Webhook callback DNS resolution timed out'
+  );
+  return postResolvedCallback(destination, payload, headers, deadlineAt);
+}
+
+module.exports = {
+  UnsafeCallbackError,
+  createPinnedLookup,
+  isBlockedAddress,
+  postWebhookCallback,
+  resolveCallbackDestination,
+  validateCallbackUrl
+};

--- a/test/webhookCallback.test.js
+++ b/test/webhookCallback.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const http = require('node:http');
+const { PassThrough } = require('node:stream');
+const test = require('node:test');
+
+const {
+  UnsafeCallbackError,
+  createPinnedLookup,
+  postWebhookCallback,
+  resolveCallbackDestination,
+  validateCallbackUrl
+} = require('../src/webhookCallback');
+
+test('callback URL validation rejects credentials and local address forms', () => {
+  assert.equal(validateCallbackUrl('ftp://example.com/hook'), false);
+  assert.equal(validateCallbackUrl('https://user:secret@example.com/hook'), false);
+  assert.equal(validateCallbackUrl('http://127.0.0.2/hook'), false);
+  assert.equal(validateCallbackUrl('http://2130706433/hook'), false);
+  assert.equal(validateCallbackUrl('http://0x7f000001/hook'), false);
+  assert.equal(validateCallbackUrl('http://[::1]/hook'), false);
+  assert.equal(validateCallbackUrl('http://[::ffff:7f00:1]/hook'), false);
+  assert.equal(validateCallbackUrl('http://[::7f00:1]/hook'), false);
+  assert.equal(validateCallbackUrl('http://[::ffff:0:7f00:1]/hook'), false);
+  assert.equal(validateCallbackUrl('http://[2001:2::1]/hook'), false);
+  assert.equal(validateCallbackUrl('http://[2001:20::1]/hook'), false);
+  assert.equal(validateCallbackUrl('http://[4000::1]/hook'), false);
+  assert.equal(validateCallbackUrl('http://service.local/hook'), false);
+  assert.equal(validateCallbackUrl('https://example.com/hook'), true);
+  assert.equal(validateCallbackUrl('https://[2606:4700:4700::1111]/hook'), true);
+});
+
+test('private callback opt-in permits local bots but never link-local metadata', async () => {
+  assert.equal(validateCallbackUrl('http://127.0.0.2/hook', true), true);
+  assert.equal(validateCallbackUrl('http://[::1]/hook', true), true);
+  assert.equal(validateCallbackUrl('http://[fd00::7]/hook', true), true);
+  assert.equal(validateCallbackUrl('http://[fe80::1]/hook', true), false);
+  assert.equal(validateCallbackUrl('http://169.254.169.254/latest/meta-data', true), false);
+
+  const local = await resolveCallbackDestination('http://bot.internal/hook', {
+    allowPrivateCallbacks: true,
+    lookup: async () => [{ address: '10.0.0.7', family: 4 }]
+  });
+  assert.equal(local.address, '10.0.0.7');
+
+  await assert.rejects(
+    resolveCallbackDestination('http://metadata.example/hook', {
+      allowPrivateCallbacks: true,
+      lookup: async () => [{ address: '169.254.169.254', family: 4 }]
+    }),
+    error => error instanceof UnsafeCallbackError && /blocked network/.test(error.message)
+  );
+});
+
+test('DNS resolution is rejected when any answer points to a blocked network', async () => {
+  await assert.rejects(
+    resolveCallbackDestination('https://mixed.example/hook', {
+      lookup: async () => [
+        { address: '93.184.216.34', family: 4 },
+        { address: '127.0.0.9', family: 4 }
+      ]
+    }),
+    error => error instanceof UnsafeCallbackError && /blocked network/.test(error.message)
+  );
+});
+
+test('pinned lookup always returns the address that passed validation', () => {
+  const lookup = createPinnedLookup('93.184.216.34', 4);
+  lookup('changed.example', {}, (error, address, family) => {
+    assert.ifError(error);
+    assert.equal(address, '93.184.216.34');
+    assert.equal(family, 4);
+  });
+  lookup('changed.example', { all: true }, (error, addresses) => {
+    assert.ifError(error);
+    assert.deepEqual(addresses, [{ address: '93.184.216.34', family: 4 }]);
+  });
+});
+
+test('HTTP delivery uses the validated address without a second DNS lookup', async () => {
+  const originalRequest = http.request;
+  let dnsLookups = 0;
+
+  try {
+    http.request = (url, options, onResponse) => {
+      assert.equal(url.hostname, 'callback.example');
+      assert.equal(options.agent, false);
+      assert.equal(options.headers['Content-Length'], Buffer.byteLength('{"event":"olá"}'));
+      options.lookup(url.hostname, {}, (error, address, family) => {
+        assert.ifError(error);
+        assert.equal(address, '93.184.216.34');
+        assert.equal(family, 4);
+      });
+
+      const request = new EventEmitter();
+      request.end = payload => {
+        assert.equal(payload, '{"event":"olá"}');
+        process.nextTick(() => {
+          const response = new PassThrough();
+          response.statusCode = 204;
+          onResponse(response);
+          response.end();
+        });
+      };
+      request.destroy = error => request.emit('error', error);
+      return request;
+    };
+
+    const response = await postWebhookCallback(
+      'http://callback.example/hook',
+      '{"event":"olá"}',
+      { 'Content-Type': 'application/json' },
+      {
+        timeoutMs: 1000,
+        lookup: async () => {
+          dnsLookups++;
+          return [{ address: '93.184.216.34', family: 4 }];
+        }
+      }
+    );
+
+    assert.equal(dnsLookups, 1);
+    assert.deepEqual(response, { ok: true, status: 204 });
+  } finally {
+    http.request = originalRequest;
+  }
+});
+
+test('callback deadline includes DNS resolution', async () => {
+  await assert.rejects(
+    postWebhookCallback('https://slow-dns.example/hook', '{}', {}, {
+      timeoutMs: 20,
+      lookup: () => new Promise(() => {})
+    }),
+    /DNS resolution timed out/
+  );
+});


### PR DESCRIPTION
## Summary

Hardens webhook callback delivery against SSRF and DNS rebinding while preserving the existing callback API and `HAVEN_ALLOW_PRIVATE_CALLBACKS` behavior.

## Changes

- reject callback URLs with embedded credentials or unsupported protocols
- validate IPv4, IPv6, IPv4-mapped, transition, reserved, and non-global address ranges
- inspect every address returned by DNS and reject mixed public/private results
- pin the HTTP connection to the exact address that passed validation
- preserve the original hostname for the Host header and TLS SNI
- apply one deadline across DNS resolution and HTTP delivery
- avoid following redirects by using the Node HTTP/HTTPS transports directly
- keep link-local and metadata destinations blocked when private callbacks are enabled
- avoid retrying destinations rejected by the SSRF guard

## Compatibility

- preserves callback payloads
- preserves existing HMAC signature headers
- preserves retry behavior for network errors and 5xx responses
- preserves `HAVEN_ALLOW_PRIVATE_CALLBACKS` for loopback, RFC1918, and ULA destinations
- does not change `package.json`, the Node.js engine range, or dependencies

## Testing

- URL credentials and unsupported protocols
- decimal and hexadecimal loopback representations
- IPv4 and IPv6 private, loopback, link-local, reserved, and transition ranges
- IPv4-mapped and IPv4-compatible IPv6 forms
- mixed public/private DNS responses
- private callback opt-in behavior
- DNS address pinning without a second resolution
- UTF-8 payload length and exact request body
- DNS resolution deadline

## Verification

- `node --test test/webhookCallback.test.js`: 6 passing
- tests pass on Node.js 18.0.0
- `node --check` passed
- `git diff --check` passed