### PR TITLE
Add secure bot voice gateway

### DIFF
--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -1685,7 +1685,9 @@ _renderWebhookList(webhooks, channelCode) {
     return;
   }
   container.innerHTML = webhooks.map(wh => {
-    const maskedToken = wh.token.slice(0, 8) + '••••••••';
+    const maskedToken = typeof wh.token === 'string' && wh.token
+      ? wh.token.slice(0, 8) + '••••••••'
+      : 'Hidden - owner/admin only';
     const statusLabel = wh.is_active ? `🟢 ${t('channels.webhook_active')}` : `🔴 ${t('channels.webhook_disabled')}`;
     const toggleLabel = wh.is_active ? t('channels.webhook_disable') : t('channels.webhook_enable');
     return `
@@ -3068,13 +3070,14 @@ _updateChannelVoiceIndicators() {
         // Self-talking state is driven by the local analyser directly (not
         // server echo), so talkingState.get('self') reflects real-time mic level.
         const isTalking = this.voice && ((isSelf && this.voice.talkingState.get('self')) || this.voice.talkingState.get(u.id));
-        return `<div class="channel-voice-user${isTalking ? ' talking' : ''}" data-user-id="${u.id}" data-username="${this._escapeHtml(u.username)}"><span class="cvu-mic${u.isMuted ? ' is-muted' : ''}" title="${u.isMuted ? 'Muted' : ''}">🎙️</span><span class="cvu-deafen${u.isDeafened ? ' is-deafened' : ''}" title="${u.isDeafened ? 'Deafened' : ''}">🔊</span>${this._escapeHtml(u.username)}</div>`;
+        const botBadge = u.isBot ? '<span class="bot-badge">BOT</span>' : '';
+        return `<div class="channel-voice-user${isTalking ? ' talking' : ''}" data-user-id="${u.id}" data-is-bot="${u.isBot ? 'true' : 'false'}" data-username="${this._escapeHtml(u.username)}"><span class="cvu-mic${u.isMuted ? ' is-muted' : ''}" title="${u.isMuted ? 'Muted' : ''}">🎙️</span><span class="cvu-deafen${u.isDeafened ? ' is-deafened' : ''}" title="${u.isDeafened ? 'Deafened' : ''}">🔊</span>${this._escapeHtml(u.username)}${botBadge}</div>`;
       }).join('');
       // Right-click on a left-sidebar voice user → same voice options menu
       userList.querySelectorAll('.channel-voice-user').forEach(item => {
         item.addEventListener('contextmenu', (e) => {
           const userId = parseInt(item.dataset.userId);
-          if (isNaN(userId) || userId === this.user.id) return;
+          if (isNaN(userId) || userId === this.user.id || item.dataset.isBot === 'true') return;
           e.preventDefault();
           e.stopPropagation();
           this._showVoiceUserMenu(item, userId, item.dataset.username || '');

--- a/public/js/modules/app-media.js
+++ b/public/js/modules/app-media.js
@@ -3484,8 +3484,9 @@ _showBotDetail(botId) {
   if (!wh) return;
   const panel = document.getElementById('bot-detail-panel');
   const baseUrl = window.location.origin;
-  const webhookUrl = `${baseUrl}/api/webhooks/${wh.token}`;
-  const maskedToken = wh.token.slice(0, 12) + '••••••••••••';
+  const tokenVisible = typeof wh.token === 'string' && wh.token.length > 0;
+  const webhookUrl = tokenVisible ? `${baseUrl}/api/webhooks/${wh.token}` : '';
+  const maskedToken = tokenVisible ? wh.token.slice(0, 12) + '••••••••••••' : 'Hidden - bot owner or admin only';
   const channelOptions = this._getBotChannelOptions(wh.channel_id);
 
   panel.innerHTML = `
@@ -3516,8 +3517,8 @@ _showBotDetail(botId) {
 
       <label class="settings-label">${t('modals.bot_mgmt.webhook_url_label')}</label>
       <div style="display:flex;gap:4px;align-items:center;margin-bottom:8px">
-        <code style="flex:1;font-size:0.6875rem;padding:6px 8px;background:var(--bg-input);border-radius:4px;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${this._escapeHtml(webhookUrl)}</code>
-        <button class="btn-xs" id="bot-detail-copy-url" title="${t('modals.bot_mgmt.copy_url_title')}">📋</button>
+        <code style="flex:1;font-size:0.6875rem;padding:6px 8px;background:var(--bg-input);border-radius:4px;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${this._escapeHtml(webhookUrl || 'Hidden - bot owner or admin only')}</code>
+        <button class="btn-xs" id="bot-detail-copy-url" title="${t('modals.bot_mgmt.copy_url_title')}" ${tokenVisible ? '' : 'disabled'}>📋</button>
       </div>
 
       <label class="settings-label">${t('modals.bot_mgmt.token_label')}</label>
@@ -3533,6 +3534,12 @@ _showBotDetail(botId) {
       <label class="toggle-row" style="margin-bottom:12px">
         <input type="checkbox" id="bot-detail-can-moderate" ${wh.can_moderate ? 'checked' : ''} ${this.user && this.user.isAdmin ? '' : 'disabled'}>
         <span>Allow this bot to perform moderation actions</span>
+      </label>
+
+      <label class="settings-label">Voice access <span style="font-size:0.625rem;color:var(--text-muted)">(admin only - lets this bot join voice as a WebRTC peer)</span></label>
+      <label class="toggle-row" style="margin-bottom:12px">
+        <input type="checkbox" id="bot-detail-can-use-voice" ${wh.can_use_voice ? 'checked' : ''} ${this.user && this.user.isAdmin ? '' : 'disabled'}>
+        <span>Allow this bot to use voice channels</span>
       </label>
 
       <div style="display:flex;gap:8px;margin-top:8px">
@@ -3563,12 +3570,15 @@ _showBotDetail(botId) {
     const payload = { id: botId, name, channel_id: channelId, callback_url: callbackUrl, callback_secret: callbackSecret };
     const modBox = panel.querySelector('#bot-detail-can-moderate');
     if (modBox && !modBox.disabled) payload.can_moderate = modBox.checked ? 1 : 0;
+    const voiceBox = panel.querySelector('#bot-detail-can-use-voice');
+    if (voiceBox && !voiceBox.disabled) payload.can_use_voice = voiceBox.checked ? 1 : 0;
     this.socket.emit('update-webhook', payload);
   });
   panel.querySelector('#bot-detail-toggle').addEventListener('click', () => {
     this.socket.emit('toggle-webhook', { id: botId });
   });
   panel.querySelector('#bot-detail-copy-url').addEventListener('click', () => {
+    if (!webhookUrl) return;
     const markCopied = () => {
       panel.querySelector('#bot-detail-copy-url').textContent = '✅';
       setTimeout(() => {

--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -1425,7 +1425,8 @@ _setupSocketListeners() {
     // panel guard above.
     const usersForSidebar = users.map(u => ({
       id: u.id, username: u.username,
-      isMuted: !!u.isMuted, isDeafened: !!u.isDeafened
+      isMuted: !!u.isMuted, isDeafened: !!u.isDeafened,
+      isBot: !!u.isBot, isListening: !!u.isListening
     }));
     const skipEmptyWipe = usersForSidebar.length === 0 && isInVoice &&
       Array.isArray(this.voiceChannelUsers?.[data.channelCode]) &&

--- a/public/js/modules/app-users.js
+++ b/public/js/modules/app-users.js
@@ -1194,13 +1194,15 @@ _renderVoiceUsers(users, channelCode) {
     const statusIconsHtml = statusIcons.length
       ? `<span class="voice-status-icons">${statusIcons.join('')}</span>`
       : '';
+    const botBadge = u.isBot ? '<span class="bot-badge">BOT</span>' : '';
     return `
-      <div class="user-item voice-user-item${talking ? ' talking' : ''}" data-user-id="${u.id}"${dotColor ? ` style="--voice-dot-color:${dotColor}"` : ''}>
+      <div class="user-item voice-user-item${talking ? ' talking' : ''}" data-user-id="${u.id}" data-is-bot="${u.isBot ? 'true' : 'false'}"${dotColor ? ` style="--voice-dot-color:${dotColor}"` : ''}>
         <span class="user-dot voice"${dotStyle}></span>
         <span class="user-item-name"${this._nicknames[u.id] ? ` title="${this._escapeHtml(u.username)}"` : ''}>${this._escapeHtml(this._getNickname(u.id, u.username))}</span>
+        ${botBadge}
         ${streamBadge}
         ${statusIconsHtml}
-        ${isSelf ? '' : `<button class="voice-user-menu-btn" data-user-id="${u.id}" data-username="${this._escapeHtml(u.username)}" title="${t('users.more_actions')}">⋯</button>`}
+        ${isSelf || u.isBot ? '' : `<button class="voice-user-menu-btn" data-user-id="${u.id}" data-username="${this._escapeHtml(u.username)}" title="${t('users.more_actions')}">⋯</button>`}
       </div>
     `;
   }).join('');
@@ -1218,7 +1220,7 @@ _renderVoiceUsers(users, channelCode) {
   // Bind voice user names/items to open profile popup (same as sidebar)
   el.querySelectorAll('.voice-user-item').forEach(item => {
     const nameEl = item.querySelector('.user-item-name');
-    if (nameEl) {
+    if (nameEl && item.dataset.isBot !== 'true') {
       nameEl.style.cursor = 'pointer';
       nameEl.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -1233,7 +1235,7 @@ _renderVoiceUsers(users, channelCode) {
     // Right-click on voice user → same options as "..." button
     item.addEventListener('contextmenu', (e) => {
       const userId = parseInt(item.dataset.userId);
-      if (isNaN(userId) || userId === this.user.id) return;
+      if (isNaN(userId) || userId === this.user.id || item.dataset.isBot === 'true') return;
       e.preventDefault();
       e.stopPropagation();
       const btn = item.querySelector('.voice-user-menu-btn');

--- a/server.js
+++ b/server.js
@@ -119,11 +119,13 @@ webpush.setVapidDetails(vapidEmail, process.env.VAPID_PUBLIC_KEY, process.env.VA
 const { initDatabase } = require('./src/database');
 const { router: authRoutes, authLimiter, verifyToken } = require('./src/auth');
 const { setupSocketHandlers, sanitizeText, sanitizeBorderTransform } = require('./src/socketHandlers');
+const { getAccessibleVoiceChannels } = require('./src/botVoice');
 const { startTunnel, stopTunnel, getTunnelStatus, registerProcessCleanup } = require('./src/tunnel');
 const { startDdns, getDdnsStatus, triggerDdnsNow } = require('./src/ddns');
 const { initFcm, setFcmAdminEnabled } = require('./src/fcm');
 
 const app = express();
+let socketRuntime = null;
 
 const UPLOAD_PATH_RE = /\/uploads\/((?!(?:deleted-attachments|stickers)\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
 
@@ -3574,6 +3576,33 @@ app.post('/api/webhooks/:token', webhookLimiter, express.json({ limit: '64kb' })
   res.status(200).json({ success: true, message_id: result.lastInsertRowid });
 });
 
+// Voice presence is scoped to the bot's assigned channel, channels its
+// creator belongs to, or every non-DM channel when its creator is an admin.
+app.get('/api/webhooks/:token/voice/channels', webhookLimiter, (req, res) => {
+  const webhook = getWebhookByToken(req.params.token);
+  if (!webhook) return res.status(404).json({ error: 'Webhook not found or inactive' });
+  if (!webhook.can_use_voice) {
+    return res.status(403).json({ error: 'This bot does not have voice permission' });
+  }
+
+  const { getDb } = require('./src/database');
+  const voiceUsers = socketRuntime?.state?.voiceUsers;
+  const channels = getAccessibleVoiceChannels(getDb(), webhook)
+    .filter(channel => channel.voice_enabled !== 0)
+    .map(channel => {
+      const room = voiceUsers?.get(channel.code);
+      const users = room ? Array.from(room.values()) : [];
+      return {
+        code: channel.code,
+        name: channel.name,
+        members: users.filter(user => !user.isBot).length,
+        bots: users.filter(user => user.isBot).length
+      };
+    })
+    .sort((a, b) => b.members - a.members || a.name.localeCompare(b.name));
+  res.json({ channels });
+});
+
 // ── Bot: Delete a message in the webhook's channel ──────
 app.delete('/api/webhooks/:token/messages/:messageId', webhookLimiter, (req, res) => {
   const { getDb } = require('./src/database');
@@ -3831,7 +3860,7 @@ function getWebhookByToken(token) {
   if (!token || typeof token !== 'string' || token.length !== 64) return null;
   const { getDb } = require('./src/database');
   return getDb().prepare(
-    'SELECT id, name, channel_id, callback_url, can_moderate, created_by FROM webhooks WHERE token = ? AND is_active = 1'
+    'SELECT id, name, channel_id, callback_url, can_moderate, can_use_voice, created_by FROM webhooks WHERE token = ? AND is_active = 1'
   ).get(token);
 }
 
@@ -4701,7 +4730,7 @@ try {
 } catch {}
 initFcm(DATA_DIR);
 app.set('io', io);   // expose to auth routes (session invalidation on password change)
-activityRef.engine = setupSocketHandlers(io, db, {
+socketRuntime = setupSocketHandlers(io, db, {
   invalidateIpBanCache,
   // Share the cached ban matcher so the socket gate and the HTTP gate agree
   // on both normalization and CIDR handling, and the socket path stops
@@ -4712,7 +4741,8 @@ activityRef.engine = setupSocketHandlers(io, db, {
   getUploadUsage,
   // Keep the Referrer-Policy cache in sync when an admin changes it.
   onReferrerPolicyChange: (v) => { if (VALID_REFERRER_POLICIES.includes(v)) currentReferrerPolicy = v; }
-}).activity;
+});
+activityRef.engine = socketRuntime.activity;
 registerProcessCleanup();
 
 // ── Auto-cleanup interval (runs every 15 minutes) ───────

--- a/src/botVoice.js
+++ b/src/botVoice.js
@@ -1,0 +1,346 @@
+'use strict';
+
+const BOT_SOCKET_ROOM = 'bot-sockets';
+
+function getAccessibleVoiceChannels(db, webhook) {
+  if (!webhook) return [];
+  const creator = webhook.created_by
+    ? db.prepare('SELECT is_admin FROM users WHERE id = ?').get(webhook.created_by)
+    : null;
+
+  if (creator?.is_admin) {
+    return db.prepare(`
+      SELECT id, code, name, voice_enabled, voice_user_limit, voice_bitrate
+      FROM channels
+      WHERE is_dm = 0
+      ORDER BY position ASC, id ASC
+    `).all();
+  }
+
+  return db.prepare(`
+    SELECT DISTINCT c.id, c.code, c.name, c.voice_enabled, c.voice_user_limit, c.voice_bitrate
+    FROM channels c
+    LEFT JOIN channel_members cm
+      ON cm.channel_id = c.id AND cm.user_id = ?
+    WHERE c.is_dm = 0 AND (c.id = ? OR cm.user_id IS NOT NULL)
+    ORDER BY c.position ASC, c.id ASC
+  `).all(webhook.created_by || -1, webhook.channel_id);
+}
+
+function canAccessVoiceChannel(db, webhook, channelCode) {
+  return getAccessibleVoiceChannels(db, webhook).find(channel => channel.code === channelCode) || null;
+}
+
+function getBotVoiceWebhookByToken(db, token) {
+  if (typeof token !== 'string' || !/^[a-f0-9]{64}$/i.test(token)) return null;
+  return db.prepare(`
+    SELECT w.id, w.name, w.token, w.channel_id, w.created_by, w.can_use_voice,
+           c.code AS channel_code
+    FROM webhooks w
+    JOIN channels c ON c.id = w.channel_id
+    WHERE w.token = ? AND w.is_active = 1
+  `).get(token) || null;
+}
+
+function getActiveBotVoiceWebhook(db, webhookId) {
+  return db.prepare(`
+    SELECT w.id, w.name, w.token, w.channel_id, w.created_by, w.can_use_voice,
+           c.code AS channel_code
+    FROM webhooks w
+    JOIN channels c ON c.id = w.channel_id
+    WHERE w.id = ? AND w.is_active = 1
+  `).get(webhookId) || null;
+}
+
+function getBotVoiceAccessFailure(db, webhookId, channelCodes = [], expectedToken = null) {
+  const webhook = getActiveBotVoiceWebhook(db, webhookId);
+  if (!webhook) return 'Webhook was deleted or disabled';
+  if (expectedToken && webhook.token !== expectedToken) return 'Bot token was rotated';
+  if (!webhook.can_use_voice) return 'Bot voice permission was revoked';
+  for (const code of channelCodes) {
+    const channel = canAccessVoiceChannel(db, webhook, code);
+    if (!channel) return 'Bot no longer has access to this channel';
+    if (channel.voice_enabled === 0) return 'Voice was disabled in this channel';
+  }
+  return null;
+}
+
+function getSocketVoiceChannelCodes(socket) {
+  const codes = new Set();
+  for (const room of socket.rooms || []) {
+    if (typeof room === 'string' && room.startsWith('voice:')) codes.add(room.slice(6));
+  }
+  return codes;
+}
+
+function disconnectBotVoiceSocket(socket, ctx, reason) {
+  const { state, handleVoiceLeave } = ctx;
+  for (const [code, room] of Array.from(state.voiceUsers.entries())) {
+    if (room.get(socket.user.id)?.socketId === socket.id) handleVoiceLeave(socket, code);
+  }
+  socket.emit('voice-kicked', { channelCode: socket.user.channelCode, reason });
+  socket.disconnect(true);
+}
+
+function disconnectDuplicateBotSockets(socket, ctx) {
+  let disconnected = 0;
+  for (const [, existing] of Array.from(ctx.io.sockets.sockets.entries())) {
+    if (existing.id === socket.id || !existing.user?.isBot) continue;
+    if (existing.user.webhookId !== socket.user.webhookId) continue;
+    disconnectBotVoiceSocket(existing, ctx, 'Bot connected from another process');
+    disconnected++;
+  }
+  return disconnected;
+}
+
+function isolateBotVoiceSocket(socket) {
+  socket.join(BOT_SOCKET_ROOM);
+  const join = socket.join.bind(socket);
+  socket.join = rooms => {
+    const requested = Array.isArray(rooms) ? rooms : [rooms];
+    const allowed = requested.filter(room => typeof room === 'string' && room.startsWith('voice:'));
+    if (!allowed.length) return Promise.resolve();
+    return join(Array.isArray(rooms) ? allowed : allowed[0]);
+  };
+}
+
+function reconcileBotVoiceAccess(io, db, state, revokeBotVoiceAccess) {
+  const invalid = new Map();
+  for (const [, socket] of io.sockets.sockets) {
+    if (!socket.user?.isBot) continue;
+    const reason = getBotVoiceAccessFailure(
+      db,
+      socket.user.webhookId,
+      getSocketVoiceChannelCodes(socket),
+      socket.user.botToken
+    );
+    if (reason) invalid.set(socket.user.webhookId, reason);
+  }
+  for (const [webhookId, reason] of invalid) revokeBotVoiceAccess(webhookId, reason);
+  return invalid.size;
+}
+
+function registerBotVoiceSocket(socket, ctx) {
+  const { io, db, state, broadcastVoiceUsers, handleVoiceLeave, revokeBotVoiceAccess } = ctx;
+  const { voiceUsers, voiceLastActivity } = state;
+  const MAX_SDP_SIZE = 16384;
+  const MAX_ICE_SIZE = 2048;
+  let eventWindowStartedAt = Date.now();
+  let eventCount = 0;
+  let disconnecting = false;
+
+  socket.emit('bot-session', {
+    id: socket.user.id,
+    webhookId: socket.user.webhookId,
+    username: socket.user.displayName,
+    channelCode: socket.user.channelCode
+  });
+
+  function disconnectRevoked(reason) {
+    if (disconnecting) return;
+    disconnecting = true;
+    if (typeof revokeBotVoiceAccess === 'function') {
+      revokeBotVoiceAccess(socket.user.webhookId, reason);
+    } else {
+      disconnectBotVoiceSocket(socket, { state, handleVoiceLeave }, reason);
+    }
+  }
+
+  socket.use((packet, next) => {
+    const now = Date.now();
+    if (now - eventWindowStartedAt >= 10000) {
+      eventWindowStartedAt = now;
+      eventCount = 0;
+    }
+    eventCount++;
+    if (eventCount > 300) return next(new Error('Bot voice event rate limit exceeded'));
+
+    const reason = getBotVoiceAccessFailure(
+      db,
+      socket.user.webhookId,
+      getSocketVoiceChannelCodes(socket),
+      socket.user.botToken
+    );
+    if (reason) {
+      next(new Error(reason));
+      disconnectRevoked(reason);
+      return;
+    }
+    next();
+  });
+
+  socket.on('voice-join', (data, callback) => {
+    const cb = typeof callback === 'function' ? callback : () => {};
+    const sessionFailure = getBotVoiceAccessFailure(
+      db,
+      socket.user.webhookId,
+      [],
+      socket.user.botToken
+    );
+    if (sessionFailure) {
+      cb({ error: sessionFailure });
+      disconnectRevoked(sessionFailure);
+      return;
+    }
+
+    const webhook = getActiveBotVoiceWebhook(db, socket.user.webhookId);
+    const requestedCode = typeof data?.code === 'string' ? data.code.trim() : socket.user.channelCode;
+    if (!/^[a-f0-9]{8}$/i.test(requestedCode)) return cb({ error: 'Invalid channel code' });
+    const channel = canAccessVoiceChannel(db, webhook, requestedCode);
+    if (!channel) return cb({ error: 'Bot cannot access this voice channel' });
+    if (channel.voice_enabled === 0) return cb({ error: 'Voice is disabled in this channel' });
+
+    if (!voiceUsers.has(requestedCode)) voiceUsers.set(requestedCode, new Map());
+    const room = voiceUsers.get(requestedCode);
+    const currentCount = room.size - (room.has(socket.user.id) ? 1 : 0);
+    if (channel.voice_user_limit > 0 && currentCount >= channel.voice_user_limit) {
+      return cb({ error: `Voice is full (${currentCount}/${channel.voice_user_limit})` });
+    }
+
+    for (const [previousCode, previousRoom] of voiceUsers) {
+      if (previousRoom.get(socket.user.id)?.socketId === socket.id && previousCode !== requestedCode) {
+        handleVoiceLeave(socket, previousCode);
+      }
+    }
+
+    const existingEntry = room.get(socket.user.id);
+    let replacedSocket = null;
+    if (existingEntry && existingEntry.socketId !== socket.id) {
+      const oldSocket = io.sockets.sockets.get(existingEntry.socketId);
+      if (oldSocket) {
+        oldSocket.leave(`voice:${requestedCode}`);
+        replacedSocket = oldSocket;
+      }
+    }
+
+    if (!voiceUsers.has(requestedCode)) voiceUsers.set(requestedCode, new Map());
+    const activeRoom = voiceUsers.get(requestedCode);
+    const existingUsers = Array.from(activeRoom.values()).filter(user => user.id !== socket.user.id);
+    socket.join(`voice:${requestedCode}`);
+    socket.user.channelCode = requestedCode;
+    activeRoom.set(socket.user.id, {
+      id: socket.user.id,
+      username: socket.user.displayName,
+      socketId: socket.id,
+      isMuted: false,
+      isDeafened: false,
+      isBot: true,
+      isListening: true
+    });
+    voiceLastActivity.set(socket.user.id, Date.now());
+
+    if (replacedSocket) {
+      replacedSocket.emit('voice-kicked', {
+        channelCode: requestedCode,
+        reason: 'Bot connected from another process'
+      });
+      replacedSocket.disconnect(true);
+    }
+
+    socket.emit('voice-existing-users', {
+      channelCode: requestedCode,
+      users: existingUsers.map(user => ({
+        id: user.id,
+        username: user.username,
+        isMuted: !!user.isMuted,
+        isDeafened: !!user.isDeafened,
+        isBot: !!user.isBot,
+        isListening: !!user.isListening
+      })),
+      voiceBitrate: channel.voice_bitrate || 0
+    });
+
+    if (!existingEntry) {
+      for (const user of existingUsers) {
+        io.to(user.socketId).emit('voice-user-joined', {
+          channelCode: requestedCode,
+          user: {
+            id: socket.user.id,
+            username: socket.user.displayName,
+            isBot: true,
+            isListening: true
+          }
+        });
+      }
+    }
+
+    broadcastVoiceUsers(requestedCode);
+    cb({ success: true, channelCode: requestedCode, botUserId: socket.user.id });
+  });
+
+  function relaySignal(data, field, maxSize, eventName, allowNull = false) {
+    if (!data || typeof data !== 'object') return;
+    if (typeof data.code !== 'string' || !/^[a-f0-9]{8}$/i.test(data.code)) return;
+    if (!Number.isInteger(data.targetUserId)) return;
+    if (voiceUsers.get(data.code)?.get(socket.user.id)?.socketId !== socket.id) return;
+    const signal = data[field];
+    if (!allowNull && (!signal || typeof signal !== 'object')) return;
+    if (signal && (typeof signal !== 'object' || JSON.stringify(signal).length > maxSize)) return;
+    const target = voiceUsers.get(data.code)?.get(data.targetUserId);
+    if (!target || target.id === socket.user.id) return;
+    io.to(target.socketId).emit(eventName, {
+      from: { id: socket.user.id, username: socket.user.displayName, isBot: true },
+      [field]: signal || null,
+      channelCode: data.code
+    });
+  }
+
+  socket.on('voice-offer', data => relaySignal(data, 'offer', MAX_SDP_SIZE, 'voice-offer'));
+  socket.on('voice-answer', data => relaySignal(data, 'answer', MAX_SDP_SIZE, 'voice-answer'));
+  socket.on('voice-ice-candidate', data => relaySignal(data, 'candidate', MAX_ICE_SIZE, 'voice-ice-candidate', true));
+
+  socket.on('voice-mute-state', data => {
+    const code = typeof data?.code === 'string' ? data.code.trim() : '';
+    const entry = voiceUsers.get(code)?.get(socket.user.id);
+    if (!entry || entry.socketId !== socket.id) return;
+    entry.isMuted = !!data.muted;
+    broadcastVoiceUsers(code);
+  });
+
+  socket.on('voice-speaking', data => {
+    for (const [code, room] of voiceUsers) {
+      if (room.get(socket.user.id)?.socketId !== socket.id) continue;
+      if (data?.speaking) voiceLastActivity.set(socket.user.id, Date.now());
+      io.to(`voice:${code}`).emit('voice-speaking', {
+        userId: socket.user.id,
+        speaking: !!data?.speaking
+      });
+      break;
+    }
+  });
+
+  socket.on('voice-activity', () => {
+    for (const room of voiceUsers.values()) {
+      if (room.get(socket.user.id)?.socketId !== socket.id) continue;
+      voiceLastActivity.set(socket.user.id, Date.now());
+      break;
+    }
+  });
+
+  socket.on('voice-leave', (data, callback) => {
+    const code = typeof data?.code === 'string' ? data.code.trim() : socket.user.channelCode;
+    if (/^[a-f0-9]{8}$/i.test(code) && voiceUsers.get(code)?.get(socket.user.id)?.socketId === socket.id) {
+      handleVoiceLeave(socket, code);
+    }
+    if (typeof callback === 'function') callback({ success: true });
+  });
+
+  socket.on('disconnect', () => {
+    for (const [code, room] of voiceUsers) {
+      if (room.get(socket.user.id)?.socketId === socket.id) handleVoiceLeave(socket, code);
+    }
+  });
+}
+
+module.exports = {
+  BOT_SOCKET_ROOM,
+  canAccessVoiceChannel,
+  disconnectBotVoiceSocket,
+  disconnectDuplicateBotSockets,
+  getAccessibleVoiceChannels,
+  getBotVoiceAccessFailure,
+  getBotVoiceWebhookByToken,
+  isolateBotVoiceSocket,
+  reconcileBotVoiceAccess,
+  registerBotVoiceSocket
+};

--- a/src/channelRotation.js
+++ b/src/channelRotation.js
@@ -100,7 +100,8 @@ function createTempChannelDeleteCallback({ db, io, state, channelId, log = conso
       channelUsers.delete(code);
       voiceUsers.delete(code);
       pendingTempDelete.delete(code);
-      io.emit('channel-deleted', { code, reason: 'temp-empty' });
+      const audience = typeof io.except === 'function' ? io.except('bot-sockets') : io;
+      audience.emit('channel-deleted', { code, reason: 'temp-empty' });
       log(`[Temporary] Temp voice channel "${code}" deleted (everyone left)`);
       return true;
     } catch (err) {
@@ -135,12 +136,24 @@ function rotateLiveChannelState(io, state, channelId, oldCode, newCode) {
   const oldVoiceRoom = `voice:${oldCode}`;
   const newVoiceRoom = `voice:${newCode}`;
   const voiceSockets = io.sockets.adapter.rooms.get(oldVoiceRoom);
+  const movedVoiceSocketIds = new Set(voiceSockets || []);
   if (voiceSockets) {
     for (const socketId of [...voiceSockets]) {
       const socket = io.sockets.sockets.get(socketId);
       if (!socket) continue;
       socket.leave(oldVoiceRoom);
       socket.join(newVoiceRoom);
+    }
+  }
+
+  const rotation = { channelId, oldCode, newCode };
+  for (const [socketId, socket] of io.sockets.sockets) {
+    if (!socket.user?.isBot) continue;
+    const currentCodeRotated = socket.user.channelCode === oldCode;
+    const assignedChannelRotated = socket.user.channelId === channelId;
+    if (currentCodeRotated) socket.user.channelCode = newCode;
+    if ((currentCodeRotated || assignedChannelRotated) && !movedVoiceSocketIds.has(socketId)) {
+      socket.emit('channel-code-rotated', rotation);
     }
   }
 
@@ -173,7 +186,7 @@ function rotateLiveChannelState(io, state, channelId, oldCode, newCode) {
     state.pendingTempDelete.set(newCode, timer);
   }
 
-  io.to(newRoom).to(newVoiceRoom).emit('channel-code-rotated', { channelId, oldCode, newCode });
+  io.to(newRoom).to(newVoiceRoom).emit('channel-code-rotated', rotation);
 }
 
 module.exports = {

--- a/src/database.js
+++ b/src/database.js
@@ -996,6 +996,8 @@ function initDatabase() {
     // 3.18.0 — opt-in moderation actions (kick/ban/mute) for bot webhooks.
     // Defaults to 0 so existing bots cannot suddenly moderate. Per #5397.
     { name: 'can_moderate',         sql: "ALTER TABLE webhooks ADD COLUMN can_moderate INTEGER DEFAULT 0" },
+    // Voice gateway access is also opt-in and can only be granted by admins.
+    { name: 'can_use_voice',        sql: "ALTER TABLE webhooks ADD COLUMN can_use_voice INTEGER DEFAULT 0" },
   ];
   for (const col of webhookCallbackCols) {
     try { db.prepare(`SELECT ${col.name} FROM webhooks LIMIT 0`).get(); } catch { db.exec(col.sql); }

--- a/src/socketHandlers/admin.js
+++ b/src/socketHandlers/admin.js
@@ -9,7 +9,7 @@ module.exports = function register(socket, ctx) {
     getUserPermissions, getUserRoles, getUserHighestRole,
     emitOnlineUsers, broadcastChannelLists, generateUniqueSharedCode,
     logAudit, fireWebhookEvent, onReferrerPolicyChange, automod, getIdleOnlineUsers,
-    getUploadUsage
+    getUploadUsage, revokeBotVoiceAccess
   } = ctx;
   const { channelUsers } = state;
 
@@ -329,13 +329,13 @@ module.exports = function register(socket, ctx) {
       return socket.emit('error-msg', 'Failed to save setting — database write error');
     }
 
-    io.emit('server-setting-changed', { key, value });
+    io.except('bot-sockets').emit('server-setting-changed', { key, value });
 
     // Clearing the name hands it back to SERVER_NAME, so tell everyone what
     // the name resolves to now rather than leaving the old one on screen
     // until the next reconnect. (#5489)
     if (key === 'server_name') {
-      io.emit('server-setting-changed', {
+      io.except('bot-sockets').emit('server-setting-changed', {
         key: 'server_name_effective',
         value: value || (process.env.SERVER_NAME || '').trim() || ''
       });
@@ -435,7 +435,7 @@ module.exports = function register(socket, ctx) {
     }
     const code = generateUniqueSharedCode();
     db.prepare('INSERT OR REPLACE INTO server_settings (key, value) VALUES (?, ?)').run('server_code', code);
-    io.emit('server-setting-changed', { key: 'server_code', value: code });
+    io.except('bot-sockets').emit('server-setting-changed', { key: 'server_code', value: code });
     socket.emit('error-msg', `Server invite code generated: ${code}`);
   });
 
@@ -444,7 +444,7 @@ module.exports = function register(socket, ctx) {
       return socket.emit('error-msg', 'Only admins can manage server codes');
     }
     db.prepare('INSERT OR REPLACE INTO server_settings (key, value) VALUES (?, ?)').run('server_code', '');
-    io.emit('server-setting-changed', { key: 'server_code', value: '' });
+    io.except('bot-sockets').emit('server-setting-changed', { key: 'server_code', value: '' });
     socket.emit('error-msg', 'Server invite code cleared');
   });
 
@@ -679,7 +679,7 @@ module.exports = function register(socket, ctx) {
     }
     const token = crypto.randomBytes(8).toString('hex');
     db.prepare('INSERT OR REPLACE INTO server_settings (key, value) VALUES (?, ?)').run('registration_token', token);
-    io.emit('server-setting-changed', { key: 'registration_token', value: token });
+    io.except('bot-sockets').emit('server-setting-changed', { key: 'registration_token', value: token });
     socket.emit('error-msg', `Registration token generated: ${token}`);
   });
 
@@ -688,7 +688,7 @@ module.exports = function register(socket, ctx) {
       return socket.emit('error-msg', 'Only admins can manage the registration token');
     }
     db.prepare('INSERT OR REPLACE INTO server_settings (key, value) VALUES (?, ?)').run('registration_token', '');
-    io.emit('server-setting-changed', { key: 'registration_token', value: '' });
+    io.except('bot-sockets').emit('server-setting-changed', { key: 'registration_token', value: '' });
     socket.emit('error-msg', 'Registration token cleared');
   });
 
@@ -709,6 +709,12 @@ module.exports = function register(socket, ctx) {
   // Two calling conventions:
   //   Bot-manager modal: uses data.channel_id (integer), data.id for delete/toggle
   //   Per-channel modal: uses data.channelCode (string), data.webhookId for delete/toggle
+
+  const visibleWebhookRows = rows => rows.map(webhook =>
+    socket.user.isAdmin || webhook.created_by === socket.user.id
+      ? webhook
+      : { ...webhook, token: null }
+  );
 
   socket.on('create-webhook', (data) => {
     if (!data || typeof data !== 'object') return;
@@ -756,15 +762,15 @@ module.exports = function register(socket, ctx) {
         'INSERT INTO webhooks (channel_id, name, token, avatar_url, created_by) VALUES (?, ?, ?, ?, ?)'
       ).run(channelId, name, token, avatarUrl, socket.user.id);
 
-      const webhooks = db.prepare(`
-        SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at,
+      const webhooks = visibleWebhookRows(db.prepare(`
+        SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at, w.created_by,
                w.callback_url, w.callback_secret,
                w.subscribed_events, w.last_delivery_status, w.last_delivery_at,
-               w.last_delivery_error, w.failure_count, w.can_moderate,
+               w.last_delivery_error, w.failure_count, w.can_moderate, w.can_use_voice,
                c.name as channel_name, c.code as channel_code
         FROM webhooks w JOIN channels c ON w.channel_id = c.id
         ORDER BY w.created_at DESC
-      `).all();
+      `).all());
       socket.emit('webhooks-list', { webhooks });
       socket.emit('error-msg', `Webhook "${name}" created for #${channel.name}`);
     }
@@ -782,21 +788,21 @@ module.exports = function register(socket, ctx) {
       const channel = db.prepare('SELECT id FROM channels WHERE code = ?').get(channelCode);
       if (!channel) return;
 
-      const webhooks = db.prepare(
-        'SELECT id, channel_id, name, token, avatar_url, is_active, created_at, callback_url, callback_secret, subscribed_events, last_delivery_status, last_delivery_at, last_delivery_error, failure_count, can_moderate FROM webhooks WHERE channel_id = ? ORDER BY created_at DESC'
-      ).all(channel.id);
+      const webhooks = visibleWebhookRows(db.prepare(
+        'SELECT id, channel_id, name, token, avatar_url, is_active, created_at, created_by, callback_url, callback_secret, subscribed_events, last_delivery_status, last_delivery_at, last_delivery_error, failure_count, can_moderate, can_use_voice FROM webhooks WHERE channel_id = ? ORDER BY created_at DESC'
+      ).all(channel.id));
       socket.emit('webhooks-list', { channelCode, webhooks });
     } else {
       // Bot-manager variant (all webhooks)
-      const webhooks = db.prepare(`
-        SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at,
+      const webhooks = visibleWebhookRows(db.prepare(`
+        SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at, w.created_by,
                w.callback_url, w.callback_secret,
                w.subscribed_events, w.last_delivery_status, w.last_delivery_at,
-               w.last_delivery_error, w.failure_count, w.can_moderate,
+               w.last_delivery_error, w.failure_count, w.can_moderate, w.can_use_voice,
                c.name as channel_name, c.code as channel_code
         FROM webhooks w JOIN channels c ON w.channel_id = c.id
         ORDER BY w.created_at DESC
-      `).all();
+      `).all());
       socket.emit('webhooks-list', { webhooks });
     }
   });
@@ -810,6 +816,7 @@ module.exports = function register(socket, ctx) {
     const webhookId = parseInt(data.webhookId || data.id);
     if (!webhookId || isNaN(webhookId)) return;
 
+    revokeBotVoiceAccess?.(webhookId, 'Webhook was deleted');
     db.prepare('DELETE FROM webhooks WHERE id = ?').run(webhookId);
 
     if (data.webhookId) {
@@ -817,15 +824,15 @@ module.exports = function register(socket, ctx) {
       socket.emit('webhook-deleted', { webhookId });
     } else {
       // Bot-manager response — return full list
-      const webhooks = db.prepare(`
-        SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at,
+      const webhooks = visibleWebhookRows(db.prepare(`
+        SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at, w.created_by,
                w.callback_url, w.callback_secret,
                w.subscribed_events, w.last_delivery_status, w.last_delivery_at,
-               w.last_delivery_error, w.failure_count, w.can_moderate,
+               w.last_delivery_error, w.failure_count, w.can_moderate, w.can_use_voice,
                c.name as channel_name, c.code as channel_code
         FROM webhooks w JOIN channels c ON w.channel_id = c.id
         ORDER BY w.created_at DESC
-      `).all();
+      `).all());
       socket.emit('webhooks-list', { webhooks });
       socket.emit('error-msg', 'Webhook deleted');
     }
@@ -843,21 +850,22 @@ module.exports = function register(socket, ctx) {
     if (!wh) return socket.emit('error-msg', 'Webhook not found');
     const newState = wh.is_active ? 0 : 1;
     db.prepare('UPDATE webhooks SET is_active = ? WHERE id = ?').run(newState, webhookId);
+    if (!newState) revokeBotVoiceAccess?.(webhookId, 'Webhook was disabled');
 
     if (data.webhookId) {
       // Per-channel response
       socket.emit('webhook-toggled', { webhookId, is_active: newState });
     } else {
       // Bot-manager response — return full list
-      const webhooks = db.prepare(`
-        SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at,
+      const webhooks = visibleWebhookRows(db.prepare(`
+        SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at, w.created_by,
                w.callback_url, w.callback_secret,
                w.subscribed_events, w.last_delivery_status, w.last_delivery_at,
-               w.last_delivery_error, w.failure_count, w.can_moderate,
+               w.last_delivery_error, w.failure_count, w.can_moderate, w.can_use_voice,
                c.name as channel_name, c.code as channel_code
         FROM webhooks w JOIN channels c ON w.channel_id = c.id
         ORDER BY w.created_at DESC
-      `).all();
+      `).all());
       socket.emit('webhooks-list', { webhooks });
     }
   });
@@ -871,6 +879,17 @@ module.exports = function register(socket, ctx) {
     const wh = db.prepare('SELECT * FROM webhooks WHERE id = ?').get(webhookId);
     if (!wh) return socket.emit('error-msg', 'Webhook not found');
 
+    if (data.can_use_voice !== undefined && !socket.user.isAdmin) {
+      return socket.emit('error-msg', 'Only admins can change a bot\'s voice permission');
+    }
+
+    if (data.channel_id !== undefined) {
+      const requestedChannelId = parseInt(data.channel_id);
+      if (!socket.user.isAdmin && requestedChannelId !== wh.channel_id && (wh.can_use_voice || wh.can_moderate)) {
+        return socket.emit('error-msg', 'Only admins can move a bot with privileged permissions');
+      }
+    }
+
     if (typeof data.name === 'string' && data.name.trim()) {
       db.prepare('UPDATE webhooks SET name = ? WHERE id = ?').run(data.name.trim().slice(0, 32), webhookId);
     }
@@ -878,7 +897,10 @@ module.exports = function register(socket, ctx) {
       const channelId = parseInt(data.channel_id);
       if (!isNaN(channelId)) {
         const channel = db.prepare('SELECT id FROM channels WHERE id = ?').get(channelId);
-        if (channel) db.prepare('UPDATE webhooks SET channel_id = ? WHERE id = ?').run(channelId, webhookId);
+        if (channel) {
+          db.prepare('UPDATE webhooks SET channel_id = ? WHERE id = ?').run(channelId, webhookId);
+          if (channelId !== wh.channel_id) revokeBotVoiceAccess?.(webhookId, 'Webhook voice channel scope changed');
+        }
       }
     }
     if (data.avatar_url !== undefined) {
@@ -921,16 +943,21 @@ module.exports = function register(socket, ctx) {
       const flag = data.can_moderate ? 1 : 0;
       db.prepare('UPDATE webhooks SET can_moderate = ? WHERE id = ?').run(flag, webhookId);
     }
+    if (data.can_use_voice !== undefined) {
+      const flag = data.can_use_voice ? 1 : 0;
+      db.prepare('UPDATE webhooks SET can_use_voice = ? WHERE id = ?').run(flag, webhookId);
+      if (!flag) revokeBotVoiceAccess?.(webhookId, 'Bot voice permission was revoked');
+    }
 
-    const webhooks = db.prepare(`
-      SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at,
+    const webhooks = visibleWebhookRows(db.prepare(`
+      SELECT w.id, w.channel_id, w.name, w.token, w.avatar_url, w.is_active, w.created_at, w.created_by,
              w.callback_url, w.callback_secret,
              w.subscribed_events, w.last_delivery_status, w.last_delivery_at,
-             w.last_delivery_error, w.failure_count, w.can_moderate,
+             w.last_delivery_error, w.failure_count, w.can_moderate, w.can_use_voice,
              c.name as channel_name, c.code as channel_code
       FROM webhooks w JOIN channels c ON w.channel_id = c.id
       ORDER BY w.created_at DESC
-    `).all();
+    `).all());
     socket.emit('webhooks-list', { webhooks });
     socket.emit('bot-updated', 'Bot updated');
   });
@@ -1236,7 +1263,7 @@ module.exports = function register(socket, ctx) {
       const payload = automod.enabled()
         ? Object.assign(automod.policy(), { enabled: true, scanDms: s.automod_scan_dms === 'true' })
         : { enabled: false, mode: 'off', allow: [], deny: [], scanDms: false };
-      io.emit('link-policy', payload);
+      io.except('bot-sockets').emit('link-policy', payload);
     } catch { /* non-critical */ }
   }
 

--- a/src/socketHandlers/channels.js
+++ b/src/socketHandlers/channels.js
@@ -254,7 +254,7 @@ module.exports = function register(socket, ctx) {
       // connected sockets so it appears for them without a refresh. (#5271)
       if (data.addAllMembers && !isPrivate) {
         for (const [, s] of io.sockets.sockets) {
-          if (!s.user || s.user.id === socket.user.id) continue;
+          if (!s.user || s.user.isBot || s.user.id === socket.user.id) continue;
           s.join(`channel:${code}`);
           s.emit('channel-created', channel);
         }
@@ -308,9 +308,9 @@ module.exports = function register(socket, ctx) {
       };
 
       for (const [, s] of io.sockets.sockets) {
-        if (s.user) s.join(`channel:${code}`);
+        if (s.user && !s.user.isBot) s.join(`channel:${code}`);
       }
-      io.emit('temp-channel-created', channel);
+      io.except('bot-sockets').emit('temp-channel-created', channel);
       socket.emit('temp-channel-join-voice', { code });
     } catch (err) {
       console.error('Create temp channel error:', err);

--- a/src/socketHandlers/index.js
+++ b/src/socketHandlers/index.js
@@ -28,6 +28,14 @@ const {
   rotateLiveChannelState,
   schedulePendingVoiceLeave
 } = require('../channelRotation');
+const {
+  disconnectBotVoiceSocket,
+  disconnectDuplicateBotSockets,
+  getBotVoiceWebhookByToken,
+  isolateBotVoiceSocket,
+  reconcileBotVoiceAccess,
+  registerBotVoiceSocket
+} = require('../botVoice');
 
 const { createActivity } = require('../activity');
 
@@ -148,7 +156,7 @@ function setupSocketHandlers(io, db, opts = {}) {
     db,
     getOnlineUserIds: () => {
       const ids = new Set();
-      for (const [, s] of io.of('/').sockets) if (s.user) ids.add(s.user.id);
+      for (const [, s] of io.of('/').sockets) if (s.user && !s.user.isBot) ids.add(s.user.id);
       return Array.from(ids);
     },
     // A user's activity changed → re-broadcast presence for whatever channel
@@ -605,7 +613,7 @@ function setupSocketHandlers(io, db, opts = {}) {
     _broadcastPending = setTimeout(() => {
       _broadcastPending = null;
       for (const [, s] of io.sockets.sockets) {
-        if (s.user) {
+        if (s.user && !s.user.isBot) {
           s.emit('channels-list', getEnrichedChannels(s.user.id, s.user.isAdmin, null));
         }
       }
@@ -710,14 +718,19 @@ function setupSocketHandlers(io, db, opts = {}) {
             roleColor: role ? role.color : null,
             roleName: role ? role.name : null,
             roles,
-            isMuted: u.isMuted || false, isDeafened: u.isDeafened || false
+            isMuted: u.isMuted || false, isDeafened: u.isDeafened || false,
+            isBot: !!u.isBot, isListening: !!u.isListening
           };
         })
       : [];
     io.to(`voice:${code}`).to(`channel:${code}`).emit('voice-users-update', { channelCode: code, users });
-    io.emit('voice-count-update', {
+    io.except('bot-sockets').emit('voice-count-update', {
       code, count: users.length,
-      users: users.map(u => ({ id: u.id, username: u.username, isMuted: u.isMuted || false, isDeafened: u.isDeafened || false }))
+      users: users.map(u => ({
+        id: u.id, username: u.username,
+        isMuted: u.isMuted || false, isDeafened: u.isDeafened || false,
+        isBot: !!u.isBot, isListening: !!u.isListening
+      }))
     });
   }
 
@@ -981,6 +994,18 @@ function setupSocketHandlers(io, db, opts = {}) {
     }
     if (!stillInVoice) voiceLastActivity.delete(socket.user.id);
   }
+
+  function revokeBotVoiceAccess(webhookId, reason = 'Bot voice access was revoked') {
+    for (const [, botSocket] of Array.from(io.sockets.sockets.entries())) {
+      if (!botSocket.user?.isBot || botSocket.user.webhookId !== webhookId) continue;
+      disconnectBotVoiceSocket(botSocket, { state, handleVoiceLeave }, reason);
+    }
+  }
+
+  const botVoiceReconciliationTimer = setInterval(() => {
+    reconcileBotVoiceAccess(io, db, state, revokeBotVoiceAccess);
+  }, 2000);
+  botVoiceReconciliationTimer.unref?.();
 
   // ── Push notification helper ────────────────────────────
   function sendPushNotifications(channelId, channelCode, channelName, senderUserId, senderUsername, messageContent) {
@@ -1414,7 +1439,27 @@ function setupSocketHandlers(io, db, opts = {}) {
 
   // Auth middleware
   io.use((socket, next) => {
-    const token = socket.handshake.auth.token;
+    const botToken = socket.handshake.auth?.botToken;
+    if (botToken !== undefined) {
+      const webhook = getBotVoiceWebhookByToken(db, botToken);
+      if (!webhook) return next(new Error('Webhook not found or inactive'));
+      if (!webhook.can_use_voice) return next(new Error('Bot voice permission is disabled'));
+      socket.user = {
+        id: -webhook.id,
+        webhookId: webhook.id,
+        botToken,
+        username: `bot-${webhook.id}`,
+        displayName: webhook.name,
+        channelId: webhook.channel_id,
+        channelCode: webhook.channel_code,
+        isBot: true,
+        isAdmin: false,
+        isGuest: false
+      };
+      return next();
+    }
+
+    const token = socket.handshake.auth?.token;
     if (!token || typeof token !== 'string') return next(new Error('Authentication required'));
 
     const user = verifyToken(token);
@@ -1539,6 +1584,16 @@ function setupSocketHandlers(io, db, opts = {}) {
       return;
     }
 
+    if (socket.user.isBot) {
+      console.log(`Bot ${socket.user.displayName} connected to the voice gateway`);
+      disconnectDuplicateBotSockets(socket, { io, state, handleVoiceLeave });
+      isolateBotVoiceSocket(socket);
+      registerBotVoiceSocket(socket, {
+        io, db, state, broadcastVoiceUsers, handleVoiceLeave, revokeBotVoiceAccess
+      });
+      return;
+    }
+
     // Stamped here rather than read from the token: the token's iat is when
     // you signed in, which can be weeks before this tab opened.
     if (socket.handshake) socket.handshake.issued = Date.now();
@@ -1631,7 +1686,9 @@ function setupSocketHandlers(io, db, opts = {}) {
       const room = voiceUsers.get(code);
       if (room && room.size > 0) {
         const users = Array.from(room.values()).map(u => ({
-          id: u.id, username: u.username, isMuted: u.isMuted || false, isDeafened: u.isDeafened || false
+          id: u.id, username: u.username,
+          isMuted: u.isMuted || false, isDeafened: u.isDeafened || false,
+          isBot: !!u.isBot, isListening: !!u.isListening
         }));
         socket.emit('voice-count-update', { code, count: room.size, users });
       } else {
@@ -1955,7 +2012,7 @@ function setupSocketHandlers(io, db, opts = {}) {
       // Transfer admin mutex
       transferAdminRef,
       // Audit log
-      logAudit,
+      logAudit, revokeBotVoiceAccess,
       // Auto-moderation (v3.42.0)
       automod,
       enforceAutomod,
@@ -2101,7 +2158,7 @@ function setupSocketHandlers(io, db, opts = {}) {
 
   // Handed back so server.js can mount the account-linking HTTP routes against
   // the same engine instance the socket layer is using.
-  return { activity };
+  return { activity, state };
 }
 
 module.exports = { setupSocketHandlers, sanitizeText, sanitizeBorderTransform };

--- a/src/socketHandlers/roles.js
+++ b/src/socketHandlers/roles.js
@@ -220,7 +220,7 @@ module.exports = function register(socket, ctx) {
     // Refresh every live display: member lists re-read getUserHighestRole and
     // clients re-fetch role-driven UI on roles-updated.
     for (const [code] of channelUsers) { emitOnlineUsers(code); }
-    io.emit('roles-updated');
+    io.except('bot-sockets').emit('roles-updated');
 
     cb({ success: true, display: { name, color, icon, visible } });
     _audit({ actor: socket.user, action: 'admin_role_display_update',
@@ -398,7 +398,7 @@ module.exports = function register(socket, ctx) {
     if (roleGrantsSeeAll(roleId)) for (const row of affected) pushChannelList(row.user_id);
     else for (const row of affected) syncSeeAllMemberships(row.user_id);
 
-    socket.broadcast.emit('roles-updated');
+    socket.broadcast.except('bot-sockets').emit('roles-updated');
     cb({ success: true, roles: freshRoles });
     _audit({ actor: socket.user, action: 'role_update',
       target_type: 'role', target_id: roleId, target_name: role.name,
@@ -477,9 +477,9 @@ module.exports = function register(socket, ctx) {
       // the payload-less broadcast below only nudges open role managers.
       const seen = new Set();
       for (const [, s] of io.sockets.sockets) {
-        if (s.user && !seen.has(s.user.id)) { seen.add(s.user.id); pushUserRoleState(s.user.id); }
+        if (s.user && !s.user.isBot && !seen.has(s.user.id)) { seen.add(s.user.id); pushUserRoleState(s.user.id); }
       }
-      io.emit('roles-updated');
+      io.except('bot-sockets').emit('roles-updated');
       cb({ success: true });
     } catch (err) {
       cb({ error: 'Failed to reset roles: ' + err.message });

--- a/src/socketHandlers/users.js
+++ b/src/socketHandlers/users.js
@@ -797,7 +797,7 @@ module.exports = function register(socket, ctx) {
         )
       ORDER BY hs.score DESC LIMIT 50
     `).all(game);
-    io.emit('high-scores', { game, leaderboard });
+    io.except('bot-sockets').emit('high-scores', { game, leaderboard });
   });
 
   socket.on('get-high-scores', (data) => {

--- a/src/socketHandlers/voice.js
+++ b/src/socketHandlers/voice.js
@@ -11,6 +11,20 @@ module.exports = function register(socket, ctx) {
           activeScreenSharers, activeWebcamUsers, streamViewers, pendingTempDelete,
           pendingVoiceLeave } = state;
 
+  const serializeVoicePeer = user => ({
+    id: user.id,
+    username: user.username,
+    isMuted: !!user.isMuted,
+    isDeafened: !!user.isDeafened,
+    isBot: !!user.isBot,
+    isListening: !!user.isListening
+  });
+
+  function serializeVoiceRosterUser(user, channelId) {
+    const role = getUserHighestRole(user.id, channelId);
+    return { ...serializeVoicePeer(user), roleColor: role ? role.color : null };
+  }
+
   // ── Local helper: broadcast stream/viewer info ──────────
   function broadcastStreamInfo(code) {
     const voiceRoom = voiceUsers.get(code);
@@ -148,7 +162,7 @@ module.exports = function register(socket, ctx) {
 
     socket.emit('voice-existing-users', {
       channelCode: code,
-      users: existingUsers.map(u => ({ id: u.id, username: u.username })),
+      users: existingUsers.map(serializeVoicePeer),
       voiceBitrate: vchSettings ? (vchSettings.voice_bitrate || 0) : 0
     });
 
@@ -512,10 +526,7 @@ module.exports = function register(socket, ctx) {
     const channelId = channel ? channel.id : null;
     const room = voiceUsers.get(code);
     const users = room
-      ? Array.from(room.values()).map(u => {
-          const role = getUserHighestRole(u.id, channelId);
-          return { id: u.id, username: u.username, roleColor: role ? role.color : null, isMuted: u.isMuted || false, isDeafened: u.isDeafened || false };
-        })
+      ? Array.from(room.values()).map(u => serializeVoiceRosterUser(u, channelId))
       : [];
     // Diagnostic for the recurring "I vanished from my own voice panel"
     // bug. If the client claims to be in voice on this channel but the
@@ -584,7 +595,7 @@ module.exports = function register(socket, ctx) {
             const vchSettings = db.prepare('SELECT voice_bitrate FROM channels WHERE code = ?').get(code);
             socket.emit('voice-existing-users', {
               channelCode: code,
-              users: existingUsers.map(u => ({ id: u.id, username: u.username })),
+              users: existingUsers.map(serializeVoicePeer),
               voiceBitrate: vchSettings ? (vchSettings.voice_bitrate || 0) : 0
             });
             // Notify existing peers that we're (back) in the room so
@@ -601,10 +612,7 @@ module.exports = function register(socket, ctx) {
             // Re-fetch the room so the response below includes us.
             const healedRoom = voiceUsers.get(code);
             const healedUsers = healedRoom
-              ? Array.from(healedRoom.values()).map(u => {
-                  const role = getUserHighestRole(u.id, vch.id);
-                  return { id: u.id, username: u.username, roleColor: role ? role.color : null, isMuted: u.isMuted || false, isDeafened: u.isDeafened || false };
-                })
+              ? Array.from(healedRoom.values()).map(u => serializeVoiceRosterUser(u, vch.id))
               : [];
             socket.emit('voice-users-update', { channelCode: code, users: healedUsers });
             return; // We've already sent the update — don't double-send below.
@@ -739,7 +747,7 @@ module.exports = function register(socket, ctx) {
         const vchSettings = db.prepare('SELECT voice_bitrate FROM channels WHERE code = ?').get(code);
         socket.emit('voice-existing-users', {
           channelCode: code,
-          users: existingUsers.map(u => ({ id: u.id, username: u.username })),
+          users: existingUsers.map(serializeVoicePeer),
           voiceBitrate: vchSettings ? (vchSettings.voice_bitrate || 0) : 0,
           // Hint to the client: skip building new RTCPeerConnections —
           // existing ones from before the blip are still live.
@@ -774,7 +782,7 @@ module.exports = function register(socket, ctx) {
       const vchSettings = db.prepare('SELECT voice_bitrate FROM channels WHERE code = ?').get(code);
       socket.emit('voice-existing-users', {
         channelCode: code,
-        users: existingUsers.map(u => ({ id: u.id, username: u.username })),
+        users: existingUsers.map(serializeVoicePeer),
         voiceBitrate: vchSettings ? (vchSettings.voice_bitrate || 0) : 0,
         skipRenegotiate: true
       });
@@ -845,7 +853,7 @@ module.exports = function register(socket, ctx) {
     const vchSettings = db.prepare('SELECT voice_bitrate FROM channels WHERE code = ?').get(code);
     socket.emit('voice-existing-users', {
       channelCode: code,
-      users: existingUsers.map(u => ({ id: u.id, username: u.username })),
+      users: existingUsers.map(serializeVoicePeer),
       voiceBitrate: vchSettings ? (vchSettings.voice_bitrate || 0) : 0
     });
 
@@ -929,7 +937,7 @@ module.exports = function register(socket, ctx) {
       const removed = pruneStaleVoiceUsers(code);
       const room = voiceUsers.get(code);
       if (room && room.size > 0) {
-        const users = Array.from(room.values()).map(u => ({ id: u.id, username: u.username, isMuted: u.isMuted || false, isDeafened: u.isDeafened || false }));
+        const users = Array.from(room.values()).map(serializeVoicePeer);
         socket.emit('voice-count-update', { code, count: room.size, users });
         if (removed.length) broadcastVoiceUsers(code);
       } else {

--- a/test/botVoice.test.js
+++ b/test/botVoice.test.js
@@ -1,0 +1,518 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const Database = require('better-sqlite3');
+
+const {
+  disconnectDuplicateBotSockets,
+  getAccessibleVoiceChannels,
+  getBotVoiceAccessFailure,
+  isolateBotVoiceSocket,
+  reconcileBotVoiceAccess,
+  registerBotVoiceSocket
+} = require('../src/botVoice');
+const registerAdmin = require('../src/socketHandlers/admin');
+const registerVoice = require('../src/socketHandlers/voice');
+
+const BOT_TOKEN = 'a'.repeat(64);
+
+function createDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE users (id INTEGER PRIMARY KEY, is_admin INTEGER DEFAULT 0);
+    CREATE TABLE channels (
+      id INTEGER PRIMARY KEY,
+      code TEXT,
+      name TEXT,
+      is_dm INTEGER DEFAULT 0,
+      position INTEGER DEFAULT 0,
+      voice_enabled INTEGER DEFAULT 1,
+      voice_user_limit INTEGER DEFAULT 0,
+      voice_bitrate INTEGER DEFAULT 0
+    );
+    CREATE TABLE channel_members (channel_id INTEGER, user_id INTEGER);
+    CREATE TABLE webhooks (
+      id INTEGER PRIMARY KEY,
+      name TEXT,
+      token TEXT,
+      channel_id INTEGER,
+      created_by INTEGER,
+      avatar_url TEXT,
+      is_active INTEGER DEFAULT 1,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      callback_url TEXT,
+      callback_secret TEXT,
+      subscribed_events TEXT DEFAULT '*',
+      last_delivery_status INTEGER,
+      last_delivery_at TEXT,
+      last_delivery_error TEXT,
+      failure_count INTEGER DEFAULT 0,
+      can_moderate INTEGER DEFAULT 0,
+      can_use_voice INTEGER DEFAULT 0
+    );
+    CREATE TABLE server_settings (key TEXT PRIMARY KEY, value TEXT);
+  `);
+  db.prepare('INSERT INTO users (id, is_admin) VALUES (?, ?)').run(10, 0);
+  db.prepare('INSERT INTO users (id, is_admin) VALUES (?, ?)').run(11, 1);
+  const insertChannel = db.prepare(`
+    INSERT INTO channels (id, code, name, is_dm, position, voice_enabled, voice_user_limit, voice_bitrate)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  insertChannel.run(1, '11111111', 'Assigned', 0, 1, 1, 0, 64);
+  insertChannel.run(2, '22222222', 'Member', 0, 2, 1, 0, 64);
+  insertChannel.run(3, '33333333', 'Private DM', 1, 3, 1, 0, 64);
+  insertChannel.run(4, '44444444', 'Restricted', 0, 4, 1, 0, 64);
+  db.prepare('INSERT INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(2, 10);
+  return db;
+}
+
+function insertBot(db, overrides = {}) {
+  const bot = {
+    id: 7,
+    name: 'Listener',
+    token: BOT_TOKEN,
+    channel_id: 1,
+    created_by: 10,
+    is_active: 1,
+    can_use_voice: 1,
+    ...overrides
+  };
+  db.prepare(`
+    INSERT INTO webhooks (id, name, token, channel_id, created_by, is_active, can_use_voice)
+    VALUES (@id, @name, @token, @channel_id, @created_by, @is_active, @can_use_voice)
+  `).run(bot);
+  return bot;
+}
+
+function createSocket(id = 'bot-socket') {
+  const outgoing = [];
+  const handlers = new Map();
+  const rooms = new Set([id]);
+  let packetMiddleware = null;
+  const socket = {
+    id,
+    connected: true,
+    outgoing,
+    handlers,
+    rooms,
+    user: {
+      id: -7,
+      webhookId: 7,
+      botToken: BOT_TOKEN,
+      username: 'bot-7',
+      displayName: 'Listener',
+      channelCode: '11111111',
+      isBot: true
+    },
+    on(event, handler) { handlers.set(event, handler); },
+    emit(event, payload) { outgoing.push({ target: id, event, payload }); },
+    use(handler) { packetMiddleware = handler; },
+    disconnect() { this.connected = false; },
+    join(room) {
+      const joined = Array.isArray(room) ? room : [room];
+      for (const item of joined) rooms.add(item);
+      outgoing.push({ target: 'join', event: room });
+      return Promise.resolve();
+    },
+    leave(room) {
+      rooms.delete(room);
+      outgoing.push({ target: 'leave', event: room });
+      return Promise.resolve();
+    },
+    get packetMiddleware() { return packetMiddleware; }
+  };
+  return socket;
+}
+
+function createGatewayHarness(db, initialVoiceUsers = null) {
+  const outgoing = [];
+  const sockets = new Map();
+  const io = {
+    sockets: { sockets },
+    to(target) {
+      return {
+        emit(event, payload) { outgoing.push({ target, event, payload }); }
+      };
+    }
+  };
+  const state = {
+    voiceUsers: initialVoiceUsers || new Map(),
+    voiceLastActivity: new Map()
+  };
+  let broadcasts = 0;
+  function handleVoiceLeave(socket, code) {
+    const room = state.voiceUsers.get(code);
+    if (room?.get(socket.user.id)?.socketId !== socket.id) return;
+    room.delete(socket.user.id);
+    socket.leave(`voice:${code}`);
+    if (room.size === 0) state.voiceUsers.delete(code);
+    state.voiceLastActivity.delete(socket.user.id);
+  }
+  function register(socket) {
+    sockets.set(socket.id, socket);
+    registerBotVoiceSocket(socket, {
+      io,
+      db,
+      state,
+      broadcastVoiceUsers() { broadcasts++; },
+      handleVoiceLeave
+    });
+    return socket;
+  }
+  return { io, state, outgoing, register, handleVoiceLeave, get broadcasts() { return broadcasts; } };
+}
+
+function createAdminHarness(db, user, io = null) {
+  const handlers = new Map();
+  const outgoing = [];
+  const socket = {
+    user,
+    on(event, handler) { handlers.set(event, handler); },
+    emit(event, payload) { outgoing.push({ event, payload }); }
+  };
+  const actualIo = io || {
+    sockets: { sockets: new Map() },
+    of() { return { sockets: new Map() }; },
+    except() { return { emit() {} }; }
+  };
+  const revoked = [];
+  registerAdmin(socket, {
+    io: actualIo,
+    db,
+    state: { channelUsers: new Map() },
+    userHasPermission: () => true,
+    getUserEffectiveLevel: () => 0,
+    getUserPermissions: () => [],
+    getUserRoles: () => [],
+    getUserHighestRole: () => null,
+    emitOnlineUsers() {},
+    broadcastChannelLists() {},
+    generateUniqueSharedCode: () => '99999999',
+    logAudit() {},
+    fireWebhookEvent() {},
+    onReferrerPolicyChange() {},
+    automod: { invalidate() {}, settings: () => ({}) },
+    getIdleOnlineUsers: () => [],
+    getUploadUsage: () => ({ byUser: new Map() }),
+    revokeBotVoiceAccess(webhookId, reason) { revoked.push({ webhookId, reason }); }
+  });
+  return { handlers, outgoing, revoked };
+}
+
+test('voice channel access is scoped to assignment, membership, or admin ownership', t => {
+  const db = createDb();
+  t.after(() => db.close());
+
+  const memberChannels = getAccessibleVoiceChannels(db, { channel_id: 1, created_by: 10 });
+  assert.deepEqual(memberChannels.map(channel => channel.code), ['11111111', '22222222']);
+
+  const adminChannels = getAccessibleVoiceChannels(db, { channel_id: 1, created_by: 11 });
+  assert.deepEqual(adminChannels.map(channel => channel.code), ['11111111', '22222222', '44444444']);
+});
+
+test('active bot access detects token, membership, channel, and permission revocation', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db);
+
+  assert.equal(getBotVoiceAccessFailure(db, 7, ['11111111', '22222222'], BOT_TOKEN), null);
+  db.prepare('DELETE FROM channel_members WHERE channel_id = 2 AND user_id = 10').run();
+  assert.match(getBotVoiceAccessFailure(db, 7, ['22222222'], BOT_TOKEN), /no longer has access/);
+  db.prepare('UPDATE channels SET voice_enabled = 0 WHERE id = 1').run();
+  assert.match(getBotVoiceAccessFailure(db, 7, ['11111111'], BOT_TOKEN), /Voice was disabled/);
+  assert.equal(getBotVoiceAccessFailure(db, 7, [], BOT_TOKEN), null);
+  db.prepare("UPDATE webhooks SET token = ? WHERE id = 7").run('b'.repeat(64));
+  assert.match(getBotVoiceAccessFailure(db, 7, [], BOT_TOKEN), /token was rotated/);
+  db.prepare('UPDATE webhooks SET token = ?, can_use_voice = 0 WHERE id = 7').run(BOT_TOKEN);
+  assert.match(getBotVoiceAccessFailure(db, 7, [], BOT_TOKEN), /permission was revoked/);
+});
+
+test('bot voice gateway joins visibly, relays authorized signaling, and refreshes AFK activity', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db);
+  const room = new Map([[
+    42,
+    { id: 42, username: 'Human', socketId: 'human-socket', isMuted: false, isDeafened: false }
+  ]]);
+  const harness = createGatewayHarness(db, new Map([['11111111', room]]));
+  const socket = harness.register(createSocket());
+
+  let acknowledgement;
+  socket.handlers.get('voice-join')({ code: '11111111' }, result => { acknowledgement = result; });
+  assert.equal(acknowledgement.success, true);
+  assert.equal(harness.state.voiceUsers.get('11111111').get(-7).isListening, true);
+  assert.equal(harness.broadcasts, 1);
+  assert.ok(harness.outgoing.some(item =>
+    item.target === 'human-socket' && item.event === 'voice-user-joined' && item.payload.user.isBot
+  ));
+
+  socket.handlers.get('voice-offer')({
+    code: '11111111',
+    targetUserId: 42,
+    offer: { type: 'offer', sdp: 'test' }
+  });
+  assert.ok(harness.outgoing.some(item =>
+    item.target === 'human-socket' && item.event === 'voice-offer' && item.payload.from.isBot
+  ));
+
+  harness.state.voiceLastActivity.set(-7, 1);
+  socket.handlers.get('voice-speaking')({ speaking: true });
+  assert.ok(harness.state.voiceLastActivity.get(-7) > 1);
+  harness.state.voiceLastActivity.set(-7, 1);
+  socket.handlers.get('voice-activity')();
+  assert.ok(harness.state.voiceLastActivity.get(-7) > 1);
+
+  db.prepare('UPDATE webhooks SET can_use_voice = 0 WHERE id = 7').run();
+  let middlewareError;
+  socket.packetMiddleware(['voice-speaking', { speaking: true }], error => { middlewareError = error; });
+  assert.match(middlewareError.message, /permission was revoked/);
+  assert.equal(socket.connected, false);
+  assert.equal(harness.state.voiceUsers.get('11111111').has(-7), false);
+});
+
+test('a replaced bot socket is disconnected and cannot signal as its replacement', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db);
+  const room = new Map([[
+    42,
+    { id: 42, username: 'Human', socketId: 'human-socket', isMuted: false, isDeafened: false }
+  ]]);
+  const harness = createGatewayHarness(db, new Map([['11111111', room]]));
+  const first = harness.register(createSocket('bot-old'));
+  first.handlers.get('voice-join')({ code: '11111111' }, () => {});
+  const second = harness.register(createSocket('bot-new'));
+  second.handlers.get('voice-join')({ code: '11111111' }, () => {});
+
+  assert.equal(first.connected, false);
+  assert.equal(harness.state.voiceUsers.get('11111111').get(-7).socketId, 'bot-new');
+  const before = harness.outgoing.length;
+  first.handlers.get('voice-offer')({
+    code: '11111111', targetUserId: 42, offer: { type: 'offer', sdp: 'stale' }
+  });
+  assert.equal(harness.outgoing.length, before);
+});
+
+test('a failed join to a full channel keeps the bot in its current channel', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db);
+  db.prepare('UPDATE channels SET voice_user_limit = 1 WHERE id = 2').run();
+  const harness = createGatewayHarness(db, new Map([
+    ['11111111', new Map()],
+    ['22222222', new Map([[42, { id: 42, username: 'Human', socketId: 'human-socket' }]])]
+  ]));
+  const socket = harness.register(createSocket());
+
+  socket.handlers.get('voice-join')({ code: '11111111' }, () => {});
+  let result;
+  socket.handlers.get('voice-join')({ code: '22222222' }, response => { result = response; });
+  assert.match(result.error, /Voice is full/);
+  assert.equal(harness.state.voiceUsers.get('11111111').get(-7).socketId, socket.id);
+});
+
+test('a voice-disabled channel rejects join without leaving the current channel', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db);
+  db.prepare('UPDATE channels SET voice_enabled = 0 WHERE id = 2').run();
+  const harness = createGatewayHarness(db);
+  const socket = harness.register(createSocket());
+  socket.handlers.get('voice-join')({ code: '11111111' }, () => {});
+
+  let result;
+  socket.handlers.get('voice-join')({ code: '22222222' }, response => { result = response; });
+  assert.match(result.error, /Voice is disabled/);
+  assert.equal(harness.state.voiceUsers.get('11111111').get(-7).socketId, socket.id);
+});
+
+test('periodic reconciliation revokes an idle bot without waiting for another packet', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db);
+  const socket = createSocket();
+  socket.rooms.add('voice:11111111');
+  const io = { sockets: { sockets: new Map([[socket.id, socket]]) } };
+  const state = { voiceUsers: new Map() };
+  db.prepare('UPDATE webhooks SET can_use_voice = 0 WHERE id = 7').run();
+  const revoked = [];
+
+  const count = reconcileBotVoiceAccess(io, db, state, (webhookId, reason) => {
+    revoked.push({ webhookId, reason });
+  });
+  assert.equal(count, 1);
+  assert.deepEqual(revoked, [{ webhookId: 7, reason: 'Bot voice permission was revoked' }]);
+});
+
+test('duplicate process protection disconnects the previous bot before it can keep voice ownership', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db);
+  const oldSocket = createSocket('bot-old');
+  const newSocket = createSocket('bot-new');
+  const state = {
+    voiceUsers: new Map([['11111111', new Map([[-7, {
+      id: -7, username: 'Listener', socketId: oldSocket.id, isBot: true
+    }]])]]),
+    voiceLastActivity: new Map([[-7, Date.now()]])
+  };
+  const io = { sockets: { sockets: new Map([[oldSocket.id, oldSocket], [newSocket.id, newSocket]]) } };
+  function handleVoiceLeave(socket, code) {
+    const room = state.voiceUsers.get(code);
+    if (room?.get(socket.user.id)?.socketId === socket.id) room.delete(socket.user.id);
+  }
+
+  assert.equal(disconnectDuplicateBotSockets(newSocket, { io, state, handleVoiceLeave }), 1);
+  assert.equal(oldSocket.connected, false);
+  assert.equal(state.voiceUsers.get('11111111').has(-7), false);
+});
+
+test('bot sockets can join voice rooms but cannot join or receive textual/global rooms', () => {
+  const socket = createSocket();
+  isolateBotVoiceSocket(socket);
+  socket.join('channel:11111111');
+  socket.join(['voice:11111111', 'admins', 'channel:22222222']);
+
+  assert.equal(socket.rooms.has('bot-sockets'), true);
+  assert.equal(socket.rooms.has('voice:11111111'), true);
+  assert.equal(socket.rooms.has('channel:11111111'), false);
+  assert.equal(socket.rooms.has('channel:22222222'), false);
+  assert.equal(socket.rooms.has('admins'), false);
+});
+
+test('only admins can change voice permission and revocation is immediate', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db, { can_use_voice: 0 });
+
+  const moderator = createAdminHarness(db, { id: 20, isAdmin: false });
+  moderator.handlers.get('update-webhook')({ id: 7, can_use_voice: 1 });
+  assert.equal(db.prepare('SELECT can_use_voice FROM webhooks WHERE id = 7').get().can_use_voice, 0);
+  assert.match(moderator.outgoing.at(-1).payload, /Only admins/);
+
+  const admin = createAdminHarness(db, { id: 11, isAdmin: true });
+  admin.handlers.get('update-webhook')({ id: 7, can_use_voice: 1 });
+  assert.equal(db.prepare('SELECT can_use_voice FROM webhooks WHERE id = 7').get().can_use_voice, 1);
+  admin.handlers.get('update-webhook')({ id: 7, can_use_voice: 0 });
+  assert.equal(db.prepare('SELECT can_use_voice FROM webhooks WHERE id = 7').get().can_use_voice, 0);
+  assert.match(admin.revoked.at(-1).reason, /permission was revoked/);
+});
+
+test('non-admin integration managers cannot obtain privileged bot tokens owned by someone else', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  insertBot(db);
+  insertBot(db, {
+    id: 8,
+    name: 'Admin Listener',
+    token: 'd'.repeat(64),
+    created_by: 11,
+    can_use_voice: 0
+  });
+  const moderator = createAdminHarness(db, { id: 10, isAdmin: false });
+
+  moderator.handlers.get('get-webhooks')();
+  let list = moderator.outgoing.filter(item => item.event === 'webhooks-list').at(-1).payload.webhooks;
+  assert.equal(list.find(webhook => webhook.id === 7).token, BOT_TOKEN);
+  assert.equal(list.find(webhook => webhook.id === 8).token, null);
+
+  db.prepare('UPDATE webhooks SET can_use_voice = 1 WHERE id = 8').run();
+  moderator.handlers.get('get-webhooks')();
+  list = moderator.outgoing.filter(item => item.event === 'webhooks-list').at(-1).payload.webhooks;
+  assert.equal(list.find(webhook => webhook.id === 8).token, null);
+});
+
+test('human voice snapshots preserve bot identity and listening state', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  const handlers = new Map();
+  const outgoing = [];
+  const socket = {
+    id: 'human-socket',
+    user: { id: 10, username: 'human', displayName: 'Human', isAdmin: false },
+    on(event, handler) { handlers.set(event, handler); },
+    emit(event, payload) { outgoing.push({ event, payload }); }
+  };
+  const state = {
+    channelUsers: new Map(),
+    voiceUsers: new Map([['11111111', new Map([[-7, {
+      id: -7,
+      username: 'Listener',
+      socketId: 'bot-socket',
+      isMuted: false,
+      isDeafened: false,
+      isBot: true,
+      isListening: true
+    }]])]]),
+    voiceLastActivity: new Map(),
+    activeMusic: new Map(),
+    activeScreenSharers: new Map(),
+    activeWebcamUsers: new Map(),
+    streamViewers: new Map(),
+    pendingTempDelete: new Map(),
+    pendingVoiceLeave: new Map()
+  };
+  registerVoice(socket, {
+    io: { to() { return { emit() {}, to() { return { emit() {} }; } }; } },
+    db,
+    state,
+    userHasPermission: () => true,
+    getUserEffectiveLevel: () => 0,
+    getUserHighestRole: () => null,
+    broadcastVoiceUsers() {},
+    emitOnlineUsers() {},
+    handleVoiceLeave() {},
+    touchVoiceActivity() {},
+    pruneStaleVoiceUsers: () => [],
+    getMentionableChannelMembers: () => [],
+    getActiveMusicSyncState: () => null,
+    getMusicQueuePayload: () => ({})
+  });
+
+  handlers.get('request-voice-users')({ code: '11111111' });
+  handlers.get('get-voice-counts')();
+  const roster = outgoing.find(item => item.event === 'voice-users-update').payload.users[0];
+  const count = outgoing.find(item => item.event === 'voice-count-update').payload.users[0];
+  assert.equal(roster.isBot, true);
+  assert.equal(roster.isListening, true);
+  assert.equal(count.isBot, true);
+  assert.equal(count.isListening, true);
+});
+
+test('administrative global broadcasts explicitly exclude bot sockets', t => {
+  const db = createDb();
+  t.after(() => db.close());
+  const broadcasts = [];
+  const io = {
+    sockets: { sockets: new Map() },
+    of() { return { sockets: new Map() }; },
+    emit(event) { broadcasts.push({ room: null, event }); },
+    except(room) {
+      return { emit(event, payload) { broadcasts.push({ room, event, payload }); } };
+    }
+  };
+  const admin = createAdminHarness(db, { id: 11, isAdmin: true }, io);
+  admin.handlers.get('update-server-setting')({ key: 'server_name', value: 'Gateway Test' });
+
+  assert.equal(broadcasts.some(item => item.room === null), false);
+  assert.ok(broadcasts.some(item => item.room === 'bot-sockets' && item.event === 'server-setting-changed'));
+});
+
+test('server namespace broadcasts always declare the bot exclusion room', () => {
+  const root = path.resolve(__dirname, '..');
+  const files = [
+    path.join(root, 'src/channelRotation.js'),
+    ...fs.readdirSync(path.join(root, 'src/socketHandlers'))
+      .filter(file => file.endsWith('.js'))
+      .map(file => path.join(root, 'src/socketHandlers', file))
+  ];
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+    assert.doesNotMatch(source, /\bio\.emit\(/, `${path.basename(file)} has an unrestricted io.emit`);
+    assert.doesNotMatch(source, /\bsocket\.broadcast\.emit\(/, `${path.basename(file)} has an unrestricted broadcast.emit`);
+  }
+});

--- a/test/botVoiceApi.integration.test.js
+++ b/test/botVoiceApi.integration.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+const test = require('node:test');
+const Database = require('better-sqlite3');
+
+async function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(error => error ? reject(error) : resolve(port));
+    });
+  });
+}
+
+async function waitForServer(url, child, output) {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`Server exited early:\n${output()}`);
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+    } catch {}
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error(`Server did not become ready:\n${output()}`);
+}
+
+test('voice channels endpoint enforces permission and creator scope end to end', async t => {
+  const root = path.resolve(__dirname, '..');
+  const dataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'haven-bot-voice-test-'));
+  const token = 'c'.repeat(64);
+  const port = await availablePort();
+  const env = {
+    ...process.env,
+    HAVEN_DATA_DIR: dataDir,
+    FORCE_HTTP: 'true',
+    HOST: '127.0.0.1',
+    PORT: String(port)
+  };
+
+  const seed = spawnSync(process.execPath, ['-e', `
+    const { initDatabase } = require('./src/database');
+    const db = initDatabase();
+    const owner = db.prepare("INSERT INTO users (username, password_hash, is_admin) VALUES ('owner', 'x', 0)").run();
+    const assigned = db.prepare("INSERT INTO channels (name, code, created_by, is_dm, voice_enabled, position) VALUES ('Assigned', '11111111', ?, 0, 1, 1)").run(owner.lastInsertRowid);
+    const member = db.prepare("INSERT INTO channels (name, code, created_by, is_dm, voice_enabled, position) VALUES ('Member', '22222222', ?, 0, 1, 2)").run(owner.lastInsertRowid);
+    db.prepare("INSERT INTO channels (name, code, created_by, is_dm, voice_enabled, position) VALUES ('Disabled', '33333333', ?, 0, 0, 3)").run(owner.lastInsertRowid);
+    db.prepare("INSERT INTO channels (name, code, created_by, is_dm, voice_enabled, position) VALUES ('Restricted', '44444444', ?, 0, 1, 4)").run(owner.lastInsertRowid);
+    db.prepare("INSERT INTO channels (name, code, created_by, is_dm, voice_enabled, position) VALUES ('Private DM', '55555555', ?, 1, 1, 5)").run(owner.lastInsertRowid);
+    db.prepare('INSERT INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(member.lastInsertRowid, owner.lastInsertRowid);
+    db.prepare('INSERT INTO webhooks (channel_id, name, token, created_by, can_use_voice) VALUES (?, ?, ?, ?, 1)').run(assigned.lastInsertRowid, 'Voice Bot', '${token}', owner.lastInsertRowid);
+    db.close();
+  `], { cwd: root, env, encoding: 'utf8' });
+  assert.equal(seed.status, 0, seed.stderr || seed.stdout);
+
+  let logs = '';
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: root,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  child.stdout.on('data', chunk => { logs += chunk; });
+  child.stderr.on('data', chunk => { logs += chunk; });
+  t.after(async () => {
+    if (child.exitCode === null) child.kill('SIGTERM');
+    await Promise.race([
+      new Promise(resolve => child.once('exit', resolve)),
+      new Promise(resolve => setTimeout(resolve, 3000))
+    ]);
+    await fs.promises.rm(dataDir, { recursive: true, force: true });
+  });
+
+  const url = `http://127.0.0.1:${port}/api/webhooks/${token}/voice/channels`;
+  const response = await waitForServer(url, child, () => logs);
+  assert.deepEqual(await response.json(), {
+    channels: [
+      { code: '11111111', name: 'Assigned', members: 0, bots: 0 },
+      { code: '22222222', name: 'Member', members: 0, bots: 0 }
+    ]
+  });
+
+  const db = new Database(path.join(dataDir, 'haven.db'));
+  db.prepare('UPDATE webhooks SET can_use_voice = 0 WHERE token = ?').run(token);
+  db.close();
+  const revoked = await fetch(url);
+  assert.equal(revoked.status, 403);
+  assert.deepEqual(await revoked.json(), { error: 'This bot does not have voice permission' });
+});

--- a/test/channelRotation.test.js
+++ b/test/channelRotation.test.js
@@ -95,8 +95,14 @@ test('channel rotation migrates text, voice, media, stream, and pending state', 
     join(room) { roomMoves.push(['text-join', room]); }
   };
   const voiceSocket = {
+    user: { isBot: true, channelCode: oldCode },
     leave(room) { roomMoves.push(['voice-leave', room]); },
     join(room) { roomMoves.push(['voice-join', room]); }
+  };
+  const idleBotEvents = [];
+  const idleBotSocket = {
+    user: { isBot: true, channelId: 9, channelCode: oldCode },
+    emit(event, payload) { idleBotEvents.push({ event, payload }); }
   };
   let emitted;
   const io = {
@@ -107,7 +113,8 @@ test('channel rotation migrates text, voice, media, stream, and pending state', 
       ]) },
       sockets: new Map([
         ['text-socket', textSocket],
-        ['voice-socket', voiceSocket]
+        ['voice-socket', voiceSocket],
+        ['idle-bot-socket', idleBotSocket]
       ])
     },
     to(firstRoom) {
@@ -139,6 +146,12 @@ test('channel rotation migrates text, voice, media, stream, and pending state', 
   assert.equal(textSocket.currentChannel, newCode);
   assert.ok(roomMoves.some(move => move[0] === 'text-join' && move[1] === `channel:${newCode}`));
   assert.ok(roomMoves.some(move => move[0] === 'voice-join' && move[1] === `voice:${newCode}`));
+  assert.equal(voiceSocket.user.channelCode, newCode);
+  assert.equal(idleBotSocket.user.channelCode, newCode);
+  assert.deepEqual(idleBotEvents, [{
+    event: 'channel-code-rotated',
+    payload: { channelId: 9, oldCode, newCode }
+  }]);
   for (const name of ['channelUsers', 'voiceUsers', 'activeMusic', 'musicQueues', 'activeScreenSharers', 'activeWebcamUsers']) {
     assert.equal(state[name].has(oldCode), false, `${name} kept the old code`);
     assert.equal(state[name].has(newCode), true, `${name} missed the new code`);


### PR DESCRIPTION
## Summary

Adds an opt-in voice gateway that allows webhook bots to join Haven voice channels as external WebRTC peers.

## Changes

- Adds `webhooks.can_use_voice`, disabled by default and configurable only by admins.
- Authenticates bots through `socket.handshake.auth.botToken`.
- Uses negative synthetic user IDs to avoid collisions with regular users.
- Adds `GET /api/webhooks/:token/voice/channels`.
- Supports voice join/leave, offer/answer/ICE signaling, speaking state, and AFK activity.
- Displays connected bots in voice rosters with a `BOT` badge.
- Revalidates access per packet and every two seconds.
- Immediately disconnects bots when permission is revoked, the webhook is disabled/deleted, or its channel scope changes.
- Prevents duplicate bot processes and rejects signaling from replaced sockets.
- Keeps bot state synchronized during channel code rotation.
- Prevents bots from joining text/admin rooms or receiving global broadcasts.
- Hides webhook tokens from non-admin integration managers who do not own the webhook.

## Security

- Voice access remains disabled for all existing webhooks.
- Bots can access:
  - Their assigned channel.
  - Channels their creator belongs to.
  - Every non-DM channel when owned by an admin.
- Voice-disabled and full channels reject joins without removing the bot from its current channel.
- Signaling is accepted only from the socket that currently owns the bot's voice entry.
- Access is periodically revalidated to cover out-of-band permission and membership changes.

## Testing

- Added tests for channel scope, membership, admin ownership, and voice-disabled channels.
- Added tests for permission and token revocation.
- Added tests for authorized signaling and replaced socket rejection.
- Added tests for duplicate processes, channel limits, and AFK activity.
- Added tests for BOT presence, room isolation, global broadcast isolation, and channel rotation.
- Added an end-to-end test for the REST endpoint using a real server process.
- `node --test test/*.test.js`: **42 passed**
- Relevant `node --check` validations passed.
- `git diff --check` passed.