### PR TITLE
Repair client state after channel code rotation

### DIFF
--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -837,6 +837,7 @@ _setupSocketListeners() {
       this.socket.emit('voice-rejoin', { code: voiceRotation.newCode });
       if (this.voice.isMuted) this.socket.emit('voice-mute-state', { code: voiceRotation.newCode, muted: true });
       if (this.voice.isDeafened) this.socket.emit('voice-deafen-state', { code: voiceRotation.newCode, deafened: true });
+      this.voice._healPeerConnectionsAfterChannelRotation?.(voiceRotation.oldCode);
     }
     // Seed client-side unreadCounts from server-reported values so the
     // desktop badge, tab title, and DM section badge stay in sync.

--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -1,5 +1,145 @@
 export default {
 
+_migrateChannelCodeState(oldCode, newCode) {
+  if (!oldCode || !newCode || oldCode === newCode) return;
+  const migrateObjectKey = store => {
+    if (!store || !Object.prototype.hasOwnProperty.call(store, oldCode)) return false;
+    store[newCode] = store[oldCode];
+    delete store[oldCode];
+    return true;
+  };
+  migrateObjectKey(this.unreadCounts);
+  migrateObjectKey(this.voiceCounts);
+  migrateObjectKey(this.voiceChannelUsers);
+  migrateObjectKey(this._pinnedCountByChannel);
+  migrateObjectKey(this._unreadPinIdByChannel);
+  if (migrateObjectKey(this._threadMentions)) this._persistThreadMentions?.();
+
+  for (const property of [
+    'currentChannel',
+    '_lastVoiceUsersChannel',
+    '_pendingChannelHistoryCode',
+    '_pinsPipChannelCode',
+    '_organizeParentCode'
+  ]) {
+    if (this[property] === oldCode) this[property] = newCode;
+  }
+  if (this.voice?.currentChannel === oldCode) this.voice.currentChannel = newCode;
+  if (this.voice?._softLeftChannel === oldCode) this.voice._softLeftChannel = newCode;
+  if (this.voice?._joiningChannelCode === oldCode) this.voice._joiningChannelCode = newCode;
+  for (const channel of this.channels || []) {
+    if (channel.afk_sub_code === oldCode) channel.afk_sub_code = newCode;
+  }
+  const createSubModal = document.getElementById('create-sub-modal');
+  if (createSubModal?._parentCode === oldCode) createSubModal._parentCode = newCode;
+
+  try {
+    if (localStorage.getItem('haven_voice_channel') === oldCode) {
+      localStorage.setItem('haven_voice_channel', newCode);
+    }
+  } catch {}
+  for (const key of ['haven_muted_channels', 'haven_hidden_channels']) {
+    try {
+      const values = JSON.parse(localStorage.getItem(key) || '[]');
+      if (!Array.isArray(values) || !values.includes(oldCode)) continue;
+      const migrated = values.map(code => code === oldCode ? newCode : code);
+      localStorage.setItem(key, JSON.stringify([...new Set(migrated)]));
+    } catch {}
+  }
+  try {
+    const moveStorageKey = (oldKey, newKey) => {
+      const value = localStorage.getItem(oldKey);
+      if (value === null) return;
+      localStorage.setItem(newKey, value);
+      localStorage.removeItem(oldKey);
+    };
+    for (const prefix of [
+      'haven_seen_pin_max_',
+      'haven_tag_sorts_',
+      'haven_cat_order_',
+      'haven_cat_sort_',
+      'haven_subs_collapsed_'
+    ]) moveStorageKey(`${prefix}${oldCode}`, `${prefix}${newCode}`);
+
+    const subtagPrefix = `haven_subtag_collapsed_${oldCode}_`;
+    const subtagKeys = [];
+    for (let index = 0; index < localStorage.length; index++) {
+      const key = localStorage.key(index);
+      if (key?.startsWith(subtagPrefix)) subtagKeys.push(key);
+    }
+    for (const key of subtagKeys) {
+      moveStorageKey(key, `haven_subtag_collapsed_${newCode}_${key.slice(subtagPrefix.length)}`);
+    }
+  } catch { /* localStorage may be unavailable */ }
+},
+
+_collectChannelCodeRotations(channels) {
+  const rotations = new Map();
+  const persistedCodes = this._readChannelCodeMap();
+  for (const channel of channels) {
+    const oldCode = persistedCodes[channel.id];
+    if (typeof oldCode === 'string' && oldCode !== channel.code) {
+      rotations.set(oldCode, { channelId: channel.id, oldCode, newCode: channel.code });
+    }
+  }
+  for (const previous of this.channels || []) {
+    const updated = channels.find(channel => channel.id === previous.id);
+    if (updated && updated.code !== previous.code) {
+      rotations.set(previous.code, {
+        channelId: previous.id,
+        oldCode: previous.code,
+        newCode: updated.code
+      });
+    }
+  }
+  return [...rotations.values()];
+},
+
+_readChannelCodeMap() {
+  const ownerId = this.user?.id;
+  if (ownerId == null) return {};
+  try {
+    const persisted = JSON.parse(localStorage.getItem('haven_channel_codes_by_id') || 'null');
+    if (String(persisted?.ownerId) !== String(ownerId) || !persisted?.codes || typeof persisted.codes !== 'object' || Array.isArray(persisted.codes)) {
+      return {};
+    }
+    return persisted.codes;
+  } catch {
+    return {};
+  }
+},
+
+_persistChannelCodeMap(channels) {
+  const ownerId = this.user?.id;
+  if (ownerId == null) return;
+  const codes = {};
+  for (const channel of channels || []) {
+    if (channel?.id != null && channel.code) codes[channel.id] = channel.code;
+  }
+  try {
+    localStorage.setItem('haven_channel_codes_by_id', JSON.stringify({
+      ownerId: String(ownerId),
+      codes
+    }));
+  } catch { /* localStorage may be unavailable */ }
+},
+
+_updatePersistedChannelCode(channelId, code) {
+  if (channelId == null || !code) return;
+  const codes = this._readChannelCodeMap();
+  codes[channelId] = code;
+  this._persistChannelCodeMap(Object.entries(codes).map(([id, channelCode]) => ({
+    id,
+    code: channelCode
+  })));
+},
+
+_clearChannelCodeMap() {
+  try {
+    localStorage.removeItem('haven_channel_codes_by_id');
+  } catch { /* localStorage may be unavailable */ }
+},
+
 // ── Socket Event Listeners ────────────────────────────
 
 _setupSocketListeners() {
@@ -147,6 +287,10 @@ _setupSocketListeners() {
       clearTimeout(this._voiceDisconnectTimer);
       this._voiceDisconnectTimer = null;
     }
+    if (this._savedVoiceRejoinTimer) {
+      clearTimeout(this._savedVoiceRejoinTimer);
+      this._savedVoiceRejoinTimer = null;
+    }
     // A reconnect usually means the machine slept or the network dropped, which
     // is the most likely moment for the media token to have expired underneath
     // us. Cheap to redo and it keeps remote images from silently breaking.
@@ -154,6 +298,7 @@ _setupSocketListeners() {
 
     // Re-join channel after reconnect (server lost our room membership)
     this.socket.emit('visibility-change', { visible: !document.hidden });
+    this.voice?.deferChannelGone?.(6000);
     this.socket.emit('get-channels');
     this.socket.emit('get-server-settings');
 
@@ -181,6 +326,7 @@ _setupSocketListeners() {
         if (resp.status === 401 || resp.status === 404) {
           // Token is stale or user row gone — same outcome as a socket
           // 'Invalid token' / 'Session expired'. Kick to login.
+          this._clearChannelCodeMap();
           localStorage.removeItem('haven_token');
           localStorage.removeItem('haven_user');
           localStorage.removeItem('haven_sync_key');
@@ -269,10 +415,13 @@ _setupSocketListeners() {
         const savedVoiceChannel = localStorage.getItem('haven_voice_channel');
         if (savedVoiceChannel && /^[a-f0-9]{8}$/i.test(savedVoiceChannel)) {
           // Auto-rejoin saved voice channel after delay (wait for channels to load)
-          setTimeout(async () => {
+          this._savedVoiceRejoinTimer = setTimeout(async () => {
+            this._savedVoiceRejoinTimer = null;
             if (this.voice && !this.voice.inVoice) {
-              console.log('[Voice] Auto-rejoining saved voice channel:', savedVoiceChannel);
-              const ok = await this.voice.join(savedVoiceChannel);
+              let currentSavedChannel = savedVoiceChannel;
+              try { currentSavedChannel = localStorage.getItem('haven_voice_channel') || savedVoiceChannel; } catch {}
+              console.log('[Voice] Auto-rejoining saved voice channel:', currentSavedChannel);
+              const ok = await this.voice.join(currentSavedChannel);
               if (ok) {
                 this._updateVoiceButtons(true);
                 this._updateVoiceStatus(true);
@@ -591,6 +740,7 @@ _setupSocketListeners() {
     // They are NEVER transient, so we redirect to /login on the first one
     // instead of stranding the user on an empty channel list. (#5375)
     if (err.message === 'Invalid token' || err.message === 'Authentication required' || err.message === 'Session expired') {
+      this._clearChannelCodeMap();
       localStorage.removeItem('haven_token');
       localStorage.removeItem('haven_user');
       localStorage.removeItem('haven_sync_key');
@@ -610,6 +760,7 @@ _setupSocketListeners() {
         this._justChangedPassword = false;
         return;
       }
+      this._clearChannelCodeMap();
       localStorage.removeItem('haven_token');
       localStorage.removeItem('haven_user');
       window.location.href = '/';
@@ -620,6 +771,7 @@ _setupSocketListeners() {
         this._justRevokedSessions = false;
         return;
       }
+      this._clearChannelCodeMap();
       localStorage.removeItem('haven_token');
       localStorage.removeItem('haven_user');
       window.location.href = '/';
@@ -629,6 +781,7 @@ _setupSocketListeners() {
         this._justEnabledTotp = false;
         return;
       }
+      this._clearChannelCodeMap();
       localStorage.removeItem('haven_token');
       localStorage.removeItem('haven_user');
       window.location.href = '/';
@@ -649,12 +802,17 @@ _setupSocketListeners() {
       clearTimeout(this._channelsWatchdog);
       this._channelsWatchdog = null;
     }
-    // Detect if currentChannel's code was rotated while disconnected (stale code).
-    // Capture the channel's ID from the old list before overwriting it.
-    let rotatedChannelId = null;
-    if (this.currentChannel && !channels.find(c => c.code === this.currentChannel)) {
-      const oldEntry = this.channels.find(c => c.code === this.currentChannel);
-      if (oldEntry) rotatedChannelId = oldEntry.id;
+    const rotations = this._collectChannelCodeRotations(channels);
+    const activeRotation = rotations.find(rotation => rotation.oldCode === this.currentChannel) || null;
+    let savedVoiceCode = null;
+    try { savedVoiceCode = localStorage.getItem('haven_voice_channel'); } catch {}
+    const voiceRotation = rotations.find(rotation =>
+      rotation.oldCode === this.voice?.currentChannel ||
+      rotation.oldCode === this.voice?._softLeftChannel ||
+      rotation.oldCode === savedVoiceCode
+    ) || null;
+    for (const rotation of rotations) {
+      this._migrateChannelCodeState(rotation.oldCode, rotation.newCode);
     }
 
     // Preserve any DM channels that were added client-side (via dm-opened
@@ -662,11 +820,23 @@ _setupSocketListeners() {
     // overwriting would wipe DM entries and break E2E decryption until the
     // user reopens the DM.
     const existingDMs = (this.channels || []).filter(c => c.is_dm);
-    this.channels = channels;
+    this.channels = [...channels];
     for (const dm of existingDMs) {
       if (!this.channels.find(c => c.code === dm.code)) {
         this.channels.push(dm);
       }
+    }
+    this._persistChannelCodeMap(channels);
+    const deferredCode = this.voice?._deferredChannelGone?.code;
+    const deferredRotation = rotations.find(rotation => rotation.oldCode === deferredCode);
+    const deferredChannel = channels.find(channel =>
+      channel.code === deferredCode && channel.voice_enabled !== 0
+    );
+    this.voice?.resolveDeferredChannelGone?.(deferredRotation?.newCode || deferredChannel?.code || null);
+    if (voiceRotation && this.voice?.inVoice && this.voice.currentChannel === voiceRotation.newCode) {
+      this.socket.emit('voice-rejoin', { code: voiceRotation.newCode });
+      if (this.voice.isMuted) this.socket.emit('voice-mute-state', { code: voiceRotation.newCode, muted: true });
+      if (this.voice.isDeafened) this.socket.emit('voice-deafen-state', { code: voiceRotation.newCode, deafened: true });
     }
     // Seed client-side unreadCounts from server-reported values so the
     // desktop badge, tab title, and DM section badge stay in sync.
@@ -749,10 +919,9 @@ _setupSocketListeners() {
 
     // If the channel code rotated while we were disconnected, re-enter with the
     // new code so messages, reactions, and presence start working again.
-    if (rotatedChannelId !== null) {
-      const updated = channels.find(c => c.id === rotatedChannelId);
+    if (activeRotation) {
+      const updated = channels.find(c => c.id === activeRotation.channelId);
       if (updated) {
-        this.currentChannel = updated.code;
         const codeDisplay = document.getElementById('channel-code-display');
         if (codeDisplay) codeDisplay.textContent = updated.display_code || updated.code;
         this.socket.emit('enter-channel', { code: this.currentChannel });
@@ -1614,74 +1783,63 @@ _setupSocketListeners() {
   // ── Channel code rotated (dynamic codes) ────────
   this.socket.on('channel-code-rotated', (data) => {
     const ch = this.channels.find(c => c.id === data.channelId);
-    if (ch) {
-      const wasViewing = this.currentChannel === data.oldCode;
-      const wasInVoiceHere = !!(this.voice && this.voice.currentChannel === data.oldCode);
-      ch.code = data.newCode;
-      // Update display_code too (admins see real code, non-admins see masked)
-      if (ch.display_code && ch.display_code !== '••••••••') ch.display_code = data.newCode;
-      // Update currentChannel BEFORE re-rendering so the active highlight is correct
-      if (wasViewing) {
-        this.currentChannel = data.newCode;
-      }
-      // CRITICAL (#5347): if we're in voice on the rotated channel, the
-      // voice manager is still holding the OLD code as its currentChannel.
-      // Without updating it, every voice-rejoin / request-voice-users /
-      // voice-mute-state / etc. sent from this client uses the old code,
-      // the server can't find it (the DB row's code column was just
-      // updated), and we get the infinite "server says voice channel is
-      // gone" loop. Migrate every voice-side code reference too.
-      if (this.voice) {
-        if (wasInVoiceHere) {
-          this.voice.currentChannel = data.newCode;
-          console.log(`[Voice] channel code rotated mid-call: ${data.oldCode} -> ${data.newCode}`);
-        }
-        if (this.voice._softLeftChannel === data.oldCode) {
-          this.voice._softLeftChannel = data.newCode;
-        }
-      }
-      this._renderChannels();
-      // If currently viewing this channel, update the header code display
-      if (this.currentChannel === data.newCode) {
-        const codeDisplay = document.getElementById('channel-code-display');
-        if (codeDisplay) codeDisplay.textContent = ch.display_code || data.newCode;
-      }
-      // If the code changed while we were actively viewing this channel,
-      // any in-flight old-code history/presence replies are now ignored by
-      // the exact channelCode guards in the listeners below. Re-issue the
-      // active-channel fetches immediately under the new code so the chat
-      // pane and member sidebar don't sit blank until the user manually
-      // switches away and back.
-      if (wasViewing) {
-        this._oldestMsgId = null;
-        this._noMoreHistory = false;
-        this._loadingHistory = false;
-        this._historyBefore = null;
-        this._newestMsgId = null;
-        this._noMoreFuture = true;
-        this._loadingFuture = false;
-        this._historyAfter = null;
+    if (!ch) return;
+    const wasViewing = this.currentChannel === data.oldCode;
+    const wasInVoiceHere = !!(this.voice && this.voice.currentChannel === data.oldCode);
+    this._migrateChannelCodeState(data.oldCode, data.newCode);
+    this._updatePersistedChannelCode(data.channelId, data.newCode);
+    ch.code = data.newCode;
+    // Update display_code too (admins see real code, non-admins see masked)
+    if (ch.display_code && ch.display_code !== '••••••••') ch.display_code = data.newCode;
+    // CRITICAL (#5347): if we're in voice on the rotated channel, the
+    // voice manager is still holding the OLD code as its currentChannel.
+    // Without updating it, every voice-rejoin / request-voice-users /
+    // voice-mute-state / etc. sent from this client uses the old code,
+    // the server can't find it (the DB row's code column was just
+    // updated), and we get the infinite "server says voice channel is
+    // gone" loop. Migrate every voice-side code reference too.
+    if (wasInVoiceHere) console.log(`[Voice] channel code rotated mid-call: ${data.oldCode} -> ${data.newCode}`);
+    this._renderChannels();
+    // If currently viewing this channel, update the header code display
+    if (this.currentChannel === data.newCode) {
+      const codeDisplay = document.getElementById('channel-code-display');
+      if (codeDisplay) codeDisplay.textContent = ch.display_code || data.newCode;
+    }
+    // If the code changed while we were actively viewing this channel,
+    // any in-flight old-code history/presence replies are now ignored by
+    // the exact channelCode guards in the listeners below. Re-issue the
+    // active-channel fetches immediately under the new code so the chat
+    // pane and member sidebar don't sit blank until the user manually
+    // switches away and back.
+    if (wasViewing) {
+      this._oldestMsgId = null;
+      this._noMoreHistory = false;
+      this._loadingHistory = false;
+      this._historyBefore = null;
+      this._newestMsgId = null;
+      this._noMoreFuture = true;
+      this._loadingFuture = false;
+      this._historyAfter = null;
 
-        this.socket.emit('enter-channel', { code: data.newCode });
-        this.socket.emit('get-messages', { code: data.newCode });
-        this.socket.emit('get-channel-members', { code: data.newCode });
-        this.socket.emit('request-online-users', { code: data.newCode });
-        this.socket.emit('request-voice-users', { code: data.newCode });
+      this.socket.emit('enter-channel', { code: data.newCode });
+      this.socket.emit('get-messages', { code: data.newCode });
+      this.socket.emit('get-channel-members', { code: data.newCode });
+      this.socket.emit('request-online-users', { code: data.newCode });
+      this.socket.emit('request-voice-users', { code: data.newCode });
 
-        if (this._switchChannelSafetyTimer) clearTimeout(this._switchChannelSafetyTimer);
-        this._pendingChannelHistoryCode = data.newCode;
-        this._switchChannelSafetyTimer = setTimeout(() => {
-          if (this._pendingChannelHistoryCode === data.newCode && this.currentChannel === data.newCode) {
-            console.warn(`[channel-code-rotated] no message-history for ${data.newCode} within 5s - forcing resync`);
-            this._forceFullResync?.('channel-code-rotated-timeout');
-          }
-        }, 5000);
-      } else if (wasInVoiceHere) {
-        this.socket.emit('request-voice-users', { code: data.newCode });
-      }
-      if (this.user.isAdmin) {
-        this._showToast(t('toasts.channel_code_rotated', { name: ch.name }), 'info');
-      }
+      if (this._switchChannelSafetyTimer) clearTimeout(this._switchChannelSafetyTimer);
+      this._pendingChannelHistoryCode = data.newCode;
+      this._switchChannelSafetyTimer = setTimeout(() => {
+        if (this._pendingChannelHistoryCode === data.newCode && this.currentChannel === data.newCode) {
+          console.warn(`[channel-code-rotated] no message-history for ${data.newCode} within 5s - forcing resync`);
+          this._forceFullResync?.('channel-code-rotated-timeout');
+        }
+      }, 5000);
+    } else if (wasInVoiceHere) {
+      this.socket.emit('request-voice-users', { code: data.newCode });
+    }
+    if (this.user.isAdmin) {
+      this._showToast(t('toasts.channel_code_rotated', { name: ch.name }), 'info');
     }
   });
 
@@ -2072,6 +2230,7 @@ _setupSocketListeners() {
   this.socket.on('banned', (data) => {
     this._showToast(data.reason ? t('toasts.banned_from_server_reason', { reason: data.reason }) : t('toasts.banned_from_server'), 'error');
     setTimeout(() => {
+      this._clearChannelCodeMap();
       localStorage.removeItem('haven_token');
       localStorage.removeItem('haven_user');
       window.location.href = '/';

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -1914,6 +1914,7 @@ _setupUI() {
   // Logout
   document.getElementById('logout-btn').addEventListener('click', () => {
     if (this.voice && this.voice.inVoice) this.voice.leave();
+    this._clearChannelCodeMap?.();
     localStorage.removeItem('haven_token');
     localStorage.removeItem('haven_user');
     localStorage.removeItem('haven_sync_key');
@@ -3715,6 +3716,7 @@ _setupUI() {
           return;
         }
         // Account deleted — clear local storage and redirect to login
+        this._clearChannelCodeMap?.();
         localStorage.removeItem('haven_token');
         localStorage.removeItem('haven_e2e_privkey');
         localStorage.removeItem('haven_sync_key');

--- a/public/js/voice.js
+++ b/public/js/voice.js
@@ -304,6 +304,7 @@ class VoiceManager {
       `(peers=${live}, micLive=${micLive}) — restoring session state for`, code);
     this.currentChannel = code;
     this.inVoice = true;
+    this._voiceSessionGeneration = (this._voiceSessionGeneration || 0) + 1;
     this._softLeftChannel = null;
     try { localStorage.setItem('haven_voice_channel', code); } catch { /* ignore */ }
     // Our socket may have been rebound while we thought we were out; rejoin so
@@ -315,6 +316,32 @@ class VoiceManager {
       this.socket.emit('voice-rejoin', { code });
     }
     return true;
+  }
+
+  deferChannelGone(timeoutMs = 6000) {
+    if (this._deferredChannelGoneTimer) {
+      clearTimeout(this._deferredChannelGoneTimer);
+      this._deferredChannelGoneTimer = null;
+    }
+    this._deferredChannelGone = null;
+    this._deferChannelGoneUntil = Date.now() + timeoutMs;
+  }
+
+  resolveDeferredChannelGone(recoveredCode = null) {
+    this._deferChannelGoneUntil = 0;
+    if (this._deferredChannelGoneTimer) {
+      clearTimeout(this._deferredChannelGoneTimer);
+      this._deferredChannelGoneTimer = null;
+    }
+    const pending = this._deferredChannelGone;
+    this._deferredChannelGone = null;
+    const sameSession = pending &&
+      pending.generation === (this._voiceSessionGeneration || 0) &&
+      pending.code === this.currentChannel;
+    if (!recoveredCode && sameSession && this.inVoice) {
+      console.warn('[Voice] Server confirmed voice channel is gone — leaving locally:', pending.code);
+      try { this.leave(); } catch (e) { console.warn('[Voice] leave() during deferred voice-channel-gone failed:', e); }
+    }
   }
 
   /**
@@ -375,6 +402,19 @@ class VoiceManager {
     this.socket.on('voice-channel-gone', (data) => {
       if (!this.inVoice) return;
       if (this.currentChannel && data && data.code && data.code !== this.currentChannel) return;
+      const remaining = (this._deferChannelGoneUntil || 0) - Date.now();
+      if (remaining > 0) {
+        this._deferredChannelGone = {
+          code: data?.code || this.currentChannel,
+          generation: this._voiceSessionGeneration || 0
+        };
+        if (this._deferredChannelGoneTimer) clearTimeout(this._deferredChannelGoneTimer);
+        this._deferredChannelGoneTimer = setTimeout(() => {
+          this._deferredChannelGoneTimer = null;
+          this.resolveDeferredChannelGone(false);
+        }, remaining);
+        return;
+      }
       console.warn('[Voice] Server says voice channel is gone — leaving locally:', data && data.code);
       try { this.leave(); } catch (e) { console.warn('[Voice] leave() during voice-channel-gone failed:', e); }
     });
@@ -955,6 +995,9 @@ class VoiceManager {
   }
 
   async join(channelCode) {
+    if (this._joinInFlight) return false;
+    this._joinInFlight = true;
+    this._joiningChannelCode = channelCode;
     try {
       const preservedMuteState = this.isMuted;
       const preservedDeafenState = this.isDeafened;
@@ -1084,8 +1127,31 @@ class VoiceManager {
         }
       }
 
+      // Do not let Socket.IO buffer a stale voice-join if the connection
+      // dropped while microphone and noise processing were being prepared.
+      if (this.socket && this.socket.connected === false) {
+        this._disableRNNoise();
+        this._stopNoiseGate();
+        this._stopLocalTalkDetection();
+        if (this.rawStream) {
+          this.rawStream.getTracks().forEach(track => track.stop());
+          this.rawStream = null;
+        }
+        if (this.localStream) {
+          this.localStream.getTracks().forEach(track => track.stop());
+          this.localStream = null;
+        }
+        if (this.audioCtx) {
+          this.audioCtx.close().catch(() => {});
+          this.audioCtx = null;
+        }
+        return false;
+      }
+
+      channelCode = this._joiningChannelCode || channelCode;
       this.currentChannel = channelCode;
       this.inVoice = true;
+      this._voiceSessionGeneration = (this._voiceSessionGeneration || 0) + 1;
       // Listener-only is always muted (no audio to send). mute-on-join also forces mute.
       this.isMuted = this.isListenerOnly || muteOnJoin || preservedMuteState;
       this.isDeafened = preservedDeafenState;
@@ -1110,6 +1176,9 @@ class VoiceManager {
     } catch (err) {
       console.error('Voice join failed:', err);
       return false;
+    } finally {
+      this._joinInFlight = false;
+      this._joiningChannelCode = null;
     }
   }
 

--- a/public/js/voice.js
+++ b/public/js/voice.js
@@ -319,11 +319,9 @@ class VoiceManager {
   }
 
   deferChannelGone(timeoutMs = 6000) {
-    if (this._deferredChannelGoneTimer) {
-      clearTimeout(this._deferredChannelGoneTimer);
-      this._deferredChannelGoneTimer = null;
-    }
-    this._deferredChannelGone = null;
+    // Once the server has answered, reconnect flaps must not discard that
+    // answer or extend its absolute deadline beyond the original window.
+    if (this._deferredChannelGone) return;
     this._deferChannelGoneUntil = Date.now() + timeoutMs;
   }
 
@@ -539,6 +537,7 @@ class VoiceManager {
         peer._makingOffer = false;
         peer._awaitingAnswer = false;
         peer._offerIsIceRestart = false;
+        peer._offerChannelCode = null;
         if (conn.signalingState !== 'stable') {
           await conn.setLocalDescription({ type: 'rollback' });
         }
@@ -605,6 +604,7 @@ class VoiceManager {
             await peer.connection.setRemoteDescription(new RTCSessionDescription(data.answer));
             peer._awaitingAnswer = false;
             peer._offerIsIceRestart = false;
+            peer._offerChannelCode = null;
             // Flush buffered ICE candidates that arrived before the answer
             if (peer._pendingCandidates && peer._pendingCandidates.length) {
               for (const c of peer._pendingCandidates) {
@@ -1897,12 +1897,13 @@ class VoiceManager {
       }
       await connection.setLocalDescription(offer);
       peer._awaitingAnswer = true;
+      peer._offerChannelCode = this.currentChannel;
       // Remember whether the offer now in flight is an ICE restart, so that if
       // it later yields to glare the restart intent can be re-queued rather
       // than silently downgraded to a plain renegotiation (#5444).
       peer._offerIsIceRestart = iceRestart;
       this.socket.emit('voice-offer', {
-        code: this.currentChannel,
+        code: peer._offerChannelCode,
         targetUserId: userId,
         offer: offer
       });
@@ -2113,6 +2114,7 @@ class VoiceManager {
         if (latestPeer._awaitingAnswer) {
           latestPeer._awaitingAnswer = false;
         }
+        latestPeer._offerChannelCode = null;
         this._drainQueuedRenegotiation(userId);
       }
     });
@@ -2164,6 +2166,7 @@ class VoiceManager {
       _renegotiateQueued: false,
       _queuedIceRestart: false,
       _offerIsIceRestart: false,
+      _offerChannelCode: null,
     });
 
     // If we're the initiator, create and send an offer
@@ -2286,6 +2289,23 @@ class VoiceManager {
         this._restartIce(userId, conn);
       }, delay);
     }
+  }
+
+  async _healPeerConnectionsAfterChannelRotation(oldCode) {
+    const rollbacks = [];
+    for (const [, peer] of this.peers) {
+      const connection = peer?.connection;
+      if (!connection || peer._offerChannelCode !== oldCode) continue;
+      peer._makingOffer = false;
+      peer._awaitingAnswer = false;
+      peer._offerIsIceRestart = false;
+      peer._offerChannelCode = null;
+      if (connection.signalingState === 'have-local-offer') {
+        rollbacks.push(connection.setLocalDescription({ type: 'rollback' }).catch(() => {}));
+      }
+    }
+    if (rollbacks.length) await Promise.all(rollbacks);
+    this._healPeerConnections();
   }
 
   // ── Volume Control ──────────────────────────────────────

--- a/test/channelCodeClientState.test.js
+++ b/test/channelCodeClientState.test.js
@@ -1,0 +1,283 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const SOCKET_SOURCE = fs.readFileSync(path.join(ROOT, 'public/js/modules/app-socket.js'), 'utf8');
+const VOICE_SOURCE = fs.readFileSync(path.join(ROOT, 'public/js/voice.js'), 'utf8');
+
+function loadSocketMethods(globals = {}) {
+  const context = vm.createContext({ module: { exports: {} }, exports: {}, ...globals });
+  vm.runInContext(SOCKET_SOURCE.replace(/^export default/, 'module.exports ='), context, {
+    filename: 'app-socket.js'
+  });
+  return context.module.exports;
+}
+
+function createStorage(values = {}) {
+  const data = new Map(Object.entries(values));
+  return {
+    get length() { return data.size; },
+    getItem: key => data.has(key) ? data.get(key) : null,
+    setItem: (key, value) => data.set(key, String(value)),
+    removeItem: key => data.delete(key),
+    key: index => [...data.keys()][index] || null
+  };
+}
+
+test('channel code migration updates runtime caches and persisted state', () => {
+  const oldCode = '11111111';
+  const newCode = '22222222';
+  const storage = createStorage({
+    haven_voice_channel: oldCode,
+    haven_muted_channels: JSON.stringify([oldCode, 'aaaaaaaa']),
+    haven_hidden_channels: JSON.stringify([oldCode]),
+    [`haven_seen_pin_max_${oldCode}`]: '42',
+    [`haven_subtag_collapsed_${oldCode}_news`]: '1'
+  });
+  const methods = loadSocketMethods({ localStorage: storage, document: { getElementById: () => null } });
+  const app = {
+    unreadCounts: { [oldCode]: 3 },
+    voiceCounts: { [oldCode]: 2 },
+    voiceChannelUsers: { [oldCode]: [{ id: 1 }] },
+    _pinnedCountByChannel: { [oldCode]: 1 },
+    _unreadPinIdByChannel: { [oldCode]: 9 },
+    _threadMentions: { [oldCode]: [7] },
+    _persistThreadMentions() { this.persistedMentions = true; },
+    currentChannel: oldCode,
+    _lastVoiceUsersChannel: oldCode,
+    _pendingChannelHistoryCode: oldCode,
+    _pinsPipChannelCode: oldCode,
+    _organizeParentCode: oldCode,
+    voice: { currentChannel: oldCode, _softLeftChannel: oldCode, _joiningChannelCode: oldCode },
+    channels: [{ afk_sub_code: oldCode }]
+  };
+
+  methods._migrateChannelCodeState.call(app, oldCode, newCode);
+
+  for (const store of [
+    app.unreadCounts,
+    app.voiceCounts,
+    app.voiceChannelUsers,
+    app._pinnedCountByChannel,
+    app._unreadPinIdByChannel,
+    app._threadMentions
+  ]) {
+    assert.equal(Object.hasOwn(store, oldCode), false);
+    assert.equal(Object.hasOwn(store, newCode), true);
+  }
+  assert.equal(app.currentChannel, newCode);
+  assert.equal(app.voice.currentChannel, newCode);
+  assert.equal(app.voice._softLeftChannel, newCode);
+  assert.equal(app.voice._joiningChannelCode, newCode);
+  assert.equal(app.channels[0].afk_sub_code, newCode);
+  assert.equal(app.persistedMentions, true);
+  assert.equal(storage.getItem('haven_voice_channel'), newCode);
+  assert.deepEqual(JSON.parse(storage.getItem('haven_muted_channels')), [newCode, 'aaaaaaaa']);
+  assert.equal(storage.getItem(`haven_seen_pin_max_${oldCode}`), null);
+  assert.equal(storage.getItem(`haven_seen_pin_max_${newCode}`), '42');
+  assert.equal(storage.getItem(`haven_subtag_collapsed_${newCode}_news`), '1');
+});
+
+test('channel lists detect rotations by stable id across memory and cold starts', () => {
+  const storage = createStorage({
+    haven_channel_codes_by_id: JSON.stringify({
+      ownerId: '7',
+      codes: { 1: '11111111', 2: 'aaaaaaaa' }
+    })
+  });
+  const methods = loadSocketMethods({ localStorage: storage });
+  const app = Object.assign({
+    user: { id: 7 },
+    channels: [{ id: 2, code: 'bbbbbbbb' }]
+  }, methods);
+  const channels = [
+    { id: 1, code: '22222222' },
+    { id: 2, code: 'cccccccc' }
+  ];
+
+  const rotations = methods._collectChannelCodeRotations.call(app, channels);
+  assert.deepEqual(JSON.parse(JSON.stringify(rotations)), [
+    { channelId: 1, oldCode: '11111111', newCode: '22222222' },
+    { channelId: 2, oldCode: 'aaaaaaaa', newCode: 'cccccccc' },
+    { channelId: 2, oldCode: 'bbbbbbbb', newCode: 'cccccccc' }
+  ]);
+
+  methods._persistChannelCodeMap.call(app, channels);
+  assert.deepEqual(JSON.parse(storage.getItem('haven_channel_codes_by_id')), {
+    ownerId: '7',
+    codes: {
+      1: '22222222',
+      2: 'cccccccc'
+    }
+  });
+
+  methods._updatePersistedChannelCode.call(app, 2, 'dddddddd');
+  assert.equal(methods._readChannelCodeMap.call(app)[2], 'dddddddd');
+  const nextRotations = methods._collectChannelCodeRotations.call(
+    { ...app, channels: [] },
+    [{ id: 2, code: 'eeeeeeee' }]
+  );
+  assert.deepEqual(JSON.parse(JSON.stringify(nextRotations)), [
+    { channelId: 2, oldCode: 'dddddddd', newCode: 'eeeeeeee' }
+  ]);
+
+  const otherUser = Object.assign({ user: { id: 8 }, channels: [] }, methods);
+  assert.deepEqual(JSON.parse(JSON.stringify(
+    methods._collectChannelCodeRotations.call(otherUser, channels)
+  )), []);
+  methods._clearChannelCodeMap.call(app);
+  assert.equal(storage.getItem('haven_channel_codes_by_id'), null);
+});
+
+test('voice-channel-gone can be repaired by channels-list without delaying rejoin', () => {
+  const handlers = {};
+  const context = vm.createContext({
+    module: { exports: {} },
+    navigator: { userAgent: '', platform: '', maxTouchPoints: 0 },
+    localStorage: createStorage(),
+    console: { log() {}, warn() {}, error: console.error },
+    setTimeout,
+    clearTimeout,
+    Date
+  });
+  vm.runInContext(`${VOICE_SOURCE}\nmodule.exports = VoiceManager;`, context, { filename: 'voice.js' });
+  const VoiceManager = context.module.exports;
+  const voice = Object.create(VoiceManager.prototype);
+  voice.socket = { on: (event, handler) => { handlers[event] = handler; } };
+  voice.inVoice = true;
+  voice.currentChannel = '11111111';
+  voice.leaveCalls = 0;
+  voice.leave = () => { voice.leaveCalls++; voice.inVoice = false; };
+  voice._setupSocketListeners();
+
+  voice.deferChannelGone(6000);
+  handlers['voice-channel-gone']({ code: '11111111' });
+  assert.equal(voice.leaveCalls, 0);
+  voice.currentChannel = '22222222';
+  voice.resolveDeferredChannelGone('22222222');
+  assert.equal(voice.leaveCalls, 0);
+
+  voice.inVoice = true;
+  voice._voiceSessionGeneration = 1;
+  voice.deferChannelGone(6000);
+  handlers['voice-channel-gone']({ code: '22222222' });
+  voice.currentChannel = '33333333';
+  voice._voiceSessionGeneration = 2;
+  voice.resolveDeferredChannelGone(null);
+  assert.equal(voice.leaveCalls, 0);
+
+  voice.inVoice = true;
+  voice.deferChannelGone(6000);
+  handlers['voice-channel-gone']({ code: '33333333' });
+  voice.deferChannelGone(6000);
+  assert.equal(voice._deferredChannelGone, null);
+  voice.resolveDeferredChannelGone(null);
+  assert.equal(voice.leaveCalls, 0);
+
+  voice.deferChannelGone(6000);
+  handlers['voice-channel-gone']({ code: '33333333' });
+  voice.resolveDeferredChannelGone(null);
+  assert.equal(voice.leaveCalls, 1);
+
+  const connectHandler = SOCKET_SOURCE.slice(
+    SOCKET_SOURCE.indexOf("this.socket.on('connect'"),
+    SOCKET_SOURCE.indexOf("this.socket.on('disconnect'")
+  );
+  assert.match(connectHandler, /emit\('enter-channel'/);
+  assert.match(connectHandler, /emit\('voice-rejoin'/);
+  assert.doesNotMatch(connectHandler, /await[^;]+channels-list|_resumeChannelsAfterList/);
+});
+
+test('voice joins are single-flight while async setup is pending', async () => {
+  const context = vm.createContext({
+    module: { exports: {} },
+    navigator: { userAgent: '', platform: '', maxTouchPoints: 0 },
+    localStorage: createStorage(),
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout,
+    clearTimeout,
+    Date
+  });
+  vm.runInContext(`${VOICE_SOURCE}\nmodule.exports = VoiceManager;`, context, { filename: 'voice.js' });
+  const VoiceManager = context.module.exports;
+  const voice = Object.create(VoiceManager.prototype);
+  voice.socket = { connected: true };
+  voice.inVoice = false;
+  let rejectSetup;
+  voice._fetchIceServers = () => new Promise((resolve, reject) => { rejectSetup = reject; });
+
+  const firstJoin = voice.join('11111111');
+  await Promise.resolve();
+  assert.equal(voice._joinInFlight, true);
+  assert.equal(await voice.join('11111111'), false);
+  rejectSetup(new Error('stop setup'));
+  assert.equal(await firstJoin, false);
+  assert.equal(voice._joinInFlight, false);
+  assert.equal(voice._joiningChannelCode, null);
+});
+
+test('an async voice join uses a rotated code and does not emit while disconnected', async () => {
+  const emissions = [];
+  const context = vm.createContext({
+    module: { exports: {} },
+    navigator: { userAgent: '', platform: '', maxTouchPoints: 0 },
+    localStorage: createStorage({ haven_listener_only: '1' }),
+    console: { log() {}, warn() {}, error() {} },
+    window: {},
+    setTimeout,
+    clearTimeout,
+    Date
+  });
+  vm.runInContext(`${VOICE_SOURCE}\nmodule.exports = VoiceManager;`, context, { filename: 'voice.js' });
+  const VoiceManager = context.module.exports;
+  const createVoice = () => {
+    const voice = Object.create(VoiceManager.prototype);
+    voice.socket = {
+      connected: true,
+      emit: (event, data) => emissions.push({ event, data })
+    };
+    voice.inVoice = false;
+    voice.isMuted = false;
+    voice.isDeafened = false;
+    voice._ensureAudioCtx = () => {};
+    voice.audioCtx = {
+      resume: async () => {},
+      close: async () => {},
+      createMediaStreamDestination: () => ({ stream: { getTracks: () => [] } })
+    };
+    voice._applyMuteStateToLocalTracks = () => {};
+    voice._disableRNNoise = () => {};
+    voice._stopNoiseGate = () => {};
+    voice._stopLocalTalkDetection = () => {};
+    return voice;
+  };
+
+  const rotatedVoice = createVoice();
+  let finishSetup;
+  rotatedVoice._fetchIceServers = () => new Promise(resolve => { finishSetup = resolve; });
+  const rotatedJoin = rotatedVoice.join('11111111');
+  rotatedVoice._joiningChannelCode = '22222222';
+  finishSetup();
+  assert.equal(await rotatedJoin, true);
+  assert.deepEqual(JSON.parse(JSON.stringify(
+    emissions.find(item => item.event === 'voice-join')
+  )), {
+    event: 'voice-join',
+    data: { code: '22222222' }
+  });
+
+  emissions.length = 0;
+  const disconnectedVoice = createVoice();
+  let finishDisconnectedSetup;
+  disconnectedVoice._fetchIceServers = () => new Promise(resolve => { finishDisconnectedSetup = resolve; });
+  const disconnectedJoin = disconnectedVoice.join('33333333');
+  disconnectedVoice.socket.connected = false;
+  finishDisconnectedSetup();
+  assert.equal(await disconnectedJoin, false);
+  assert.equal(emissions.some(item => item.event === 'voice-join'), false);
+});

--- a/test/channelCodeClientState.test.js
+++ b/test/channelCodeClientState.test.js
@@ -174,13 +174,12 @@ test('voice-channel-gone can be repaired by channels-list without delaying rejoi
   voice.inVoice = true;
   voice.deferChannelGone(6000);
   handlers['voice-channel-gone']({ code: '33333333' });
+  const originalDeadline = voice._deferChannelGoneUntil;
+  const originalTimer = voice._deferredChannelGoneTimer;
   voice.deferChannelGone(6000);
-  assert.equal(voice._deferredChannelGone, null);
-  voice.resolveDeferredChannelGone(null);
-  assert.equal(voice.leaveCalls, 0);
-
-  voice.deferChannelGone(6000);
-  handlers['voice-channel-gone']({ code: '33333333' });
+  assert.ok(voice._deferredChannelGone);
+  assert.equal(voice._deferChannelGoneUntil, originalDeadline);
+  assert.equal(voice._deferredChannelGoneTimer, originalTimer);
   voice.resolveDeferredChannelGone(null);
   assert.equal(voice.leaveCalls, 1);
 
@@ -191,6 +190,51 @@ test('voice-channel-gone can be repaired by channels-list without delaying rejoi
   assert.match(connectHandler, /emit\('enter-channel'/);
   assert.match(connectHandler, /emit\('voice-rejoin'/);
   assert.doesNotMatch(connectHandler, /await[^;]+channels-list|_resumeChannelsAfterList/);
+  const channelListHandler = SOCKET_SOURCE.slice(
+    SOCKET_SOURCE.indexOf("this.socket.on('channels-list'"),
+    SOCKET_SOURCE.indexOf("this.socket.on('message-history'")
+  );
+  assert.match(channelListHandler, /voiceRotation[\s\S]+_healPeerConnectionsAfterChannelRotation/);
+});
+
+test('rotation recovery rolls back an unanswered offer sent with the old code', async () => {
+  const context = vm.createContext({
+    module: { exports: {} },
+    navigator: { userAgent: '', platform: '', maxTouchPoints: 0 },
+    localStorage: createStorage(),
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout,
+    clearTimeout,
+    Date
+  });
+  vm.runInContext(`${VOICE_SOURCE}\nmodule.exports = VoiceManager;`, context, { filename: 'voice.js' });
+  const VoiceManager = context.module.exports;
+  const voice = Object.create(VoiceManager.prototype);
+  let rollback;
+  let healCalls = 0;
+  const connection = {
+    signalingState: 'have-local-offer',
+    async setLocalDescription(description) {
+      rollback = description;
+      this.signalingState = 'stable';
+    }
+  };
+  const peer = {
+    connection,
+    _makingOffer: false,
+    _awaitingAnswer: true,
+    _offerIsIceRestart: true,
+    _offerChannelCode: '11111111'
+  };
+  voice.peers = new Map([[7, peer]]);
+  voice._healPeerConnections = () => { healCalls++; };
+
+  await voice._healPeerConnectionsAfterChannelRotation('11111111');
+
+  assert.deepEqual(JSON.parse(JSON.stringify(rollback)), { type: 'rollback' });
+  assert.equal(peer._awaitingAnswer, false);
+  assert.equal(peer._offerChannelCode, null);
+  assert.equal(healCalls, 1);
 });
 
 test('voice joins are single-flight while async setup is pending', async () => {


### PR DESCRIPTION
## Summary

- Detect channel-code rotations by stable channel ID and migrate runtime and persisted client state.
- Preserve immediate `enter-channel` and `voice-rejoin` emissions during reconnects.
- Repair stale channel, voice, pin, thread, mute, hidden-channel, and category state after `channels-list` arrives.
- Make voice recovery race-safe with single-flight joins and a bounded 6-second `voice-channel-gone` deferral.
- Scope persisted channel mappings to the authenticated user and clear them during logout or session invalidation.
- Keep the persisted map updated across consecutive live rotations.

This complements the server-side state migration in #5521 while remaining independently based on `main`.

## Testing

- `node --test test/*.test.js`
- `node --check public/js/modules/app-socket.js`
- `node --check public/js/modules/app-ui.js`
- `node --check public/js/voice.js`
- `node --check test/channelCodeClientState.test.js`
- `git diff --check upstream/main...HEAD`