### PR TITLE
Add webhook bulk message deletion

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1321,6 +1321,17 @@ DELETE https://your-server.com/api/webhooks/<token>/messages/<message_id>
 
 Bots can delete any message in their assigned channel. Returns `{ "success": true }`.
 
+Bots with moderation permission can delete up to 100 of the most recent messages
+from their assigned channel in one request. Thread replies are removed with their
+parent messages.
+
+```
+DELETE https://your-server.com/api/webhooks/<token>/messages?limit=25
+```
+
+Returns `{ "success": true, "deleted": 25 }`. The `deleted` count includes
+thread replies removed with the selected messages.
+
 ### Playing Soundboard Sounds
 
 ```

--- a/server.js
+++ b/server.js
@@ -137,7 +137,7 @@ let botAudioManager = null;
 let socketRuntime = null;
 
 const UPLOAD_PATH_RE = /\/uploads\/((?!(?:bot-audio|deleted-attachments|stickers)\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
-const UPLOAD_URL_PATH_RE = /\/uploads\/((?:[A-Za-z0-9_.~%-]+\/)*[A-Za-z0-9_.~%-]+)/g;
+const UPLOAD_URL_PATH_RE = /\/uploads\/+([-A-Za-z0-9_.~%/\\]+)/gi;
 
 function isSafeUploadRelPath(relPath) {
   if (typeof relPath !== 'string' || !relPath) return false;
@@ -172,9 +172,23 @@ function collectUploadRelPaths(contents) {
     UPLOAD_URL_PATH_RE.lastIndex = 0;
     let match;
     while ((match = UPLOAD_URL_PATH_RE.exec(content)) !== null) {
-      let relPath;
-      try { relPath = decodeURIComponent(match[1]); } catch { continue; }
-      if (/^(?:deleted-attachments|stickers)\//.test(relPath)) continue;
+      let decoded;
+      try { decoded = decodeURIComponent(match[1]); } catch { continue; }
+      const parts = [];
+      let escapesRoot = false;
+      const segments = decoded.split(process.platform === 'win32' ? /[\\/]+/ : /\/+/);
+      for (const segment of segments) {
+        if (!segment || segment === '.') continue;
+        if (segment === '..') {
+          if (parts.length === 0) { escapesRoot = true; break; }
+          parts.pop();
+        } else {
+          parts.push(segment);
+        }
+      }
+      if (escapesRoot) continue;
+      const relPath = parts.join('/');
+      if (/^(?:bot-audio|deleted-attachments|stickers)\//i.test(relPath)) continue;
       if (isSafeUploadRelPath(relPath)) paths.add(relPath);
     }
   }
@@ -205,23 +219,29 @@ function relocateUnreferencedUploads(db, relPaths) {
     if (candidates.size === 0) return;
   }
 
+  const protectedUrlReferences = db.prepare(`
+    SELECT avatar AS reference FROM users WHERE avatar LIKE '%/uploads/%'
+    UNION ALL SELECT border FROM users WHERE border LIKE '%/uploads/%'
+    UNION ALL SELECT avatar FROM user_personas WHERE avatar LIKE '%/uploads/%'
+    UNION ALL SELECT avatar_url FROM webhooks WHERE avatar_url LIKE '%/uploads/%'
+    UNION ALL SELECT icon FROM roles WHERE icon LIKE '%/uploads/%'
+    UNION ALL SELECT value FROM server_settings WHERE value LIKE '%/uploads/%'
+  `).iterate();
+  for (const row of protectedUrlReferences) {
+    for (const relPath of collectUploadRelPaths([row.reference])) candidates.delete(relPath);
+    if (candidates.size === 0) return;
+  }
+
   const findOwnership = db.prepare(
-    'SELECT scope, created_at FROM upload_ownership WHERE rel_path = ?'
+    'SELECT user_id, scope, created_at FROM upload_ownership WHERE rel_path = ?'
   );
-  const latestDmMessage = db.prepare(`
-    SELECT MAX(COALESCE(m.edited_at, m.created_at)) AS referenced_at
+  const latestDmMessageByUser = new Map(db.prepare(`
+    SELECT m.user_id, MAX(COALESCE(m.edited_at, m.created_at)) AS referenced_at
     FROM messages m
     JOIN channels c ON c.id = m.channel_id
-    WHERE c.is_dm = 1
-  `).get()?.referenced_at || null;
-  const findProtectedUrlReference = db.prepare(`
-    SELECT 1
-    WHERE EXISTS(SELECT 1 FROM users WHERE avatar = ? OR border = ?)
-       OR EXISTS(SELECT 1 FROM user_personas WHERE avatar = ?)
-       OR EXISTS(SELECT 1 FROM webhooks WHERE avatar_url = ?)
-       OR EXISTS(SELECT 1 FROM roles WHERE icon = ?)
-       OR EXISTS(SELECT 1 FROM server_settings WHERE value = ?)
-  `);
+    WHERE c.is_dm = 1 AND m.user_id IS NOT NULL
+    GROUP BY m.user_id
+  `).all().map(row => [row.user_id, row.referenced_at]));
   const findProtectedFilenameReference = db.prepare(`
     SELECT 1
     WHERE EXISTS(SELECT 1 FROM custom_sounds WHERE filename = ?)
@@ -233,12 +253,11 @@ function relocateUnreferencedUploads(db, relPaths) {
     const ownership = findOwnership.get(relPath);
     // Legacy/unattributed files and private/profile uploads cannot be proven
     // orphaned, so leave them in place. A channel upload is also retained if
-    // a later encrypted DM could contain a reference the server cannot read.
+    // its owner later sent an encrypted DM that could contain a reference.
     if (!ownership || ownership.scope !== 'channel') continue;
+    const latestDmMessage = latestDmMessageByUser.get(ownership.user_id);
     if (latestDmMessage && latestDmMessage >= ownership.created_at) continue;
 
-    const uploadUrl = `/uploads/${relPath}`;
-    if (findProtectedUrlReference.get(uploadUrl, uploadUrl, uploadUrl, uploadUrl, uploadUrl, uploadUrl)) continue;
     if (findProtectedFilenameReference.get(relPath, relPath, relPath)) continue;
     moveUploadToDeleted(relPath);
   }
@@ -3912,11 +3931,11 @@ app.delete('/api/webhooks/:token/messages/:messageId', webhookLimiter, (req, res
     return res.status(500).json({ error: 'Failed to delete message' });
   }
 
-  // Move uploaded attachments only after proving no surviving reference uses them.
-  try {
-    relocateUnreferencedUploads(db, collectUploadRelPaths([msg.content]));
-  } catch (err) {
-    console.error('Bot delete message attachment cleanup error:', err);
+  // Move any uploaded attachments to the deleted folder
+  const uploadRe = UPLOAD_PATH_RE;
+  let m;
+  while ((m = uploadRe.exec(msg.content || '')) !== null) {
+    moveUploadToDeleted(m[1], uploadDir);
   }
 
   // Find channel code for broadcasting

--- a/server.js
+++ b/server.js
@@ -137,6 +137,7 @@ let botAudioManager = null;
 let socketRuntime = null;
 
 const UPLOAD_PATH_RE = /\/uploads\/((?!(?:bot-audio|deleted-attachments|stickers)\/)(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_.-]+)/g;
+const UPLOAD_URL_PATH_RE = /\/uploads\/((?:[A-Za-z0-9_.~%-]+\/)*[A-Za-z0-9_.~%-]+)/g;
 
 function isSafeUploadRelPath(relPath) {
   if (typeof relPath !== 'string' || !relPath) return false;
@@ -162,6 +163,85 @@ function moveUploadToDeleted(relPath, srcRoot = UPLOADS_DIR) {
     fs.mkdirSync(path.dirname(dst), { recursive: true });
     fs.renameSync(src, dst);
   } catch { /* file locked or already moved */ }
+}
+
+function collectUploadRelPaths(contents) {
+  const paths = new Set();
+  for (const content of contents) {
+    if (typeof content !== 'string' || !content) continue;
+    UPLOAD_URL_PATH_RE.lastIndex = 0;
+    let match;
+    while ((match = UPLOAD_URL_PATH_RE.exec(content)) !== null) {
+      let relPath;
+      try { relPath = decodeURIComponent(match[1]); } catch { continue; }
+      if (/^(?:deleted-attachments|stickers)\//.test(relPath)) continue;
+      if (isSafeUploadRelPath(relPath)) paths.add(relPath);
+    }
+  }
+  return paths;
+}
+
+function relocateUnreferencedUploads(db, relPaths) {
+  const candidates = new Set(
+    Array.from(relPaths).filter(relPath => fs.existsSync(path.join(UPLOADS_DIR, relPath)))
+  );
+  if (candidates.size === 0) return;
+
+  const survivingMessages = db.prepare(`
+    SELECT content, persona_avatar, webhook_avatar
+    FROM messages
+    WHERE content LIKE '%/uploads/%'
+       OR persona_avatar IS NOT NULL
+       OR webhook_avatar IS NOT NULL
+  `).iterate();
+  for (const message of survivingMessages) {
+    for (const relPath of collectUploadRelPaths([
+      message.content,
+      message.persona_avatar,
+      message.webhook_avatar
+    ])) {
+      candidates.delete(relPath);
+    }
+    if (candidates.size === 0) return;
+  }
+
+  const findOwnership = db.prepare(
+    'SELECT scope, created_at FROM upload_ownership WHERE rel_path = ?'
+  );
+  const latestDmMessage = db.prepare(`
+    SELECT MAX(COALESCE(m.edited_at, m.created_at)) AS referenced_at
+    FROM messages m
+    JOIN channels c ON c.id = m.channel_id
+    WHERE c.is_dm = 1
+  `).get()?.referenced_at || null;
+  const findProtectedUrlReference = db.prepare(`
+    SELECT 1
+    WHERE EXISTS(SELECT 1 FROM users WHERE avatar = ? OR border = ?)
+       OR EXISTS(SELECT 1 FROM user_personas WHERE avatar = ?)
+       OR EXISTS(SELECT 1 FROM webhooks WHERE avatar_url = ?)
+       OR EXISTS(SELECT 1 FROM roles WHERE icon = ?)
+       OR EXISTS(SELECT 1 FROM server_settings WHERE value = ?)
+  `);
+  const findProtectedFilenameReference = db.prepare(`
+    SELECT 1
+    WHERE EXISTS(SELECT 1 FROM custom_sounds WHERE filename = ?)
+       OR EXISTS(SELECT 1 FROM custom_emojis WHERE filename = ?)
+       OR EXISTS(SELECT 1 FROM stickers WHERE filename = ?)
+  `);
+
+  for (const relPath of candidates) {
+    const ownership = findOwnership.get(relPath);
+    // Legacy/unattributed files and private/profile uploads cannot be proven
+    // orphaned, so leave them in place. A channel upload is also retained if
+    // a later encrypted DM could contain a reference the server cannot read.
+    if (!ownership || ownership.scope !== 'channel') continue;
+    if (latestDmMessage && latestDmMessage >= ownership.created_at) continue;
+
+    const uploadUrl = `/uploads/${relPath}`;
+    if (findProtectedUrlReference.get(uploadUrl, uploadUrl, uploadUrl, uploadUrl, uploadUrl, uploadUrl)) continue;
+    if (findProtectedFilenameReference.get(relPath, relPath, relPath)) continue;
+    moveUploadToDeleted(relPath);
+  }
 }
 
 // ── Per-member upload accounting (#5521) ─────────────────
@@ -3832,11 +3912,11 @@ app.delete('/api/webhooks/:token/messages/:messageId', webhookLimiter, (req, res
     return res.status(500).json({ error: 'Failed to delete message' });
   }
 
-  // Move any uploaded attachments to the deleted folder
-  const uploadRe = UPLOAD_PATH_RE;
-  let m;
-  while ((m = uploadRe.exec(msg.content || '')) !== null) {
-    moveUploadToDeleted(m[1], uploadDir);
+  // Move uploaded attachments only after proving no surviving reference uses them.
+  try {
+    relocateUnreferencedUploads(db, collectUploadRelPaths([msg.content]));
+  } catch (err) {
+    console.error('Bot delete message attachment cleanup error:', err);
   }
 
   // Find channel code for broadcasting
@@ -3849,6 +3929,100 @@ app.delete('/api/webhooks/:token/messages/:messageId', webhookLimiter, (req, res
   }
 
   res.json({ success: true });
+});
+
+// ── Bot: Delete recent messages and their replies ─────────
+app.delete('/api/webhooks/:token/messages', webhookLimiter, (req, res) => {
+  const webhook = requireModBot(req, res);
+  if (!webhook) return;
+
+  const rawLimit = req.query.limit;
+  if (typeof rawLimit !== 'string' || !/^[1-9]\d*$/.test(rawLimit)) {
+    return res.status(400).json({ error: 'limit must be an integer between 1 and 100' });
+  }
+  const limit = Number(rawLimit);
+  if (!Number.isSafeInteger(limit) || limit > 100) {
+    return res.status(400).json({ error: 'limit must be an integer between 1 and 100' });
+  }
+
+  const { getDb } = require('./src/database');
+  const db = getDb();
+  const channel = db.prepare('SELECT id, code FROM channels WHERE id = ?').get(webhook.channel_id);
+  if (!channel) return res.status(404).json({ error: 'Channel not found' });
+
+  const selectMessages = db.prepare(`
+    WITH RECURSIVE
+      roots(id) AS (
+        SELECT id FROM (
+          SELECT id FROM messages
+          WHERE channel_id = ? AND thread_id IS NULL
+          ORDER BY created_at DESC, id DESC
+          LIMIT ?
+        )
+      ),
+      doomed(id) AS (
+        SELECT id FROM roots
+        UNION
+        SELECT m.id
+        FROM messages m
+        JOIN doomed d ON m.reply_to = d.id
+        UNION
+        SELECT m.id
+        FROM messages m
+        JOIN doomed d ON m.thread_id = d.id
+      )
+    SELECT m.id, m.channel_id, m.content
+    FROM messages m
+    JOIN doomed d ON d.id = m.id
+    ORDER BY m.id DESC
+  `);
+  const deletePin = db.prepare('DELETE FROM pinned_messages WHERE message_id = ?');
+  const deleteReactions = db.prepare('DELETE FROM reactions WHERE message_id = ?');
+  const deleteMessage = db.prepare('DELETE FROM messages WHERE id = ? AND channel_id = ?');
+  const purge = db.transaction(() => {
+    const messages = selectMessages.all(channel.id, limit);
+    if (messages.some(message => message.channel_id !== channel.id)) {
+      const error = new Error('Related replies exist in another channel');
+      error.statusCode = 409;
+      throw error;
+    }
+    for (const message of messages) {
+      deletePin.run(message.id);
+      deleteReactions.run(message.id);
+    }
+    for (const message of messages) deleteMessage.run(message.id, channel.id);
+    return messages;
+  });
+
+  let deletedMessages;
+  try {
+    deletedMessages = purge();
+  } catch (err) {
+    console.error('Bot bulk delete messages error:', err);
+    const status = err?.statusCode === 409 ? 409 : 500;
+    const error = status === 409 ? err.message : 'Failed to delete messages';
+    return res.status(status).json({ error });
+  }
+
+  try {
+    relocateUnreferencedUploads(
+      db,
+      collectUploadRelPaths(deletedMessages.map(message => message.content))
+    );
+  } catch (err) {
+    console.error('Bot bulk delete attachment cleanup error:', err);
+  }
+
+  if (io) {
+    for (const message of deletedMessages) {
+      io.to(`channel:${channel.code}`).emit('message-deleted', {
+        channelCode: channel.code,
+        messageId: message.id
+      });
+    }
+  }
+
+  return res.json({ success: true, deleted: deletedMessages.length });
 });
 
 // ── Bot: Play a soundboard sound in the webhook's channel ──

--- a/src/database.js
+++ b/src/database.js
@@ -1515,6 +1515,7 @@ function initDatabase() {
     db.exec("ALTER TABLE messages ADD COLUMN thread_id INTEGER DEFAULT NULL REFERENCES messages(id) ON DELETE CASCADE");
   }
   db.exec("CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id) WHERE thread_id IS NOT NULL");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_messages_reply_to ON messages(reply_to) WHERE reply_to IS NOT NULL");
 
   // ── Audit log ───────────────────────────────────────────
   // Tracks admin/moderator actions: channel CRUD, role changes,

--- a/test/webhookBulkDelete.integration.test.js
+++ b/test/webhookBulkDelete.integration.test.js
@@ -1,0 +1,415 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+const test = require('node:test');
+const Database = require('better-sqlite3');
+const WebSocket = require('ws');
+
+async function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(error => error ? reject(error) : resolve(port));
+    });
+  });
+}
+
+async function waitForServer(url, child, output) {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`Server exited early:\n${output()}`);
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {}
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error(`Server did not become ready:\n${output()}`);
+}
+
+function connectChannelSocket(baseUrl, token, channelCode) {
+  const socketUrl = baseUrl.replace(/^http/, 'ws') + '/socket.io/?EIO=4&transport=websocket';
+  const ws = new WebSocket(socketUrl);
+  const events = [];
+  const waiters = [];
+
+  function pushEvent(event, payload) {
+    events.push({ event, payload });
+    for (let index = waiters.length - 1; index >= 0; index--) {
+      const waiter = waiters[index];
+      if (waiter.event !== event || !waiter.predicate(payload)) continue;
+      waiters.splice(index, 1);
+      clearTimeout(waiter.timer);
+      waiter.resolve(payload);
+    }
+  }
+
+  const ready = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out joining Socket.IO channel')), 5000);
+    ws.on('message', raw => {
+      const packet = raw.toString();
+      if (packet === '2') return ws.send('3');
+      if (packet.startsWith('0')) {
+        ws.send(`40${JSON.stringify({ token })}`);
+        return;
+      }
+      if (packet.startsWith('44')) {
+        clearTimeout(timer);
+        reject(new Error(`Socket.IO authentication failed: ${packet}`));
+        return;
+      }
+      if (packet.startsWith('40')) {
+        ws.send(`42${JSON.stringify(['join-channel', { code: channelCode }])}`);
+        return;
+      }
+      if (!packet.startsWith('42')) return;
+      const [event, payload] = JSON.parse(packet.slice(2));
+      pushEvent(event, payload);
+      if (event === 'channel-joined' && payload?.code === channelCode) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    ws.once('error', reject);
+  });
+
+  function waitFor(event, predicate = () => true, timeoutMs = 3000) {
+    const existing = events.find(item => item.event === event && predicate(item.payload));
+    if (existing) return Promise.resolve(existing.payload);
+    return new Promise((resolve, reject) => {
+      const waiter = { event, predicate, resolve, timer: null };
+      waiter.timer = setTimeout(() => {
+        const index = waiters.indexOf(waiter);
+        if (index !== -1) waiters.splice(index, 1);
+        reject(new Error(`Timed out waiting for ${event}`));
+      }, timeoutMs);
+      waiters.push(waiter);
+    });
+  }
+
+  function checkpoint() {
+    return events.length;
+  }
+
+  function eventsSince(index, event) {
+    return events.slice(index)
+      .filter(item => item.event === event)
+      .map(item => item.payload);
+  }
+
+  return { ws, ready, waitFor, checkpoint, eventsSince };
+}
+
+test('webhook bulk delete enforces moderation and cleans related data end to end', async t => {
+  const root = path.resolve(__dirname, '..');
+  const dataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'haven-webhook-bulk-delete-'));
+  const modToken = 'm'.repeat(64);
+  const noModToken = 'n'.repeat(64);
+  const port = await availablePort();
+  const env = {
+    ...process.env,
+    HAVEN_DATA_DIR: dataDir,
+    FORCE_HTTP: 'true',
+    HOST: '127.0.0.1',
+    JWT_SECRET: 'b'.repeat(64),
+    PORT: String(port)
+  };
+
+  const seed = spawnSync(process.execPath, ['-e', `
+    const fs = require('fs');
+    const path = require('path');
+    const jwt = require('jsonwebtoken');
+    const { initDatabase } = require('./src/database');
+    const db = initDatabase();
+    const user = db.prepare("INSERT INTO users (username, password_hash, display_name, is_admin) VALUES ('owner', 'x', 'Owner', 1)").run();
+    const channel = db.prepare("INSERT INTO channels (name, code, created_by, is_dm) VALUES ('Bots', 'abcd1234', ?, 0)").run(user.lastInsertRowid);
+    const otherChannel = db.prepare("INSERT INTO channels (name, code, created_by, is_dm) VALUES ('Other', 'abcd5678', ?, 0)").run(user.lastInsertRowid);
+    const dmChannel = db.prepare("INSERT INTO channels (name, code, created_by, is_dm) VALUES ('DM', 'abcd9012', ?, 1)").run(user.lastInsertRowid);
+    db.prepare('INSERT INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(channel.lastInsertRowid, user.lastInsertRowid);
+    db.prepare('INSERT INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(otherChannel.lastInsertRowid, user.lastInsertRowid);
+    db.prepare('INSERT INTO webhooks (channel_id, name, token, created_by, can_moderate) VALUES (?, ?, ?, ?, 1)').run(channel.lastInsertRowid, 'Mod Bot', '${modToken}', user.lastInsertRowid);
+    db.prepare('INSERT INTO webhooks (channel_id, name, token, created_by, can_moderate) VALUES (?, ?, ?, ?, 0)').run(channel.lastInsertRowid, 'Plain Bot', '${noModToken}', user.lastInsertRowid);
+
+    const insertMessage = db.prepare('INSERT INTO messages (channel_id, user_id, content, created_at) VALUES (?, ?, ?, ?)');
+    const survivorShared = insertMessage.run(channel.lastInsertRowid, user.lastInsertRowid, 'keep /uploads/local-shared.txt', '2026-01-01 00:00:00');
+    const survivorPlain = insertMessage.run(channel.lastInsertRowid, user.lastInsertRowid, 'keep this too', '2026-01-02 00:00:00');
+    const parent = insertMessage.run(
+      channel.lastInsertRowid,
+      user.lastInsertRowid,
+      'remove /uploads/local-shared.txt /uploads/global-shared.txt /uploads/protected.mp3 /uploads/private.txt /uploads/dm-edited.txt',
+      '2026-01-03 00:00:00'
+    );
+    const threadReply = db.prepare('INSERT INTO messages (channel_id, user_id, content, thread_id, reply_to, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(
+      channel.lastInsertRowid,
+      user.lastInsertRowid,
+      'reply /uploads/orphan.txt',
+      parent.lastInsertRowid,
+      parent.lastInsertRowid,
+      '2026-01-03 00:01:00'
+    );
+    const inlineReply = db.prepare('INSERT INTO messages (channel_id, user_id, content, reply_to, created_at) VALUES (?, ?, ?, ?, ?)').run(
+      channel.lastInsertRowid,
+      user.lastInsertRowid,
+      'inline reply /uploads/inline-orphan.txt',
+      parent.lastInsertRowid,
+      '2019-01-01 00:00:00'
+    );
+    const importedOld = insertMessage.run(channel.lastInsertRowid, user.lastInsertRowid, 'imported old message', '2020-01-01 00:00:00');
+    const external = insertMessage.run(otherChannel.lastInsertRowid, user.lastInsertRowid, 'other /uploads/%67lobal-shared.txt', '2026-01-04 00:00:00');
+    db.prepare("INSERT INTO messages (channel_id, user_id, content, created_at, edited_at) VALUES (?, ?, 'encrypted payload', '2010-01-01 00:00:00', '2019-01-01 00:00:00')").run(dmChannel.lastInsertRowid, user.lastInsertRowid);
+
+    const addReaction = db.prepare("INSERT INTO reactions (message_id, user_id, emoji) VALUES (?, ?, 'ok')");
+    const addPin = db.prepare('INSERT INTO pinned_messages (message_id, channel_id, pinned_by) VALUES (?, ?, ?)');
+    for (const id of [parent.lastInsertRowid, threadReply.lastInsertRowid, inlineReply.lastInsertRowid]) {
+      addReaction.run(id, user.lastInsertRowid);
+      addPin.run(id, channel.lastInsertRowid, user.lastInsertRowid);
+    }
+    db.prepare('INSERT INTO custom_sounds (name, filename, uploaded_by) VALUES (?, ?, ?)').run('Protected', 'protected.mp3', user.lastInsertRowid);
+    const ownChannelUpload = db.prepare("INSERT INTO upload_ownership (rel_path, user_id, bytes, scope, created_at) VALUES (?, ?, ?, 'channel', '2020-01-01 00:00:00')");
+    for (const relPath of ['local-shared.txt', 'global-shared.txt', 'orphan.txt', 'inline-orphan.txt']) {
+      ownChannelUpload.run(relPath, user.lastInsertRowid, 7);
+    }
+    db.prepare("INSERT INTO upload_ownership (rel_path, user_id, bytes, scope, created_at) VALUES (?, ?, ?, 'channel', '2018-01-01 00:00:00')").run('dm-edited.txt', user.lastInsertRowid, 7);
+    db.prepare("INSERT INTO upload_ownership (rel_path, user_id, bytes, scope) VALUES (?, ?, ?, 'dm')").run('private.txt', user.lastInsertRowid, 7);
+
+    const uploads = path.join(process.env.HAVEN_DATA_DIR, 'uploads');
+    fs.writeFileSync(path.join(uploads, 'local-shared.txt'), 'shared');
+    fs.writeFileSync(path.join(uploads, 'global-shared.txt'), 'global');
+    fs.writeFileSync(path.join(uploads, 'orphan.txt'), 'orphan');
+    fs.writeFileSync(path.join(uploads, 'inline-orphan.txt'), 'inline');
+    fs.writeFileSync(path.join(uploads, 'protected.mp3'), 'sound');
+    fs.writeFileSync(path.join(uploads, 'private.txt'), 'private');
+    fs.writeFileSync(path.join(uploads, 'dm-edited.txt'), 'dm edited');
+    const fixture = {
+      humanToken: jwt.sign({ id: Number(user.lastInsertRowid), username: 'owner', pwv: 1 }, process.env.JWT_SECRET),
+      survivorShared: Number(survivorShared.lastInsertRowid),
+      survivorPlain: Number(survivorPlain.lastInsertRowid),
+      parent: Number(parent.lastInsertRowid),
+      threadReply: Number(threadReply.lastInsertRowid),
+      inlineReply: Number(inlineReply.lastInsertRowid),
+      importedOld: Number(importedOld.lastInsertRowid),
+      external: Number(external.lastInsertRowid)
+    };
+    fs.writeFileSync(path.join(process.env.HAVEN_DATA_DIR, 'fixture.json'), JSON.stringify(fixture));
+    db.close();
+  `], { cwd: root, env, encoding: 'utf8' });
+  assert.equal(seed.status, 0, seed.stderr || seed.stdout);
+
+  const fixture = JSON.parse(await fs.promises.readFile(path.join(dataDir, 'fixture.json'), 'utf8'));
+  let logs = '';
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: root,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  child.stdout.on('data', chunk => { logs += chunk; });
+  child.stderr.on('data', chunk => { logs += chunk; });
+  let socket;
+  t.after(async () => {
+    socket?.terminate();
+    if (child.exitCode === null) child.kill('SIGTERM');
+    await Promise.race([
+      child.exitCode === null ? new Promise(resolve => child.once('exit', resolve)) : Promise.resolve(),
+      new Promise(resolve => setTimeout(resolve, 3000))
+    ]);
+    if (child.exitCode === null) child.kill('SIGKILL');
+    await fs.promises.rm(dataDir, { recursive: true, force: true });
+  });
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForServer(`${baseUrl}/api/health`, child, () => logs);
+  const channelSocket = connectChannelSocket(baseUrl, fixture.humanToken, 'abcd1234');
+  socket = channelSocket.ws;
+  await channelSocket.ready;
+
+  const noPermission = await fetch(`${baseUrl}/api/webhooks/${noModToken}/messages?limit=1`, { method: 'DELETE' });
+  assert.equal(noPermission.status, 403);
+  assert.deepEqual(await noPermission.json(), { error: 'This bot does not have moderation permission' });
+
+  const missingBot = await fetch(`${baseUrl}/api/webhooks/${'x'.repeat(64)}/messages?limit=1`, { method: 'DELETE' });
+  assert.equal(missingBot.status, 404);
+
+  for (const query of ['', '?limit=0', '?limit=1.5', '?limit=101', '?limit=abc']) {
+    const response = await fetch(`${baseUrl}/api/webhooks/${modToken}/messages${query}`, { method: 'DELETE' });
+    assert.equal(response.status, 400, query || 'missing limit');
+    assert.match((await response.json()).error, /between 1 and 100/);
+  }
+
+  const firstCheckpoint = channelSocket.checkpoint();
+  const parentEvent = channelSocket.waitFor(
+    'message-deleted',
+    payload => payload?.messageId === fixture.parent
+  );
+  const replyEvent = channelSocket.waitFor(
+    'message-deleted',
+    payload => payload?.messageId === fixture.threadReply
+  );
+  const inlineReplyEvent = channelSocket.waitFor(
+    'message-deleted',
+    payload => payload?.messageId === fixture.inlineReply
+  );
+  const firstDelete = await fetch(`${baseUrl}/api/webhooks/${modToken}/messages?limit=1`, { method: 'DELETE' });
+  assert.equal(firstDelete.status, 200);
+  assert.deepEqual(await firstDelete.json(), { success: true, deleted: 3 });
+  assert.deepEqual(await Promise.all([parentEvent, replyEvent, inlineReplyEvent]), [
+    { channelCode: 'abcd1234', messageId: fixture.parent },
+    { channelCode: 'abcd1234', messageId: fixture.threadReply },
+    { channelCode: 'abcd1234', messageId: fixture.inlineReply }
+  ]);
+  await new Promise(resolve => setTimeout(resolve, 25));
+  assert.deepEqual(
+    channelSocket.eventsSince(firstCheckpoint, 'message-deleted').sort((a, b) => a.messageId - b.messageId),
+    [
+      { channelCode: 'abcd1234', messageId: fixture.parent },
+      { channelCode: 'abcd1234', messageId: fixture.threadReply },
+      { channelCode: 'abcd1234', messageId: fixture.inlineReply }
+    ]
+  );
+
+  const db = new Database(path.join(dataDir, 'haven.db'));
+  db.pragma('foreign_keys = ON');
+  const deletedIds = [fixture.parent, fixture.threadReply, fixture.inlineReply];
+  const placeholders = deletedIds.map(() => '?').join(',');
+  assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM messages WHERE id IN (${placeholders})`).get(...deletedIds).count, 0);
+  assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM reactions WHERE message_id IN (${placeholders})`).get(...deletedIds).count, 0);
+  assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM pinned_messages WHERE message_id IN (${placeholders})`).get(...deletedIds).count, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM messages WHERE id IN (?, ?, ?)').get(fixture.survivorShared, fixture.survivorPlain, fixture.importedOld).count, 3);
+
+  const uploads = path.join(dataDir, 'uploads');
+  const deletedUploads = path.join(uploads, 'deleted-attachments');
+  assert.equal(fs.existsSync(path.join(uploads, 'local-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(deletedUploads, 'local-shared.txt')), false);
+  assert.equal(fs.existsSync(path.join(uploads, 'global-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'orphan.txt')), false);
+  assert.equal(fs.existsSync(path.join(deletedUploads, 'orphan.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'inline-orphan.txt')), false);
+  assert.equal(fs.existsSync(path.join(deletedUploads, 'inline-orphan.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'protected.mp3')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'private.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'dm-edited.txt')), true);
+
+  const secondCheckpoint = channelSocket.checkpoint();
+  const survivorSharedEvent = channelSocket.waitFor(
+    'message-deleted',
+    payload => payload?.messageId === fixture.survivorShared
+  );
+  const survivorPlainEvent = channelSocket.waitFor(
+    'message-deleted',
+    payload => payload?.messageId === fixture.survivorPlain
+  );
+  const secondDelete = await fetch(`${baseUrl}/api/webhooks/${modToken}/messages?limit=2`, { method: 'DELETE' });
+  assert.equal(secondDelete.status, 200);
+  assert.deepEqual(await secondDelete.json(), { success: true, deleted: 2 });
+  await Promise.all([survivorSharedEvent, survivorPlainEvent]);
+  await new Promise(resolve => setTimeout(resolve, 25));
+  assert.deepEqual(
+    channelSocket.eventsSince(secondCheckpoint, 'message-deleted').sort((a, b) => a.messageId - b.messageId),
+    [
+      { channelCode: 'abcd1234', messageId: fixture.survivorShared },
+      { channelCode: 'abcd1234', messageId: fixture.survivorPlain }
+    ]
+  );
+
+  assert.equal(fs.existsSync(path.join(uploads, 'local-shared.txt')), false);
+  assert.equal(fs.existsSync(path.join(deletedUploads, 'local-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'global-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'protected.mp3')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'private.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'dm-edited.txt')), true);
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM messages WHERE channel_id = (SELECT id FROM channels WHERE code = ?)').get('abcd1234').count, 1);
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM messages WHERE id = ?').get(fixture.importedOld).count, 1);
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM messages WHERE id = ?').get(fixture.external).count, 1);
+
+  const importedEvent = channelSocket.waitFor(
+    'message-deleted',
+    payload => payload?.messageId === fixture.importedOld
+  );
+  const thirdDelete = await fetch(`${baseUrl}/api/webhooks/${modToken}/messages?limit=1`, { method: 'DELETE' });
+  assert.equal(thirdDelete.status, 200);
+  assert.deepEqual(await thirdDelete.json(), { success: true, deleted: 1 });
+  await importedEvent;
+
+  const emptyDelete = await fetch(`${baseUrl}/api/webhooks/${modToken}/messages?limit=1`, { method: 'DELETE' });
+  assert.equal(emptyDelete.status, 200);
+  assert.deepEqual(await emptyDelete.json(), { success: true, deleted: 0 });
+
+  const userId = db.prepare('SELECT id FROM users WHERE username = ?').get('owner').id;
+  const channelId = db.prepare('SELECT id FROM channels WHERE code = ?').get('abcd1234').id;
+  const otherChannelId = db.prepare('SELECT id FROM channels WHERE code = ?').get('abcd5678').id;
+  fs.writeFileSync(path.join(uploads, 'legacy.txt'), 'legacy');
+  const singleMessage = db.prepare(`
+    INSERT INTO messages (channel_id, user_id, content, created_at)
+    VALUES (?, ?, '/uploads/global-shared.txt /uploads/protected.mp3 /uploads/private.txt /uploads/legacy.txt', '2026-12-01 00:00:00')
+  `).run(channelId, userId);
+  const singleEvent = channelSocket.waitFor(
+    'message-deleted',
+    payload => payload?.messageId === Number(singleMessage.lastInsertRowid)
+  );
+  const singleDelete = await fetch(
+    `${baseUrl}/api/webhooks/${noModToken}/messages/${singleMessage.lastInsertRowid}`,
+    { method: 'DELETE' }
+  );
+  assert.equal(singleDelete.status, 200);
+  assert.deepEqual(await singleDelete.json(), { success: true });
+  await singleEvent;
+  assert.equal(fs.existsSync(path.join(uploads, 'global-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'protected.mp3')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'private.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'legacy.txt')), true);
+
+  const crossParent = db.prepare(
+    "INSERT INTO messages (channel_id, user_id, content, created_at) VALUES (?, ?, 'cross parent', '2027-01-01 00:00:00')"
+  ).run(channelId, userId);
+  const crossReply = db.prepare(
+    "INSERT INTO messages (channel_id, user_id, content, thread_id, created_at) VALUES (?, ?, 'cross reply', ?, '2027-01-01 00:01:00')"
+  ).run(otherChannelId, userId, crossParent.lastInsertRowid);
+  const crossCheckpoint = channelSocket.checkpoint();
+  const crossDelete = await fetch(`${baseUrl}/api/webhooks/${modToken}/messages?limit=1`, { method: 'DELETE' });
+  assert.equal(crossDelete.status, 409);
+  assert.deepEqual(await crossDelete.json(), { error: 'Related replies exist in another channel' });
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM messages WHERE id IN (?, ?)').get(crossParent.lastInsertRowid, crossReply.lastInsertRowid).count, 2);
+  await new Promise(resolve => setTimeout(resolve, 25));
+  assert.deepEqual(channelSocket.eventsSince(crossCheckpoint, 'message-deleted'), []);
+  db.prepare('DELETE FROM messages WHERE id = ?').run(crossReply.lastInsertRowid);
+  db.prepare('DELETE FROM messages WHERE id = ?').run(crossParent.lastInsertRowid);
+
+  const rollbackFirst = db.prepare(
+    "INSERT INTO messages (channel_id, user_id, content, created_at) VALUES (?, ?, '/uploads/rollback.txt', '2027-02-01 00:00:00')"
+  ).run(channelId, userId);
+  const rollbackSecond = db.prepare(
+    "INSERT INTO messages (channel_id, user_id, content, created_at) VALUES (?, ?, '/uploads/rollback.txt', '2027-02-02 00:00:00')"
+  ).run(channelId, userId);
+  for (const id of [rollbackFirst.lastInsertRowid, rollbackSecond.lastInsertRowid]) {
+    db.prepare("INSERT INTO reactions (message_id, user_id, emoji) VALUES (?, ?, 'rollback')").run(id, userId);
+    db.prepare('INSERT INTO pinned_messages (message_id, channel_id, pinned_by) VALUES (?, ?, ?)').run(id, channelId, userId);
+  }
+  fs.writeFileSync(path.join(uploads, 'rollback.txt'), 'rollback');
+  db.exec(`
+    CREATE TRIGGER fail_webhook_bulk_delete
+    BEFORE DELETE ON messages
+    WHEN OLD.id = ${Number(rollbackFirst.lastInsertRowid)}
+    BEGIN
+      SELECT RAISE(ABORT, 'blocked by test');
+    END
+  `);
+  const rollbackCheckpoint = channelSocket.checkpoint();
+  const rollbackDelete = await fetch(`${baseUrl}/api/webhooks/${modToken}/messages?limit=2`, { method: 'DELETE' });
+  assert.equal(rollbackDelete.status, 500);
+  assert.deepEqual(await rollbackDelete.json(), { error: 'Failed to delete messages' });
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM messages WHERE id IN (?, ?)').get(rollbackFirst.lastInsertRowid, rollbackSecond.lastInsertRowid).count, 2);
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM reactions WHERE message_id IN (?, ?)').get(rollbackFirst.lastInsertRowid, rollbackSecond.lastInsertRowid).count, 2);
+  assert.equal(db.prepare('SELECT COUNT(*) AS count FROM pinned_messages WHERE message_id IN (?, ?)').get(rollbackFirst.lastInsertRowid, rollbackSecond.lastInsertRowid).count, 2);
+  assert.equal(fs.existsSync(path.join(uploads, 'rollback.txt')), true);
+  assert.equal(fs.existsSync(path.join(deletedUploads, 'rollback.txt')), false);
+  await new Promise(resolve => setTimeout(resolve, 25));
+  assert.deepEqual(channelSocket.eventsSince(rollbackCheckpoint, 'message-deleted'), []);
+  db.exec('DROP TRIGGER fail_webhook_bulk_delete');
+  db.close();
+});

--- a/test/webhookBulkDelete.integration.test.js
+++ b/test/webhookBulkDelete.integration.test.js
@@ -129,6 +129,8 @@ test('webhook bulk delete enforces moderation and cleans related data end to end
     const { initDatabase } = require('./src/database');
     const db = initDatabase();
     const user = db.prepare("INSERT INTO users (username, password_hash, display_name, is_admin) VALUES ('owner', 'x', 'Owner', 1)").run();
+    const otherUser = db.prepare("INSERT INTO users (username, password_hash, display_name) VALUES ('other', 'x', 'Other')").run();
+    db.prepare("UPDATE users SET avatar = '/UPLOADS/%61vatar-protected.txt' WHERE id = ?").run(user.lastInsertRowid);
     const channel = db.prepare("INSERT INTO channels (name, code, created_by, is_dm) VALUES ('Bots', 'abcd1234', ?, 0)").run(user.lastInsertRowid);
     const otherChannel = db.prepare("INSERT INTO channels (name, code, created_by, is_dm) VALUES ('Other', 'abcd5678', ?, 0)").run(user.lastInsertRowid);
     const dmChannel = db.prepare("INSERT INTO channels (name, code, created_by, is_dm) VALUES ('DM', 'abcd9012', ?, 1)").run(user.lastInsertRowid);
@@ -143,7 +145,7 @@ test('webhook bulk delete enforces moderation and cleans related data end to end
     const parent = insertMessage.run(
       channel.lastInsertRowid,
       user.lastInsertRowid,
-      'remove /uploads/local-shared.txt /uploads/global-shared.txt /uploads/protected.mp3 /uploads/private.txt /uploads/dm-edited.txt',
+      'remove /uploads/local-shared.txt /uploads/global-shared.txt /uploads/slash-shared.txt /uploads/dot-shared.txt /uploads/windows-shared.txt /uploads/../escape-victim.txt /uploads/avatar-protected.txt /uploads/protected.mp3 /uploads/private.txt /uploads/dm-edited.txt',
       '2026-01-03 00:00:00'
     );
     const threadReply = db.prepare('INSERT INTO messages (channel_id, user_id, content, thread_id, reply_to, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(
@@ -162,8 +164,10 @@ test('webhook bulk delete enforces moderation and cleans related data end to end
       '2019-01-01 00:00:00'
     );
     const importedOld = insertMessage.run(channel.lastInsertRowid, user.lastInsertRowid, 'imported old message', '2020-01-01 00:00:00');
-    const external = insertMessage.run(otherChannel.lastInsertRowid, user.lastInsertRowid, 'other /uploads/%67lobal-shared.txt', '2026-01-04 00:00:00');
+    const windowsAlias = '/uploads/folder' + String.fromCharCode(92) + '..' + String.fromCharCode(92) + 'windows-shared.txt';
+    const external = insertMessage.run(otherChannel.lastInsertRowid, user.lastInsertRowid, 'other /UPLOADS/%67lobal-shared.txt /uploads//slash-shared.txt /uploads/folder/../dot-shared.txt ' + windowsAlias, '2026-01-04 00:00:00');
     db.prepare("INSERT INTO messages (channel_id, user_id, content, created_at, edited_at) VALUES (?, ?, 'encrypted payload', '2010-01-01 00:00:00', '2019-01-01 00:00:00')").run(dmChannel.lastInsertRowid, user.lastInsertRowid);
+    db.prepare("INSERT INTO messages (channel_id, user_id, content, created_at) VALUES (?, ?, 'unrelated encrypted payload', '2026-06-01 00:00:00')").run(dmChannel.lastInsertRowid, otherUser.lastInsertRowid);
 
     const addReaction = db.prepare("INSERT INTO reactions (message_id, user_id, emoji) VALUES (?, ?, 'ok')");
     const addPin = db.prepare('INSERT INTO pinned_messages (message_id, channel_id, pinned_by) VALUES (?, ?, ?)');
@@ -173,7 +177,7 @@ test('webhook bulk delete enforces moderation and cleans related data end to end
     }
     db.prepare('INSERT INTO custom_sounds (name, filename, uploaded_by) VALUES (?, ?, ?)').run('Protected', 'protected.mp3', user.lastInsertRowid);
     const ownChannelUpload = db.prepare("INSERT INTO upload_ownership (rel_path, user_id, bytes, scope, created_at) VALUES (?, ?, ?, 'channel', '2020-01-01 00:00:00')");
-    for (const relPath of ['local-shared.txt', 'global-shared.txt', 'orphan.txt', 'inline-orphan.txt']) {
+    for (const relPath of ['local-shared.txt', 'global-shared.txt', 'slash-shared.txt', 'dot-shared.txt', 'windows-shared.txt', 'escape-victim.txt', 'avatar-protected.txt', 'protected.mp3', 'orphan.txt', 'inline-orphan.txt']) {
       ownChannelUpload.run(relPath, user.lastInsertRowid, 7);
     }
     db.prepare("INSERT INTO upload_ownership (rel_path, user_id, bytes, scope, created_at) VALUES (?, ?, ?, 'channel', '2018-01-01 00:00:00')").run('dm-edited.txt', user.lastInsertRowid, 7);
@@ -182,6 +186,11 @@ test('webhook bulk delete enforces moderation and cleans related data end to end
     const uploads = path.join(process.env.HAVEN_DATA_DIR, 'uploads');
     fs.writeFileSync(path.join(uploads, 'local-shared.txt'), 'shared');
     fs.writeFileSync(path.join(uploads, 'global-shared.txt'), 'global');
+    fs.writeFileSync(path.join(uploads, 'slash-shared.txt'), 'slash');
+    fs.writeFileSync(path.join(uploads, 'dot-shared.txt'), 'dot');
+    fs.writeFileSync(path.join(uploads, 'windows-shared.txt'), 'windows');
+    fs.writeFileSync(path.join(uploads, 'escape-victim.txt'), 'escape');
+    fs.writeFileSync(path.join(uploads, 'avatar-protected.txt'), 'avatar');
     fs.writeFileSync(path.join(uploads, 'orphan.txt'), 'orphan');
     fs.writeFileSync(path.join(uploads, 'inline-orphan.txt'), 'inline');
     fs.writeFileSync(path.join(uploads, 'protected.mp3'), 'sound');
@@ -287,6 +296,11 @@ test('webhook bulk delete enforces moderation and cleans related data end to end
   assert.equal(fs.existsSync(path.join(uploads, 'local-shared.txt')), true);
   assert.equal(fs.existsSync(path.join(deletedUploads, 'local-shared.txt')), false);
   assert.equal(fs.existsSync(path.join(uploads, 'global-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'slash-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'dot-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'windows-shared.txt')), process.platform === 'win32');
+  assert.equal(fs.existsSync(path.join(uploads, 'escape-victim.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'avatar-protected.txt')), true);
   assert.equal(fs.existsSync(path.join(uploads, 'orphan.txt')), false);
   assert.equal(fs.existsSync(path.join(deletedUploads, 'orphan.txt')), true);
   assert.equal(fs.existsSync(path.join(uploads, 'inline-orphan.txt')), false);
@@ -320,6 +334,11 @@ test('webhook bulk delete enforces moderation and cleans related data end to end
   assert.equal(fs.existsSync(path.join(uploads, 'local-shared.txt')), false);
   assert.equal(fs.existsSync(path.join(deletedUploads, 'local-shared.txt')), true);
   assert.equal(fs.existsSync(path.join(uploads, 'global-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'slash-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'dot-shared.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'windows-shared.txt')), process.platform === 'win32');
+  assert.equal(fs.existsSync(path.join(uploads, 'escape-victim.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'avatar-protected.txt')), true);
   assert.equal(fs.existsSync(path.join(uploads, 'protected.mp3')), true);
   assert.equal(fs.existsSync(path.join(uploads, 'private.txt')), true);
   assert.equal(fs.existsSync(path.join(uploads, 'dm-edited.txt')), true);
@@ -359,10 +378,10 @@ test('webhook bulk delete enforces moderation and cleans related data end to end
   assert.equal(singleDelete.status, 200);
   assert.deepEqual(await singleDelete.json(), { success: true });
   await singleEvent;
-  assert.equal(fs.existsSync(path.join(uploads, 'global-shared.txt')), true);
-  assert.equal(fs.existsSync(path.join(uploads, 'protected.mp3')), true);
-  assert.equal(fs.existsSync(path.join(uploads, 'private.txt')), true);
-  assert.equal(fs.existsSync(path.join(uploads, 'legacy.txt')), true);
+  assert.equal(fs.existsSync(path.join(uploads, 'global-shared.txt')), false);
+  assert.equal(fs.existsSync(path.join(uploads, 'protected.mp3')), false);
+  assert.equal(fs.existsSync(path.join(uploads, 'private.txt')), false);
+  assert.equal(fs.existsSync(path.join(uploads, 'legacy.txt')), false);
 
   const crossParent = db.prepare(
     "INSERT INTO messages (channel_id, user_id, content, created_at) VALUES (?, ?, 'cross parent', '2027-01-01 00:00:00')"


### PR DESCRIPTION
## Summary

Adds a moderation-protected webhook endpoint for deleting recent messages in bulk from a bot's assigned channel.

## API

```http
DELETE /api/webhooks/:token/messages?limit=25