### PR TITLE
Fix dropped screen-share renegotiations

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -4130,7 +4130,7 @@
   <script src="/js/theme.js?v=4.0.1"></script>
   <script src="/js/notifications.js?v=3.16.15"></script>
   <script src="/js/servers.js?v=3.16.15"></script>
-  <script src="/js/voice.js?v=3.34.0"></script>
+  <script src="/js/voice.js?v=3.34.1"></script>
   <script src="/js/modmode.js?v=3.16.15"></script>
   <script src="/js/e2e.js?v=3.16.15"></script>
   <!-- Shared with the server (src/automod.js requires the same file) so both

--- a/public/js/voice.js
+++ b/public/js/voice.js
@@ -500,6 +500,7 @@ class VoiceManager {
 
       try {
         const conn = peer.connection;
+        peer._handlingRemoteOffer = true;
 
         // ── Glare handling (perfect negotiation) ──────────────
         //
@@ -534,13 +535,26 @@ class VoiceManager {
         // if we still have local changes to publish.
         const hadPendingLocalChanges = peer._makingOffer || peer._awaitingAnswer;
         const rolledBackIceRestart = !!peer._offerIsIceRestart;
+        const activeOfferId = peer._activeOfferId;
+        if (conn.signalingState !== 'stable') {
+          this._clearOfferAnswerTimer(peer);
+          try {
+            await conn.setLocalDescription({ type: 'rollback' });
+          } catch (err) {
+            if (conn.signalingState !== 'stable') {
+              if (peer._awaitingAnswer && activeOfferId && conn.signalingState !== 'closed') {
+                this._scheduleOfferAnswerTimeout(from.id, conn, activeOfferId);
+              }
+              throw err;
+            }
+          }
+        }
+        this._clearOfferAnswerTimer(peer);
         peer._makingOffer = false;
         peer._awaitingAnswer = false;
+        peer._activeOfferId = null;
         peer._offerIsIceRestart = false;
         peer._offerChannelCode = null;
-        if (conn.signalingState !== 'stable') {
-          await conn.setLocalDescription({ type: 'rollback' });
-        }
         // Anything we were trying to publish (added screen tracks, an ICE
         // restart) was just discarded with the rollback. Queue it so the drain
         // after this answer re-offers it, rather than silently losing it.
@@ -562,13 +576,15 @@ class VoiceManager {
           }
         }
         await conn.setRemoteDescription(new RTCSessionDescription(offer));
+        if (typeof data.offerId === 'string') peer._supportsOfferIds = true;
         const answer = await conn.createAnswer();
         await conn.setLocalDescription(answer);
 
         this.socket.emit('voice-answer', {
           code: this.currentChannel,
           targetUserId: from.id,
-          answer: answer
+          answer: answer,
+          offerId: typeof data.offerId === 'string' ? data.offerId : undefined
         });
 
         // Flush any ICE candidates that arrived before the remote
@@ -586,6 +602,9 @@ class VoiceManager {
         console.error('Error handling voice offer:', err);
       } finally {
         const latestPeer = this.peers.get(from.id);
+        if (latestPeer && latestPeer.connection === peer?.connection) {
+          latestPeer._handlingRemoteOffer = false;
+        }
         if (latestPeer && latestPeer.connection === peer?.connection && latestPeer.connection.signalingState === 'stable') {
           latestPeer._awaitingAnswer = false;
           this._drainQueuedRenegotiation(from.id);
@@ -597,12 +616,27 @@ class VoiceManager {
     this.socket.on('voice-answer', async (data) => {
       const peer = this.peers.get(data.from.id);
       if (peer) {
+        const answerOfferId = typeof data.offerId === 'string' ? data.offerId : null;
+        if (answerOfferId) peer._supportsOfferIds = true;
+        const staleCorrelatedAnswer = peer._activeOfferId && answerOfferId &&
+          answerOfferId !== peer._activeOfferId;
+        const unsafeLegacyAnswer = peer._activeOfferId && !answerOfferId &&
+          (peer._supportsOfferIds || (peer._offerTimeoutCount || 0) > 0);
+        if (staleCorrelatedAnswer || unsafeLegacyAnswer) {
+          console.warn('[Voice] Ignoring stale answer for peer', data.from.id,
+            `(expected ${peer._activeOfferId}, received ${answerOfferId || 'no offer id'})`);
+          return;
+        }
         try {
           // Only accept answer if we're actually waiting for one
           // (we may have rolled back our offer due to glare)
           if (peer.connection.signalingState === 'have-local-offer') {
             await peer.connection.setRemoteDescription(new RTCSessionDescription(data.answer));
+            this._clearOfferAnswerTimer(peer);
             peer._awaitingAnswer = false;
+            peer._activeOfferId = null;
+            peer._offerTimeoutCount = 0;
+            peer._offerRecoveryExhausted = false;
             peer._offerIsIceRestart = false;
             peer._offerChannelCode = null;
             // Flush buffered ICE candidates that arrived before the answer
@@ -614,12 +648,16 @@ class VoiceManager {
             }
           } else if (peer._awaitingAnswer && peer.connection.signalingState === 'stable') {
             // Stale answer for a local offer we already rolled back after glare.
+            this._clearOfferAnswerTimer(peer);
             peer._awaitingAnswer = false;
+            peer._activeOfferId = null;
           }
         } catch (err) {
           console.error('Error handling voice answer:', err);
           if (peer._awaitingAnswer && peer.connection.signalingState === 'stable') {
+            this._clearOfferAnswerTimer(peer);
             peer._awaitingAnswer = false;
+            peer._activeOfferId = null;
           }
         } finally {
           if (peer.connection.signalingState === 'stable') {
@@ -1852,6 +1890,70 @@ class VoiceManager {
     });
   }
 
+  _clearOfferAnswerTimer(peer) {
+    if (!peer || !peer._offerAnswerTimer) return;
+    clearTimeout(peer._offerAnswerTimer);
+    peer._offerAnswerTimer = null;
+  }
+
+  _scheduleOfferAnswerTimeout(userId, connection, offerId) {
+    const peer = this.peers.get(userId);
+    if (!peer || peer.connection !== connection) return;
+    this._clearOfferAnswerTimer(peer);
+    const timeoutCount = peer._offerTimeoutCount || 0;
+    const timeoutMs = Math.min(8000 + (timeoutCount * 4000), 20000);
+    peer._offerAnswerTimer = setTimeout(() => {
+      this._recoverTimedOutOffer(userId, connection, offerId).catch(err => {
+        console.warn('[Voice] Failed to recover unanswered offer for peer', userId, err);
+      });
+    }, timeoutMs);
+  }
+
+  async _recoverTimedOutOffer(userId, connection, offerId) {
+    const peer = this.peers.get(userId);
+    if (!peer || peer.connection !== connection ||
+        !peer._awaitingAnswer || peer._activeOfferId !== offerId) return false;
+
+    this._clearOfferAnswerTimer(peer);
+    const alreadyQueued = !!peer._renegotiateQueued;
+    peer._offerTimeoutCount = (peer._offerTimeoutCount || 0) + 1;
+    peer._renegotiateQueued = alreadyQueued || peer._offerTimeoutCount <= 3;
+    peer._recoveringTimedOutOffer = true;
+
+    console.warn('[Voice] Offer answer timed out for peer', userId,
+      '— rolling back and retrying negotiation');
+    if (connection.signalingState === 'have-local-offer') {
+      try {
+        await connection.setLocalDescription({ type: 'rollback' });
+      } catch (err) {
+        if (connection.signalingState !== 'stable') {
+          peer._recoveringTimedOutOffer = false;
+          console.warn('[Voice] Could not roll back timed-out offer for peer', userId, err);
+          if (connection.signalingState !== 'closed') {
+            this._scheduleOfferAnswerTimeout(userId, connection, offerId);
+          }
+          return false;
+        }
+      }
+    }
+    peer._recoveringTimedOutOffer = false;
+    peer._awaitingAnswer = false;
+    peer._activeOfferId = null;
+    peer._offerIsIceRestart = false;
+    peer._offerChannelCode = null;
+    if (connection.signalingState === 'stable') {
+      if (peer._renegotiateQueued) {
+        this._drainQueuedRenegotiation(userId);
+      } else {
+        peer._offerRecoveryExhausted = true;
+        console.warn('[Voice] Automatic offer recovery exhausted for peer', userId,
+          '— waiting for a new media or connection event');
+      }
+      return true;
+    }
+    return false;
+  }
+
   _drainQueuedRenegotiation(userId) {
     const peer = this.peers.get(userId);
     if (!peer || peer._makingOffer || peer._awaitingAnswer || !peer._renegotiateQueued) return;
@@ -1868,6 +1970,10 @@ class VoiceManager {
       peer._renegotiateQueued = true;
       peer._queuedIceRestart = peer._queuedIceRestart || iceRestart;
       return false;
+    }
+    if (peer._offerRecoveryExhausted) {
+      peer._offerRecoveryExhausted = false;
+      peer._offerTimeoutCount = 0;
     }
     // Wait for the signaling state to be stable before issuing a fresh
     // offer. RTCPeerConnection.createOffer() throws if called while a
@@ -1896,16 +2002,21 @@ class VoiceManager {
         return false;
       }
       await connection.setLocalDescription(offer);
+      this._offerSequence = (this._offerSequence || 0) + 1;
+      const offerId = `${this.localUserId ?? 'unknown'}-${Date.now().toString(36)}-${this._offerSequence.toString(36)}`;
       peer._awaitingAnswer = true;
+      peer._activeOfferId = offerId;
       peer._offerChannelCode = this.currentChannel;
       // Remember whether the offer now in flight is an ICE restart, so that if
       // it later yields to glare the restart intent can be re-queued rather
       // than silently downgraded to a plain renegotiation (#5444).
       peer._offerIsIceRestart = iceRestart;
+      this._scheduleOfferAnswerTimeout(userId, connection, offerId);
       this.socket.emit('voice-offer', {
         code: peer._offerChannelCode,
         targetUserId: userId,
-        offer: offer
+        offer: offer,
+        offerId
       });
       return true;
     } catch (err) {
@@ -2111,11 +2222,17 @@ class VoiceManager {
       const latestPeer = this.peers.get(userId);
       if (!latestPeer || latestPeer.connection !== connection) return;
       if (connection.signalingState === 'stable') {
-        if (latestPeer._awaitingAnswer) {
+        if (latestPeer._awaitingAnswer && !latestPeer._recoveringTimedOutOffer) {
+          this._clearOfferAnswerTimer(latestPeer);
           latestPeer._awaitingAnswer = false;
+          latestPeer._activeOfferId = null;
+          latestPeer._offerTimeoutCount = 0;
+          latestPeer._offerRecoveryExhausted = false;
         }
         latestPeer._offerChannelCode = null;
-        this._drainQueuedRenegotiation(userId);
+        if (!latestPeer._recoveringTimedOutOffer && !latestPeer._handlingRemoteOffer) {
+          this._drainQueuedRenegotiation(userId);
+        }
       }
     });
 
@@ -2163,6 +2280,13 @@ class VoiceManager {
       username,
       _makingOffer: false,
       _awaitingAnswer: false,
+      _activeOfferId: null,
+      _offerAnswerTimer: null,
+      _offerTimeoutCount: 0,
+      _offerRecoveryExhausted: false,
+      _recoveringTimedOutOffer: false,
+      _handlingRemoteOffer: false,
+      _supportsOfferIds: false,
       _renegotiateQueued: false,
       _queuedIceRestart: false,
       _offerIsIceRestart: false,
@@ -2185,6 +2309,7 @@ class VoiceManager {
     }
     const peer = this.peers.get(userId);
     if (peer) {
+      this._clearOfferAnswerTimer(peer);
       peer.connection.close();
       const audioEl = document.getElementById(`voice-audio-${userId}`);
       if (audioEl) audioEl.remove();
@@ -2297,7 +2422,12 @@ class VoiceManager {
       const connection = peer?.connection;
       if (!connection || peer._offerChannelCode !== oldCode) continue;
       peer._makingOffer = false;
+      this._clearOfferAnswerTimer(peer);
       peer._awaitingAnswer = false;
+      peer._activeOfferId = null;
+      peer._offerTimeoutCount = 0;
+      peer._offerRecoveryExhausted = false;
+      peer._recoveringTimedOutOffer = false;
       peer._offerIsIceRestart = false;
       peer._offerChannelCode = null;
       if (connection.signalingState === 'have-local-offer') {

--- a/src/socketHandlers/voice.js
+++ b/src/socketHandlers/voice.js
@@ -240,19 +240,26 @@ module.exports = function register(socket, ctx) {
   });
 
   // ── WebRTC signaling ────────────────────────────────────
-  const MAX_SDP_SIZE = 16384; // 16 KB — generous limit for SDP offers/answers
+  // Renegotiation offers include candidates already gathered by the live
+  // connection. With multiple interfaces or TURN relays, a normal
+  // voice + screen + webcam SDP can exceed 16 KB; silently rejecting it left
+  // that peer stuck waiting for an answer until they rejoined the call.
+  const MAX_SDP_SIZE = 65536;
+  const MAX_OFFER_ID_SIZE = 96;
   const MAX_ICE_SIZE = 2048;  // 2 KB — ICE candidates are small
 
   socket.on('voice-offer', (data) => {
     if (!data || typeof data !== 'object') return;
     if (!isString(data.code, 8, 8) || !isInt(data.targetUserId) || !data.offer) return;
     if (typeof data.offer !== 'object' || JSON.stringify(data.offer).length > MAX_SDP_SIZE) return;
+    if (data.offerId != null && !isString(data.offerId, 1, MAX_OFFER_ID_SIZE)) return;
     if (!voiceUsers.get(data.code)?.has(socket.user.id)) return;
     const target = voiceUsers.get(data.code)?.get(data.targetUserId);
     if (target) {
       io.to(target.socketId).emit('voice-offer', {
         from: { id: socket.user.id, username: socket.user.displayName },
         offer: data.offer,
+        offerId: data.offerId,
         channelCode: data.code
       });
     }
@@ -262,12 +269,14 @@ module.exports = function register(socket, ctx) {
     if (!data || typeof data !== 'object') return;
     if (!isString(data.code, 8, 8) || !isInt(data.targetUserId) || !data.answer) return;
     if (typeof data.answer !== 'object' || JSON.stringify(data.answer).length > MAX_SDP_SIZE) return;
+    if (data.offerId != null && !isString(data.offerId, 1, MAX_OFFER_ID_SIZE)) return;
     if (!voiceUsers.get(data.code)?.has(socket.user.id)) return;
     const target = voiceUsers.get(data.code)?.get(data.targetUserId);
     if (target) {
       io.to(target.socketId).emit('voice-answer', {
         from: { id: socket.user.id, username: socket.user.displayName },
         answer: data.answer,
+        offerId: data.offerId,
         channelCode: data.code
       });
     }

--- a/test/voiceScreenSignaling.test.js
+++ b/test/voiceScreenSignaling.test.js
@@ -1,0 +1,452 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const registerVoice = require('../src/socketHandlers/voice');
+
+const ROOT = path.join(__dirname, '..');
+const VOICE_SOURCE = fs.readFileSync(path.join(ROOT, 'public/js/voice.js'), 'utf8');
+
+function createStorage() {
+  return {
+    getItem() { return null; },
+    setItem() {},
+    removeItem() {}
+  };
+}
+
+function loadVoiceManager(globals = {}) {
+  const context = vm.createContext({
+    module: { exports: {} },
+    navigator: { userAgent: '', platform: '', maxTouchPoints: 0 },
+    localStorage: createStorage(),
+    console: { log() {}, warn() {}, error() {} },
+    RTCSessionDescription: function RTCSessionDescription(description) { return description; },
+    setTimeout,
+    clearTimeout,
+    Date,
+    ...globals
+  });
+  vm.runInContext(`${VOICE_SOURCE}\nmodule.exports = VoiceManager;`, context, { filename: 'voice.js' });
+  return context.module.exports;
+}
+
+function createRelayHarness() {
+  const handlers = new Map();
+  const outgoing = [];
+  const socket = {
+    id: 'sender-socket',
+    user: { id: 1, username: 'sender', displayName: 'Sender', isAdmin: false },
+    on(event, handler) { handlers.set(event, handler); },
+    emit() {}
+  };
+  const voiceUsers = new Map([['11111111', new Map([
+    [1, { id: 1, username: 'Sender', socketId: socket.id }],
+    [2, { id: 2, username: 'Viewer', socketId: 'viewer-socket' }]
+  ])]]);
+  const io = {
+    sockets: { sockets: new Map() },
+    to(target) {
+      return {
+        emit(event, payload) { outgoing.push({ target, event, payload }); },
+        to() { return this; }
+      };
+    }
+  };
+  const state = {
+    channelUsers: new Map(),
+    voiceUsers,
+    voiceLastActivity: new Map(),
+    activeMusic: new Map(),
+    activeScreenSharers: new Map(),
+    activeWebcamUsers: new Map(),
+    streamViewers: new Map(),
+    pendingTempDelete: new Map(),
+    pendingVoiceLeave: new Map()
+  };
+  registerVoice(socket, {
+    io,
+    db: {},
+    state,
+    userHasPermission: () => true,
+    getUserEffectiveLevel: () => 0,
+    getUserHighestRole: () => null,
+    broadcastVoiceUsers() {},
+    emitOnlineUsers() {},
+    handleVoiceLeave() {},
+    touchVoiceActivity() {},
+    pruneStaleVoiceUsers: () => [],
+    getMentionableChannelMembers: () => [],
+    getActiveMusicSyncState: () => null,
+    getMusicQueuePayload: () => ({})
+  });
+  return { handlers, outgoing };
+}
+
+test('voice relay accepts large gathered SDP and preserves offer correlation', () => {
+  const { handlers, outgoing } = createRelayHarness();
+  const largeSdp = `v=0\r\n${'a=candidate:screen-share-candidate\r\n'.repeat(1000)}`;
+
+  handlers.get('voice-offer')({
+    code: '11111111',
+    targetUserId: 2,
+    offerId: '1-screen-offer-1',
+    offer: { type: 'offer', sdp: largeSdp }
+  });
+
+  assert.equal(outgoing.length, 1);
+  assert.equal(outgoing[0].target, 'viewer-socket');
+  assert.equal(outgoing[0].event, 'voice-offer');
+  assert.equal(outgoing[0].payload.offerId, '1-screen-offer-1');
+  assert.equal(outgoing[0].payload.offer.sdp, largeSdp);
+
+  handlers.get('voice-answer')({
+    code: '11111111',
+    targetUserId: 2,
+    offerId: '1-screen-offer-1',
+    answer: { type: 'answer', sdp: largeSdp }
+  });
+  assert.equal(outgoing.length, 2);
+  assert.equal(outgoing[1].payload.offerId, '1-screen-offer-1');
+
+  handlers.get('voice-offer')({
+    code: '11111111',
+    targetUserId: 2,
+    offerId: 'too-large',
+    offer: { type: 'offer', sdp: 'x'.repeat(66000) }
+  });
+  assert.equal(outgoing.length, 2);
+});
+
+test('an unanswered offer is rolled back and queued for retry', async () => {
+  const VoiceManager = loadVoiceManager();
+  const voice = Object.create(VoiceManager.prototype);
+  let rollback = null;
+  let drainCalls = 0;
+  const connection = {
+    signalingState: 'have-local-offer',
+    async setLocalDescription(description) {
+      rollback = description;
+      this.signalingState = 'stable';
+    }
+  };
+  const peer = {
+    connection,
+    _awaitingAnswer: true,
+    _activeOfferId: 'offer-current',
+    _offerAnswerTimer: null,
+    _offerTimeoutCount: 0,
+    _offerIsIceRestart: false,
+    _offerChannelCode: '11111111',
+    _renegotiateQueued: false
+  };
+  voice.peers = new Map([[2, peer]]);
+  voice._drainQueuedRenegotiation = userId => {
+    assert.equal(userId, 2);
+    drainCalls++;
+  };
+
+  assert.equal(await voice._recoverTimedOutOffer(2, connection, 'offer-stale'), false);
+  assert.equal(rollback, null);
+
+  assert.equal(await voice._recoverTimedOutOffer(2, connection, 'offer-current'), true);
+  assert.deepEqual(JSON.parse(JSON.stringify(rollback)), { type: 'rollback' });
+  assert.equal(peer._awaitingAnswer, false);
+  assert.equal(peer._activeOfferId, null);
+  assert.equal(peer._renegotiateQueued, true);
+  assert.equal(peer._offerTimeoutCount, 1);
+  assert.equal(drainCalls, 1);
+});
+
+test('a late answer cannot satisfy a newer correlated offer', async () => {
+  const VoiceManager = loadVoiceManager();
+  const handlers = {};
+  const voice = Object.create(VoiceManager.prototype);
+  voice.socket = { on: (event, handler) => { handlers[event] = handler; } };
+  voice.peers = new Map();
+  voice._setupSocketListeners();
+
+  let applied = 0;
+  const connection = {
+    signalingState: 'have-local-offer',
+    async setRemoteDescription() {
+      applied++;
+      this.signalingState = 'stable';
+    }
+  };
+  const peer = {
+    connection,
+    _awaitingAnswer: true,
+    _activeOfferId: 'offer-new',
+    _offerAnswerTimer: null,
+    _offerTimeoutCount: 2,
+    _renegotiateQueued: false,
+    _pendingCandidates: []
+  };
+  voice.peers.set(2, peer);
+
+  await handlers['voice-answer']({
+    from: { id: 2 },
+    offerId: 'offer-old',
+    answer: { type: 'answer', sdp: 'stale' }
+  });
+  assert.equal(applied, 0);
+  assert.equal(peer._activeOfferId, 'offer-new');
+
+  await handlers['voice-answer']({
+    from: { id: 2 },
+    answer: { type: 'answer', sdp: 'legacy-stale' }
+  });
+  assert.equal(applied, 0);
+  assert.equal(peer._activeOfferId, 'offer-new');
+
+  await handlers['voice-answer']({
+    from: { id: 2 },
+    offerId: 'offer-new',
+    answer: { type: 'answer', sdp: 'current' }
+  });
+  assert.equal(applied, 1);
+  assert.equal(peer._awaitingAnswer, false);
+  assert.equal(peer._activeOfferId, null);
+  assert.equal(peer._offerTimeoutCount, 0);
+});
+
+test('rollback failure preserves the pending offer and rearms recovery', async () => {
+  const VoiceManager = loadVoiceManager();
+  const voice = Object.create(VoiceManager.prototype);
+  let scheduled = null;
+  const connection = {
+    signalingState: 'have-local-offer',
+    async setLocalDescription() { throw new Error('rollback failed'); }
+  };
+  const peer = {
+    connection,
+    _awaitingAnswer: true,
+    _activeOfferId: 'offer-current',
+    _offerAnswerTimer: null,
+    _offerTimeoutCount: 0,
+    _renegotiateQueued: false
+  };
+  voice.peers = new Map([[2, peer]]);
+  voice._scheduleOfferAnswerTimeout = (userId, conn, offerId) => {
+    scheduled = { userId, conn, offerId };
+  };
+
+  assert.equal(await voice._recoverTimedOutOffer(2, connection, 'offer-current'), false);
+  assert.equal(peer._awaitingAnswer, true);
+  assert.equal(peer._activeOfferId, 'offer-current');
+  assert.equal(peer._recoveringTimedOutOffer, false);
+  assert.deepEqual(scheduled, { userId: 2, conn: connection, offerId: 'offer-current' });
+});
+
+test('automatic offer recovery stops after its bounded retry budget', async () => {
+  const VoiceManager = loadVoiceManager();
+  const voice = Object.create(VoiceManager.prototype);
+  let drainCalls = 0;
+  const connection = {
+    signalingState: 'have-local-offer',
+    async setLocalDescription() { this.signalingState = 'stable'; }
+  };
+  const peer = {
+    connection,
+    _awaitingAnswer: true,
+    _activeOfferId: 'offer-four',
+    _offerAnswerTimer: null,
+    _offerTimeoutCount: 3,
+    _renegotiateQueued: false
+  };
+  voice.peers = new Map([[2, peer]]);
+  voice._drainQueuedRenegotiation = () => { drainCalls++; };
+
+  assert.equal(await voice._recoverTimedOutOffer(2, connection, 'offer-four'), true);
+  assert.equal(peer._offerTimeoutCount, 4);
+  assert.equal(peer._renegotiateQueued, false);
+  assert.equal(peer._offerRecoveryExhausted, true);
+  assert.equal(drainCalls, 0);
+});
+
+test('a peer that advertised offer IDs cannot answer without correlation', async () => {
+  const VoiceManager = loadVoiceManager();
+  const handlers = {};
+  const voice = Object.create(VoiceManager.prototype);
+  voice.socket = { on: (event, handler) => { handlers[event] = handler; } };
+  voice.peers = new Map();
+  voice._setupSocketListeners();
+
+  let applied = 0;
+  const peer = {
+    connection: {
+      signalingState: 'have-local-offer',
+      async setRemoteDescription() { applied++; }
+    },
+    _awaitingAnswer: true,
+    _activeOfferId: 'offer-current',
+    _offerTimeoutCount: 0,
+    _supportsOfferIds: true
+  };
+  voice.peers.set(2, peer);
+
+  await handlers['voice-answer']({
+    from: { id: 2 },
+    answer: { type: 'answer', sdp: 'uncorrelated' }
+  });
+  assert.equal(applied, 0);
+  assert.equal(peer._awaitingAnswer, true);
+});
+
+test('a new media event restarts an exhausted offer recovery budget', async () => {
+  const VoiceManager = loadVoiceManager();
+  const voice = Object.create(VoiceManager.prototype);
+  const emissions = [];
+  const connection = {
+    signalingState: 'stable',
+    async createOffer() { return { type: 'offer', sdp: 'fresh' }; },
+    async setLocalDescription() { this.signalingState = 'have-local-offer'; }
+  };
+  const peer = {
+    connection,
+    _makingOffer: false,
+    _awaitingAnswer: false,
+    _offerTimeoutCount: 4,
+    _offerRecoveryExhausted: true,
+    _renegotiateQueued: false,
+    _queuedIceRestart: false
+  };
+  voice.peers = new Map([[2, peer]]);
+  voice.currentChannel = '11111111';
+  voice.localUserId = 1;
+  voice.socket = { emit: (event, payload) => emissions.push({ event, payload }) };
+  voice._scheduleOfferAnswerTimeout = () => {};
+
+  assert.equal(await voice._renegotiate(2, connection), true);
+  assert.equal(peer._offerRecoveryExhausted, false);
+  assert.equal(peer._offerTimeoutCount, 0);
+  assert.equal(emissions.length, 1);
+  assert.equal(emissions[0].event, 'voice-offer');
+  assert.equal(emissions[0].payload.offerId, peer._activeOfferId);
+});
+
+test('signaling state guards defer cleanup and drain during recovery', async () => {
+  class FakeMediaStream {
+    constructor(tracks = []) { this.tracks = tracks; }
+    getTracks() { return this.tracks; }
+  }
+  class FakePeerConnection {
+    constructor() {
+      this.signalingState = 'stable';
+      this.connectionState = 'new';
+      this.iceConnectionState = 'new';
+      this.listeners = {};
+    }
+    addEventListener(event, handler) { this.listeners[event] = handler; }
+    getReceivers() { return []; }
+    close() {}
+  }
+  const VoiceManager = loadVoiceManager({
+    MediaStream: FakeMediaStream,
+    RTCPeerConnection: FakePeerConnection
+  });
+  const voice = Object.create(VoiceManager.prototype);
+  voice.peers = new Map();
+  voice.rtcConfig = {};
+  voice.localStream = null;
+  voice.audioBitrate = 0;
+  voice.screenStream = null;
+  voice.isScreenSharing = false;
+  voice.webcamStream = null;
+  voice.isWebcamActive = false;
+  voice.screenSharers = new Set();
+  voice.webcamUsers = new Set();
+  voice._screenDelivered = new Set();
+  let drainCalls = 0;
+  voice._drainQueuedRenegotiation = () => { drainCalls++; };
+
+  await voice._createPeer(2, 'Viewer', false);
+  const peer = voice.peers.get(2);
+  peer._awaitingAnswer = true;
+  peer._activeOfferId = 'offer-current';
+  peer._renegotiateQueued = true;
+  peer._recoveringTimedOutOffer = true;
+  peer.connection.listeners.signalingstatechange();
+  assert.equal(peer._awaitingAnswer, true);
+  assert.equal(peer._activeOfferId, 'offer-current');
+  assert.equal(drainCalls, 0);
+
+  peer._recoveringTimedOutOffer = false;
+  peer._awaitingAnswer = false;
+  peer._handlingRemoteOffer = true;
+  peer.connection.listeners.signalingstatechange();
+  assert.equal(drainCalls, 0);
+
+  peer._handlingRemoteOffer = false;
+  peer.connection.listeners.signalingstatechange();
+  assert.equal(drainCalls, 1);
+});
+
+test('glare rollback failure preserves the outgoing offer and rearms its timer', async () => {
+  const VoiceManager = loadVoiceManager();
+  const handlers = {};
+  const voice = Object.create(VoiceManager.prototype);
+  voice.socket = { on: (event, handler) => { handlers[event] = handler; } };
+  voice.localUserId = 1;
+  voice.peers = new Map();
+  voice._setupSocketListeners();
+
+  let scheduled = null;
+  const connection = {
+    signalingState: 'have-local-offer',
+    connectionState: 'connected',
+    iceConnectionState: 'connected',
+    async setLocalDescription() { throw new Error('rollback failed'); }
+  };
+  const peer = {
+    connection,
+    _makingOffer: false,
+    _awaitingAnswer: true,
+    _activeOfferId: 'offer-current',
+    _offerAnswerTimer: null,
+    _offerIsIceRestart: false,
+    _renegotiateQueued: false
+  };
+  voice.peers.set(2, peer);
+  voice._scheduleOfferAnswerTimeout = (userId, conn, offerId) => {
+    scheduled = { userId, conn, offerId };
+  };
+
+  await handlers['voice-offer']({
+    from: { id: 2, username: 'Viewer' },
+    offerId: 'remote-offer',
+    offer: { type: 'offer', sdp: 'remote' }
+  });
+  assert.equal(peer._awaitingAnswer, true);
+  assert.equal(peer._activeOfferId, 'offer-current');
+  assert.equal(peer._handlingRemoteOffer, false);
+  assert.deepEqual(scheduled, { userId: 2, conn: connection, offerId: 'offer-current' });
+});
+
+test('removing a peer cancels its pending offer timer', () => {
+  const cleared = [];
+  const VoiceManager = loadVoiceManager({
+    clearTimeout: handle => { cleared.push(handle); },
+    document: { getElementById: () => null }
+  });
+  const voice = Object.create(VoiceManager.prototype);
+  let closed = false;
+  voice.peers = new Map([[2, {
+    connection: { close() { closed = true; } },
+    _offerAnswerTimer: 42
+  }]]);
+  voice.screenGainNodes = new Map();
+  voice.gainNodes = new Map();
+  voice._screenDelivered = new Set();
+  voice._stopAnalyser = () => {};
+
+  voice._removePeer(2);
+  assert.deepEqual(cleared, [42]);
+  assert.equal(closed, true);
+  assert.equal(voice.peers.has(2), false);
+});


### PR DESCRIPTION
## Summary

Fixes an intermittent issue where the screen sharer could see their local preview, while other participants saw a black screen or no stream tile. Leaving and rejoining the voice call temporarily restored the stream.

This affects the existing browser-based WebRTC screen-sharing path used by both web clients and Haven Desktop.

## Root cause

Two signaling problems could leave a peer permanently stuck:

1. The server silently rejected SDP offers and answers larger than 16 KB. Screen-share renegotiations can exceed this after ICE/STUN/TURN candidates have already been gathered.
2. When an answer was dropped or rejected, the sender remained indefinitely in `have-local-offer`. Further screen-share recovery requests were queued but could never run. Rejoining worked because it created a fresh `RTCPeerConnection`.

## Changes

- Increase the bounded SDP signaling limit from 16 KB to 64 KB.
- Add optional `offerId` correlation to WebRTC offers and answers.
- Ignore delayed answers belonging to an older offer.
- Roll back and retry unanswered offers with bounded backoff.
- Preserve recovery state if rollback fails.
- Stop automatic retries after the recovery budget is exhausted.
- Reset the retry budget when a new media or connection event requests negotiation.
- Clear pending offer timers during glare handling, peer removal, and channel rotation.
- Keep compatibility with clients that do not yet send `offerId`.
- Bump the `voice.js` cache version.

No native screen-capture transport or Haven Desktop-specific changes are required.

## Testing

- Added signaling tests covering:
  - SDP payloads above the previous 16 KB limit
  - offer/answer correlation
  - delayed and uncorrelated answers
  - unanswered-offer rollback and retry
  - rollback failure during timeout recovery and glare
  - bounded retry exhaustion and restart
  - `signalingstatechange` race guards
  - timer cleanup when removing a peer
- Full suite: `75/75` tests passing
- `node --check` passing
- `git diff --check` passing