### PR TITLE
Automatic language selection

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -1210,14 +1210,15 @@
         <label class="select-row">
           <span data-i18n="settings.language_section.label">Language</span>
           <select id="language-select" class="settings-select">
-            <option value="en">🇬🇧 English</option>
-            <option value="fr">🇫🇷 Français</option>
-            <option value="de">🇩🇪 Deutsch</option>
-            <option value="es">🇪🇸 Español</option>
-            <option value="pl">🇵🇱 Polski</option>
-            <option value="ru">🇷🇺 Русский</option>
-            <option value="zh">🇨🇳 中文</option>
-            <option value="pt">🇧🇷 Português (Brasil)</option>
+            <option value="auto" data-i18n="settings.language_section.auto">Automatic</option>
+            <option value="en">English</option>
+            <option value="fr">Français</option>
+            <option value="de">Deutsch</option>
+            <option value="es">Español</option>
+            <option value="pl">Polski</option>
+            <option value="ru">Русский</option>
+            <option value="zh">中文</option>
+            <option value="pt">Português (Brasil)</option>
           </select>
         </label>
         <small class="settings-hint" data-i18n="settings.language_section.hint">Changes apply immediately</small>
@@ -2044,14 +2045,14 @@
               <span data-i18n="settings.admin.default_locale">Default Language</span>
               <select id="default-locale-select" style="max-width:160px">
                 <option value="" data-i18n="settings.admin.no_locale">Auto-detect (browser)</option>
-                <option value="en">🇬🇧 English</option>
-                <option value="fr">🇫🇷 Français</option>
-                <option value="de">🇩🇪 Deutsch</option>
-                <option value="es">🇪🇸 Español</option>
-                <option value="pl">🇵🇱 Polski</option>
-                <option value="ru">🇷🇺 Русский</option>
-                <option value="zh">🇨🇳 中文</option>
-                <option value="pt">🇧🇷 Português (Brasil)</option>
+                <option value="en">English</option>
+                <option value="fr">Français</option>
+                <option value="de">Deutsch</option>
+                <option value="es">Español</option>
+                <option value="pl">Polski</option>
+                <option value="ru">Русский</option>
+                <option value="zh">中文</option>
+                <option value="pt">Português (Brasil)</option>
               </select>
             </label>
             <small class="settings-hint" data-i18n="settings.admin.default_locale_hint">New users see Haven in this language on first visit. They can still pick their own.</small>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -14372,6 +14372,11 @@ ul.chat-list { list-style-type: disc; }
   text-align: left;
 }
 .lang-picker-btn:hover { border-color: var(--accent); }
+.lang-picker-btn:focus-visible,
+.lang-picker-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .lang-caret { margin-left: auto; opacity: 0.6; font-size: 0.625rem; }
 
 .lang-picker-list {
@@ -14405,6 +14410,7 @@ ul.chat-list { list-style-type: disc; }
   text-align: left;
 }
 .lang-picker-item:hover { background: var(--bg-tertiary); }
+.lang-picker-item.active { background: color-mix(in srgb, var(--accent) 14%, transparent); }
 
 .lang-flag {
   width: 1.25rem;
@@ -14423,6 +14429,13 @@ ul.chat-list { list-style-type: disc; }
   font-weight: 700;
   background: var(--bg-secondary);
   color: var(--text-muted);
+}
+.lang-flag-auto { border-radius: 50%; }
+
+/* The auth picker sits near the bottom edge, so open it upward. */
+.auth-lang-bar .lang-picker-list {
+  top: auto;
+  bottom: calc(100% + 4px);
 }
 
 .file-attachment {

--- a/public/index.html
+++ b/public/index.html
@@ -319,14 +319,15 @@
       </div>
       <div class="auth-lang-bar">
         <select id="auth-lang-select" class="settings-select">
-          <option value="en">🇬🇧 English</option>
-          <option value="fr">🇫🇷 Français</option>
-          <option value="de">🇩🇪 Deutsch</option>
-          <option value="es">🇪🇸 Español</option>
-          <option value="pl">🇵🇱 Polski</option>
-          <option value="ru">🇷🇺 Русский</option>
-          <option value="zh">🇨🇳 中文</option>
-          <option value="pt">🇧🇷 Português (Brasil)</option>
+          <option value="auto" data-i18n="settings.language_section.auto">Automatic</option>
+          <option value="en">English</option>
+          <option value="fr">Français</option>
+          <option value="de">Deutsch</option>
+          <option value="es">Español</option>
+          <option value="pl">Polski</option>
+          <option value="ru">Русский</option>
+          <option value="zh">中文</option>
+          <option value="pt">Português (Brasil)</option>
         </select>
       </div>
       <p class="auth-version" id="auth-version"></p>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -67,7 +67,8 @@
   // ── Language switcher ─────────────────────────────────
   const langSelect = document.getElementById('auth-lang-select');
   if (langSelect) {
-    langSelect.value = window.i18n.locale;
+    langSelect.value = window.i18n.preference;
+    window.i18n.buildLocalePicker(langSelect);
     langSelect.addEventListener('change', e => window.i18n.setLocale(e.target.value));
   }
 

--- a/public/js/i18n.js
+++ b/public/js/i18n.js
@@ -12,11 +12,26 @@ const I18n = (() => {
   let _translations = {};
   let _fallback = null;   // English base map for per-key fallback (#5451)
   let _locale = 'en';
+  let _preference = 'auto';
   let _ready = null;  // shared init promise — ensures init() is only run once
+  let _loadVersion = 0;
+  let _languageChangeBound = false;
 
   // Locales available — add entries here as you create new locale files
   const SUPPORTED = ['en', 'fr', 'de', 'es', 'pl', 'ru', 'zh', 'pt'];
   const DEFAULT   = 'en';
+  const FLAGS = { en: 'gb', fr: 'fr', de: 'de', es: 'es', pl: 'pl', ru: 'ru', zh: 'cn', pt: 'br' };
+
+  function _browserLocale() {
+    const languages = Array.isArray(navigator.languages) && navigator.languages.length
+      ? navigator.languages
+      : [navigator.language || DEFAULT];
+    for (const language of languages) {
+      const locale = String(language || '').split('-')[0].toLowerCase();
+      if (SUPPORTED.includes(locale)) return locale;
+    }
+    return DEFAULT;
+  }
 
   // ── Detect preferred locale ──────────────────────────────────────────
   // Precedence:
@@ -25,10 +40,16 @@ const I18n = (() => {
   //   3. browser language
   //   4. DEFAULT ('en')
   async function _detect() {
-    const stored = localStorage.getItem('haven_locale');
-    if (stored && SUPPORTED.includes(stored)) return stored;
+    let stored = null;
+    try { stored = localStorage.getItem('haven_locale'); } catch {}
+    if (stored && SUPPORTED.includes(stored)) {
+      _preference = stored;
+      return stored;
+    }
+    _preference = 'auto';
     // Try server default — only blocks for first-time visitors with no stored
-    // choice, and uses a short timeout so a slow/offline server can't hang init.
+    // choice (or an explicit Automatic choice), and uses a short timeout so a
+    // slow/offline server can't hang init.
     try {
       const ctrl = new AbortController();
       const timeout = setTimeout(() => ctrl.abort(), 1500);
@@ -41,35 +62,45 @@ const I18n = (() => {
         }
       }
     } catch { /* offline / not ready — fall through to browser detection */ }
-    const browser = (navigator.language || 'en').split('-')[0].toLowerCase();
-    return SUPPORTED.includes(browser) ? browser : DEFAULT;
+    return _browserLocale();
   }
 
   // ── Load a locale JSON file ──────────────────────────────────────────
   async function load(locale) {
+    if (!SUPPORTED.includes(locale)) locale = DEFAULT;
+    const version = ++_loadVersion;
     try {
       const res = await fetch(`/locales/${locale}.json`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      _translations = await res.json();
+      const translations = await res.json();
+      let fallback = _fallback;
+      if (locale !== DEFAULT && !fallback) {
+        try {
+          const fb = await fetch(`/locales/${DEFAULT}.json`);
+          if (fb.ok) fallback = await fb.json();
+        } catch { /* no fallback available — t() shows raw keys as before */ }
+      }
+      // A slower earlier request must never overwrite a newer language choice.
+      if (version !== _loadVersion) return false;
+      _translations = translations;
       _locale = locale;
       document.documentElement.lang = locale;
-      localStorage.setItem('haven_locale', locale);
       // Keep an English base so a key missing from a non-English locale falls
       // back to readable English instead of a raw dotted key (#5451).
       if (locale === DEFAULT) {
-        _fallback = _translations;
-      } else if (!_fallback) {
-        try {
-          const fb = await fetch(`/locales/${DEFAULT}.json`);
-          if (fb.ok) _fallback = await fb.json();
-        } catch { /* no fallback available — t() shows raw keys as before */ }
+        _fallback = translations;
+      } else if (fallback) {
+        _fallback = fallback;
       }
+      return true;
     } catch (err) {
+      if (version !== _loadVersion) return false;
       console.warn(`[i18n] Failed to load locale "${locale}":`, err.message);
       if (locale !== DEFAULT) {
         console.info(`[i18n] Falling back to "${DEFAULT}"`);
-        await load(DEFAULT);
+        return load(DEFAULT);
       }
+      return false;
     }
   }
 
@@ -145,35 +176,181 @@ const I18n = (() => {
         await new Promise(r => document.addEventListener('DOMContentLoaded', r, { once: true }));
       }
       applyDOM();
+      if (!_languageChangeBound && typeof window.addEventListener === 'function') {
+        _languageChangeBound = true;
+        window.addEventListener('languagechange', () => {
+          if (_preference === 'auto') {
+            try { window.location.reload(); } catch {}
+          }
+        });
+      }
     })();
     return _ready;
   }
 
   // ── Change locale at runtime (e.g. from a language picker) ───────────
-  // Reloads the page after persisting the choice. applyDOM() only refreshes
-  // elements with data-i18n* attributes, so anything rendered dynamically by
-  // JS (channel list, messages, settings sections built on the fly, etc.) would
-  // otherwise keep its old-language text and make it look like the switch
-  // didn't take effect (#5386).
+  // Persist first and reload immediately. Waiting for a locale fetch here lets
+  // rapid selections finish out of order, and dynamically rendered UI still
+  // needs a full render in the selected language.
   async function setLocale(locale) {
-    if (!SUPPORTED.includes(locale)) locale = DEFAULT;
-    // Persist immediately so the post-reload init picks up the new choice even
-    // if the locale JSON fetch is slow or fails.
-    try { localStorage.setItem('haven_locale', locale); } catch {}
-    await load(locale);
+    const preference = locale === 'auto' ? 'auto' : (SUPPORTED.includes(locale) ? locale : DEFAULT);
+    _preference = preference;
+    try { localStorage.setItem('haven_locale', preference); } catch {}
+    try {
+      window.location.reload();
+      return;
+    } catch { /* non-browser test harness or embedded view without reload */ }
+    const resolved = await _detect();
+    await load(resolved);
     applyDOM();
-    document.dispatchEvent(new CustomEvent('haven:localechange', { detail: { locale } }));
-    // Hard reload to re-render dynamic content in the new language.
-    try { window.location.reload(); } catch {}
+    document.dispatchEvent(new CustomEvent('haven:localechange', { detail: { locale: resolved, preference } }));
+  }
+
+  function _escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, char => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    })[char]);
+  }
+
+  // Native <option> elements cannot contain images and several Linux/Windows
+  // font stacks render regional-indicator emoji as letters. Keep the select as
+  // the source of truth while presenting bundled, OS-independent SVG flags.
+  function buildLocalePicker(target) {
+    const select = typeof target === 'string' ? document.querySelector(target) : target;
+    if (!select) return null;
+    if (select.dataset.havenPicker) {
+      select._havenPickerSync?.();
+      return select._havenPickerSync || null;
+    }
+    select.dataset.havenPicker = '1';
+
+    const options = Array.from(select.options).map(option => ({
+      value: option.value,
+      label: option.textContent.trim() || option.value,
+      flag: FLAGS[option.value] || null,
+      automatic: option.value === 'auto' || option.value === ''
+    }));
+    const wrap = document.createElement('div');
+    wrap.className = 'lang-picker';
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'lang-picker-btn';
+    button.setAttribute('aria-haspopup', 'listbox');
+    button.setAttribute('aria-expanded', 'false');
+    const list = document.createElement('div');
+    list.className = 'lang-picker-list';
+    list.setAttribute('role', 'listbox');
+    list.hidden = true;
+
+    const faceFor = option => {
+      const icon = option.flag
+        ? `<img class="lang-flag" src="/emoji/flags/${option.flag}.svg" alt="">`
+        : `<span class="lang-flag lang-flag-text${option.automatic ? ' lang-flag-auto' : ''}" aria-hidden="true">${option.automatic ? 'A' : _escapeHtml(option.value.toUpperCase())}</span>`;
+      return `${icon}<span class="lang-name">${_escapeHtml(option.label)}</span>`;
+    };
+    list.innerHTML = options.map(option =>
+      `<button type="button" class="lang-picker-item" role="option" data-value="${_escapeHtml(option.value)}">${faceFor(option)}</button>`
+    ).join('');
+
+    const items = Array.from(list.querySelectorAll('.lang-picker-item'));
+    const close = (restoreFocus = false) => {
+      list.hidden = true;
+      button.setAttribute('aria-expanded', 'false');
+      document.removeEventListener('click', onOutside, true);
+      if (restoreFocus) button.focus();
+    };
+    const focusSelected = () => {
+      const selected = items.find(item => item.getAttribute('aria-selected') === 'true') || items[0];
+      selected?.focus();
+    };
+    const open = (moveFocus = false) => {
+      list.hidden = false;
+      button.setAttribute('aria-expanded', 'true');
+      setTimeout(() => document.addEventListener('click', onOutside, true), 0);
+      if (moveFocus) focusSelected();
+    };
+    const onOutside = event => { if (!wrap.contains(event.target)) close(); };
+    const sync = () => {
+      const current = options.find(option => option.value === select.value) || options[0];
+      if (!current) return;
+      button.innerHTML = `${faceFor(current)}<span class="lang-caret">▾</span>`;
+      list.querySelectorAll('.lang-picker-item').forEach(item => {
+        const selected = item.dataset.value === current.value;
+        item.classList.toggle('active', selected);
+        item.setAttribute('aria-selected', String(selected));
+      });
+    };
+
+    button.addEventListener('click', event => {
+      event.stopPropagation();
+      if (list.hidden) open(event.detail === 0); else close();
+    });
+    button.addEventListener('keydown', event => {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        event.stopPropagation();
+        open(true);
+      } else if (event.key === 'Escape' && !list.hidden) {
+        event.preventDefault();
+        event.stopPropagation();
+        close(true);
+      }
+    });
+    list.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        close(true);
+        return;
+      }
+      const current = event.target.closest('.lang-picker-item');
+      if (!current) return;
+      const index = items.indexOf(current);
+      let nextIndex = null;
+      if (event.key === 'ArrowDown') nextIndex = (index + 1) % items.length;
+      else if (event.key === 'ArrowUp') nextIndex = (index - 1 + items.length) % items.length;
+      else if (event.key === 'Home') nextIndex = 0;
+      else if (event.key === 'End') nextIndex = items.length - 1;
+      if (nextIndex !== null) {
+        event.preventDefault();
+        event.stopPropagation();
+        items[nextIndex]?.focus();
+      }
+    });
+    items.forEach(item => {
+      item.addEventListener('click', event => {
+        event.stopPropagation();
+        select.value = item.dataset.value;
+        sync();
+        close();
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    });
+
+    select._havenPickerSync = sync;
+    sync();
+    wrap.appendChild(button);
+    wrap.appendChild(list);
+    select.parentElement.insertBefore(wrap, select);
+    select.classList.add('lang-select-hidden');
+    return sync;
+  }
+
+  function syncLocalePicker(target) {
+    const select = typeof target === 'string' ? document.querySelector(target) : target;
+    select?._havenPickerSync?.();
   }
 
   return {
     init,
     load,
     setLocale,
+    buildLocalePicker,
+    syncLocalePicker,
     t,
     applyDOM,
     get locale()    { return _locale; },
+    get preference(){ return _preference; },
     get supported() { return [...SUPPORTED]; },
   };
 })();

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -3113,7 +3113,10 @@ _setupUI() {
     this._switchSettingsTab('user');
     // Sync language select with current locale
     const langSelect = document.getElementById('language-select');
-    if (langSelect && window.i18n) langSelect.value = i18n.locale;
+    if (langSelect && window.i18n) {
+      langSelect.value = i18n.preference;
+      i18n.syncLocalePicker(langSelect);
+    }
     // Show desktop-only sections when running inside Haven Desktop
     if (window.havenDesktop?.isDesktopApp) {
       document.getElementById('desktop-shortcuts-nav')?.style.removeProperty('display');
@@ -4644,87 +4647,9 @@ _setupUI() {
  */
 _buildLanguagePicker() {
   const select = document.getElementById('language-select');
-  if (!select || select.dataset.havenPicker) return;
-  select.dataset.havenPicker = '1';
-
-  // Locale -> flag SVG. Only ISO country codes with artwork in
-  // public/emoji/flags/ can appear; anything unmapped falls back to a text
-  // badge rather than a broken image.
-  const FLAGS = { en: 'gb', fr: 'fr', de: 'de', es: 'es', pl: 'pl', ru: 'ru', zh: 'cn' };
-
-  const options = Array.from(select.options).map(o => ({
-    value: o.value,
-    // Strip the now-redundant emoji prefix from the label.
-    label: o.textContent.replace(/^[\p{Extended_Pictographic}\p{Regional_Indicator}️\s]+/u, '').trim() || o.value,
-    flag: FLAGS[o.value] || null,
-  }));
-
-  const wrap = document.createElement('div');
-  wrap.className = 'lang-picker';
-
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'lang-picker-btn';
-  button.setAttribute('aria-haspopup', 'listbox');
-  button.setAttribute('aria-expanded', 'false');
-
-  const list = document.createElement('div');
-  list.className = 'lang-picker-list';
-  list.setAttribute('role', 'listbox');
-  list.hidden = true;
-
-  const faceFor = (opt) => {
-    const flag = opt.flag
-      ? `<img class="lang-flag" src="/emoji/flags/${opt.flag}.svg" alt="">`
-      : `<span class="lang-flag lang-flag-text">${this._escapeHtml(opt.value.toUpperCase())}</span>`;
-    return `${flag}<span class="lang-name">${this._escapeHtml(opt.label)}</span>`;
-  };
-
-  const paintButton = () => {
-    const cur = options.find(o => o.value === select.value) || options[0];
-    if (cur) button.innerHTML = faceFor(cur) + '<span class="lang-caret">▾</span>';
-  };
-
-  list.innerHTML = options.map(o =>
-    `<button type="button" class="lang-picker-item" role="option" data-value="${this._escapeHtml(o.value)}">${faceFor(o)}</button>`
-  ).join('');
-
-  const close = () => {
-    list.hidden = true;
-    button.setAttribute('aria-expanded', 'false');
-    document.removeEventListener('click', onOutside, true);
-  };
-  const onOutside = (e) => { if (!wrap.contains(e.target)) close(); };
-
-  button.addEventListener('click', (e) => {
-    e.stopPropagation();
-    const opening = list.hidden;
-    list.hidden = !opening;
-    button.setAttribute('aria-expanded', String(opening));
-    if (opening) setTimeout(() => document.addEventListener('click', onOutside, true), 0);
-    else close();
-  });
-
-  list.querySelectorAll('.lang-picker-item').forEach(item => {
-    item.addEventListener('click', (e) => {
-      e.stopPropagation();
-      select.value = item.dataset.value;
-      // Drive the real control so the existing listener does the work.
-      select.dispatchEvent(new Event('change', { bubbles: true }));
-      paintButton();
-      close();
-    });
-  });
-
-  paintButton();
-  wrap.appendChild(button);
-  wrap.appendChild(list);
-  select.parentElement.insertBefore(wrap, select);
-  // Kept for state + the change event, but no longer the visible control.
-  select.classList.add('lang-select-hidden');
-
-  // Locale changes made elsewhere (or restored on load) must repaint the face.
-  select.addEventListener('change', paintButton);
+  if (!select || !window.i18n) return;
+  select.value = i18n.preference;
+  i18n.buildLocalePicker(select);
 },
 
 _canShareChannelLink(code) {

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -657,6 +657,7 @@
     "language_section": {
       "title": "Sprache",
       "label": "Sprache",
+      "auto": "Automatisch",
       "hint": "Änderungen werden sofort übernommen"
     },
     "layout_density": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -728,6 +728,7 @@
     "language_section": {
       "title": "Language",
       "label": "Language",
+      "auto": "Automatic",
       "hint": "Changes apply immediately"
     },
     "layout_density": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -657,6 +657,7 @@
     "language_section": {
       "title": "Idioma",
       "label": "Idioma",
+      "auto": "Automático",
       "hint": "Los cambios se aplican inmediatamente"
     },
     "layout_density": {

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -657,6 +657,7 @@
     "language_section": {
       "title": "Langue",
       "label": "Langue",
+      "auto": "Automatique",
       "hint": "Les changements s'appliquent immédiatement"
     },
     "layout_density": {

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -682,6 +682,7 @@
     "language_section": {
       "title": "Język",
       "label": "Język",
+      "auto": "Automatycznie",
       "hint": "Zmiany są stosowane natychmiast"
     },
     "layout_density": {

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -728,6 +728,7 @@
     "language_section": {
       "title": "Idioma",
       "label": "Idioma",
+      "auto": "Automático",
       "hint": "As alterações são aplicadas imediatamente"
     },
     "layout_density": {

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -687,6 +687,7 @@
     "language_section": {
       "title": "Язык",
       "label": "Язык",
+      "auto": "Автоматически",
       "hint": "Изменения применяются немедленно"
     },
     "layout_density": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -657,6 +657,7 @@
     "language_section": {
       "title": "语言",
       "label": "语言",
+      "auto": "自动",
       "hint": "更改立即生效"
     },
     "layout_density": {

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const I18N_SOURCE = fs.readFileSync(path.join(ROOT, 'public/js/i18n.js'), 'utf8');
+
+function jsonResponse(value) {
+  return { ok: true, status: 200, json: async () => value };
+}
+
+async function createI18n({ storedLocale, languages = ['en-US'], defaultLocale = '', fetchOverride } = {}) {
+  const storage = new Map();
+  if (storedLocale !== undefined) storage.set('haven_locale', storedLocale);
+  const requests = [];
+  const listeners = new Map();
+  let reloads = 0;
+  const localStorage = {
+    getItem: key => storage.has(key) ? storage.get(key) : null,
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: key => storage.delete(key)
+  };
+  const document = {
+    readyState: 'complete',
+    documentElement: { lang: '' },
+    querySelectorAll: () => [],
+    querySelector: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true
+  };
+  const fetch = async (url, options) => {
+    requests.push(url);
+    if (fetchOverride) {
+      const response = fetchOverride(url, options);
+      if (response !== undefined) return response;
+    }
+    if (url === '/api/public-config') return jsonResponse({ default_locale: defaultLocale });
+    const locale = String(url).match(/\/locales\/([a-z]+)\.json$/)?.[1] || 'en';
+    return jsonResponse({ marker: locale });
+  };
+  const window = {
+    document,
+    location: { reload: () => { reloads++; } },
+    addEventListener: (type, listener) => listeners.set(type, listener)
+  };
+  const context = vm.createContext({
+    window,
+    document,
+    navigator: { language: languages[0], languages },
+    localStorage,
+    fetch,
+    AbortController,
+    CustomEvent: class CustomEvent {
+      constructor(type, init) { this.type = type; this.detail = init?.detail; }
+    },
+    Event: class Event {},
+    console,
+    setTimeout,
+    clearTimeout
+  });
+  vm.runInContext(I18N_SOURCE, context, { filename: 'i18n.js' });
+  await window.i18n.init();
+  return {
+    i18n: window.i18n,
+    storage,
+    requests,
+    listeners,
+    document,
+    get reloads() { return reloads; }
+  };
+}
+
+test('automatic language follows the first supported browser language without freezing it', async () => {
+  const env = await createI18n({ languages: ['xx-ZZ', 'pt-BR'] });
+  assert.equal(env.i18n.locale, 'pt');
+  assert.equal(env.i18n.preference, 'auto');
+  assert.equal(env.document.documentElement.lang, 'pt');
+  assert.equal(env.storage.has('haven_locale'), false);
+  assert.ok(env.listeners.has('languagechange'));
+  env.listeners.get('languagechange')();
+  assert.equal(env.reloads, 1);
+});
+
+test('automatic language honors the server default before browser languages', async () => {
+  const env = await createI18n({ storedLocale: 'auto', languages: ['pt-BR'], defaultLocale: 'fr' });
+  assert.equal(env.i18n.locale, 'fr');
+  assert.equal(env.i18n.preference, 'auto');
+  assert.equal(env.storage.get('haven_locale'), 'auto');
+});
+
+test('an explicit language remains authoritative over server and browser defaults', async () => {
+  const env = await createI18n({ storedLocale: 'de', languages: ['pt-BR'], defaultLocale: 'fr' });
+  assert.equal(env.i18n.locale, 'de');
+  assert.equal(env.i18n.preference, 'de');
+  assert.equal(env.requests.includes('/api/public-config'), false);
+  env.listeners.get('languagechange')();
+  assert.equal(env.reloads, 0);
+});
+
+test('changing language persists once and reloads without waiting for another fetch', async () => {
+  const env = await createI18n({ storedLocale: 'en' });
+  const requestCount = env.requests.length;
+  await env.i18n.setLocale('pt');
+  assert.equal(env.storage.get('haven_locale'), 'pt');
+  assert.equal(env.i18n.preference, 'pt');
+  assert.equal(env.reloads, 1);
+  assert.equal(env.requests.length, requestCount);
+
+  await env.i18n.setLocale('auto');
+  assert.equal(env.storage.get('haven_locale'), 'auto');
+  assert.equal(env.reloads, 2);
+});
+
+test('a slower stale locale response cannot overwrite the latest load', async () => {
+  let resolveFrench;
+  const frenchResponse = new Promise(resolve => { resolveFrench = resolve; });
+  const env = await createI18n({
+    storedLocale: 'en',
+    fetchOverride: url => url === '/locales/fr.json' ? frenchResponse : undefined
+  });
+
+  const staleLoad = env.i18n.load('fr');
+  const latestLoad = env.i18n.load('pt');
+  await latestLoad;
+  resolveFrench(jsonResponse({ marker: 'fr' }));
+  await staleLoad;
+  assert.equal(env.i18n.locale, 'pt');
+  assert.equal(env.i18n.t('marker'), 'pt');
+});
+
+test('language controls use bundled Brazilian artwork instead of OS flag emoji', () => {
+  const indexHtml = fs.readFileSync(path.join(ROOT, 'public/index.html'), 'utf8');
+  const appHtml = fs.readFileSync(path.join(ROOT, 'public/app.html'), 'utf8');
+  const authSelect = indexHtml.match(/<select id="auth-lang-select"[\s\S]*?<\/select>/)?.[0] || '';
+  const appSelect = appHtml.match(/<select id="language-select"[\s\S]*?<\/select>/)?.[0] || '';
+
+  assert.match(I18N_SOURCE, /pt:\s*'br'/);
+  assert.equal(fs.existsSync(path.join(ROOT, 'public/emoji/flags/br.svg')), true);
+  assert.match(authSelect, /value="auto"/);
+  assert.match(appSelect, /value="auto"/);
+  assert.doesNotMatch(authSelect + appSelect, /[\u{1F1E6}-\u{1F1FF}]/u);
+  assert.match(fs.readFileSync(path.join(ROOT, 'public/js/auth.js'), 'utf8'), /buildLocalePicker\(langSelect\)/);
+});
+
+test('the custom language picker preserves visible focus and listbox keyboard navigation', () => {
+  const css = fs.readFileSync(path.join(ROOT, 'public/css/style.css'), 'utf8');
+  assert.match(css, /\.lang-picker-btn:focus-visible,[\s\S]*\.lang-picker-item:focus-visible/);
+  for (const key of ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Escape']) {
+    assert.match(I18N_SOURCE, new RegExp(`event\\.key === '${key}'`));
+  }
+  assert.match(I18N_SOURCE, /close\(true\)/);
+  assert.ok((I18N_SOURCE.match(/event\.stopPropagation\(\)/g) || []).length >= 4);
+});


### PR DESCRIPTION
## Summary

This PR improves Haven's language selection and fixes inconsistent locale switching across the login page and the main app.

It also replaces OS-dependent flag emoji with bundled SVG artwork, ensuring the Brazilian flag and other language flags render correctly on Linux, Windows, and systems without color emoji fonts.

## Changes

- Adds an **Automatic** language option to the login page and user settings.
- Automatic mode uses:
  1. The server-configured default language.
  2. The first supported browser/system language.
  3. English as the final fallback.
- Reacts to browser language changes while Automatic mode is enabled.
- Preserves explicit user language preferences.
- Prevents slower locale requests from overwriting newer selections.
- Persists the selected preference before reloading the interface.
- Uses a shared language picker across the login page and main app.
- Replaces native flag emoji with bundled SVG flags.
- Adds the Automatic label to all supported locale files.
- Adds accessible keyboard navigation with visible focus, arrow keys, Home, End, and Escape.
- Prevents picker keyboard events from triggering global app shortcuts or closing the settings modal.

## Compatibility

Existing explicit language preferences remain unchanged. Users who want language detection based on server/browser settings can select **Automatic**.

## Testing

```text
node --test test/*.test.js
13 tests passed
```

Additional validation:

- All locale JSON files passed `scripts/validate-locales.js`.
- Tested language switching between Automatic, English, and Portuguese.
- Tested persistence and page reload behavior.
- Tested the login page and main app on desktop and a `390×844` mobile viewport.