### PR TITLE
Add Compact Theme API v1 theme

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -277,6 +277,11 @@ Click **Clear** to remove your avatar and revert to the default initial-letter a
 
 Haven includes 20+ visual themes. Click the **🎨** button at the bottom of the sidebar to open the theme picker. Themes change colors, fonts, and overall aesthetic. Your choice is saved per browser.
 
+Servers also include the optional **Compact** Theme API v1 file theme. An admin
+can publish it from **Settings → Admin → Branding → Custom Themes**. Compact
+tightens the desktop chrome while preserving the user's separate message-density
+choice under **Settings → Layout**.
+
 ### Effect Overlays
 
 Effects are stackable visual layers on top of any theme. Choose from the effect selector in the theme popup:
@@ -682,6 +687,7 @@ Haven also ships a couple of extras that are **installed but switched off by def
 
 | File | What it is |
 |------|-----------|
+| `themes/compact.theme.css` | Compact, a dense graphite Theme API v1 theme |
 | `themes/braid.theme.css` | Braid, a dark mint theme |
 | `themes/braid-light.theme.css` | Braid Light |
 | `plugins/BraidLayout.plugin.js` | Braid's layout changes |

--- a/docs/theme-authoring.md
+++ b/docs/theme-authoring.md
@@ -74,6 +74,11 @@ per browser as an additive CSS tweak from Plugins & Themes.
 Themes are server-managed files. Haven does not download themes from arbitrary
 URLs or provide a per-user raw CSS editor.
 
+`themes/compact.theme.css` is a shipped Theme API v1 example that uses only
+public tokens, page markers, and layout regions. It deliberately leaves message
+geometry to the user's Layout Density setting; structural compaction belongs in
+a plugin.
+
 ## Scoping a theme
 
 Both the login page and the main application expose the API version:
@@ -127,8 +132,8 @@ from the Haven base theme.
 | `--text-link` | Links |
 
 Always check the contrast between `--accent` and `--accent-text`. A light accent
-usually needs dark accent text. Some specialised media and voice controls still
-define their own foreground colours, so verify those surfaces as well.
+usually needs dark accent text. A few specialised media controls use a fixed
+foreground for compatibility with existing themes, so verify those too.
 
 ### Borders and semantic states
 
@@ -137,11 +142,17 @@ define their own foreground colours, so verify those surfaces as well.
 | `--border` | Default border |
 | `--border-light` | Stronger or raised border |
 | `--success` | Positive and connected states |
+| `--success-text` | Foreground on success-filled controls |
 | `--danger` | Destructive and error states |
+| `--danger-text` | Foreground on danger-filled controls |
 | `--warning` | Warning states |
+| `--warning-text` | Foreground on warning-filled controls |
 | `--led-on` | Connected presence indicator |
 | `--led-off` | Disconnected presence indicator |
 | `--led-glow` | Connected indicator glow |
+
+Semantic colours can also appear as text or icons on Haven surfaces. Check each
+state colour against your backgrounds as well as against its paired foreground.
 
 ### Typography and geometry
 

--- a/public/css/music.css
+++ b/public/css/music.css
@@ -243,7 +243,7 @@
   font-weight: 500;
   border-radius: var(--radius);
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-text);
   border: none;
   cursor: pointer;
   animation: pulse-glow 2s ease-in-out infinite;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -70,8 +70,11 @@
   --border-light:  #383b5e;
 
   --success:       #43b581;
+  --success-text:  #fff;
   --danger:        #f04747;
+  --danger-text:   #fff;
   --warning:       #faa61a;
+  --warning-text:  #1a1a2e;
 
   --led-on:        #43b581;
   --led-off:       #555;
@@ -3396,7 +3399,7 @@ html.rgb-cycling *::after {
 .btn-sm:disabled:hover { background: var(--bg-tertiary); color: var(--text-secondary); }
 .btn-sm.btn-accent { background: var(--accent); color: var(--accent-text); font-size: 1rem; padding: 0.4375rem 0.625rem; line-height: 1; }
 .btn-sm.btn-accent:hover { background: var(--accent-hover); }
-.btn-sm.btn-danger { background: var(--danger, #e74c3c); color: white; font-size: 1rem; padding: 0.4375rem 0.625rem; line-height: 1; }
+.btn-sm.btn-danger { background: var(--danger, #e74c3c); color: var(--danger-text); font-size: 1rem; padding: 0.4375rem 0.625rem; line-height: 1; }
 .btn-sm.btn-danger:hover { filter: brightness(1.15); }
 
 /* ── Channel List ──────────────────────────────────────── */
@@ -3443,7 +3446,7 @@ html.rgb-cycling *::after {
 
 .channel-badge {
   background: var(--danger);
-  color: white;
+  color: var(--danger-text);
   font-size: 0.625rem;
   font-weight: 700;
   min-width: 1.125rem;
@@ -3807,7 +3810,7 @@ html.rgb-cycling *::after {
 }
 .dm-pip-send {
   background: var(--accent, #5865f2);
-  color: #fff;
+  color: var(--accent-text);
   border: none;
   border-radius: 0.375rem;
   padding: 0 0.625rem;
@@ -3987,7 +3990,7 @@ html.rgb-cycling *::after {
   gap: 0.375rem;
   padding: 0.25rem 0.75rem;
   background: linear-gradient(135deg, var(--accent), var(--accent-hover));
-  color: #fff;
+  color: var(--accent-text);
   font-size: 0.75rem;
   font-weight: 600;
   border-radius: 1.25rem;
@@ -4001,7 +4004,7 @@ html.rgb-cycling *::after {
 .update-banner:hover {
   transform: scale(1.05);
   box-shadow: 0 2px 12px rgba(var(--accent-rgb, 88, 101, 242), 0.4);
-  color: #fff;
+  color: var(--accent-text);
 }
 /* Low disk warning, admins only (#5505). Amber rather than red: uploads are
    refused but the server is still working, so this is a "go clear some space"
@@ -4028,7 +4031,7 @@ html.rgb-cycling *::after {
   padding: 0.0625rem 0.375rem;
   border-radius: 1rem;
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-text);
 }
 
 /* Member search in the right sidebar. Sits above the roster and filters it as
@@ -4455,7 +4458,7 @@ html.rgb-cycling *::after {
 }
 .desktop-promo-install:hover {
   background: var(--accent-hover);
-  color: #fff;
+  color: var(--accent-text);
   transform: scale(1.03);
 }
 .desktop-promo-later {
@@ -4968,7 +4971,7 @@ select.cfn-select.cfn-input {
   font-size: 0.8125rem; font-weight: 600;
 }
 .border-crop-mode-btn:last-child { border-right: none; }
-.border-crop-mode-btn.active { background: var(--accent, #7aa2ff); color: #fff; }
+.border-crop-mode-btn.active { background: var(--accent, #7aa2ff); color: var(--accent-text); }
 
 /* Shown only for the Crop tool (toggled in _renderBorderEditor). Auto-positions
    the crop handles around the border's opaque pixels; user edits/keeps from there. */
@@ -6107,7 +6110,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   height: 1rem;
   border-radius: 50%;
   background: var(--danger);
-  color: white;
+  color: var(--danger-text);
   font-size: 0.75rem;
   line-height: 1;
   display: none;
@@ -6566,7 +6569,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 .wizard-indicator.active {
   background: var(--accent, #7c5cfc);
   border-color: var(--accent, #7c5cfc);
-  color: #fff;
+  color: var(--accent-text);
   box-shadow: 0 0 12px var(--accent-glow, rgba(124,92,252,0.4));
 }
 
@@ -6694,7 +6697,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .wizard-btn-small:hover {
   background: var(--accent, #7c5cfc);
-  color: #fff;
+  color: var(--accent-text);
 }
 
 .wizard-steps-list {
@@ -6721,7 +6724,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .wizard-btn-primary {
   background: var(--accent, #7c5cfc);
-  color: #fff;
+  color: var(--accent-text);
   border: none;
   border-radius: 0.375rem;
   padding: 0.625rem 1.5rem;
@@ -8971,6 +8974,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 .image-queue-remove:hover {
   background: var(--danger);
+  color: var(--danger-text);
 }
 
 /* Custom dropdown wrapper for native <select> (#5418).
@@ -9948,7 +9952,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 }
 .btn-danger {
   background: var(--danger, #f44);
-  color: #fff;
+  color: var(--danger-text);
   border: none;
   padding: 0.375rem 1.125rem;
   border-radius: var(--radius-sm);
@@ -10446,7 +10450,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 
 .btn-danger-fill {
   background: var(--danger) !important;
-  color: white !important;
+  color: var(--danger-text) !important;
 }
 
 .btn-danger-fill:hover {
@@ -11294,7 +11298,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   padding: 0.0625rem 0.3125rem;
   border-radius: 0.1875rem;
   background: var(--danger);
-  color: #fff;
+  color: var(--danger-text);
   font-weight: 600;
 }
 
@@ -11558,7 +11562,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .btn-unban {
   flex-shrink: 0;
   background: var(--success) !important;
-  color: white !important;
+  color: var(--success-text) !important;
 }
 
 .btn-unban:hover { opacity: 0.85; }
@@ -11573,7 +11577,7 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
 .btn-delete-user {
   flex-shrink: 0;
   background: var(--danger) !important;
-  color: white !important;
+  color: var(--danger-text) !important;
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem !important;
 }
@@ -12991,7 +12995,7 @@ body.is-ios.ios-keyboard-open .message-input-area {
   padding: 0.3125rem 0.625rem; border-radius: 0.25rem; text-align: left; font-size: 0.75rem; white-space: nowrap;
 }
 .stream-layout-opt:hover { background: rgba(255,255,255,0.08); color: #fff; }
-.stream-layout-opt.active { background: var(--accent, #7c5cfc); color: #fff; }
+.stream-layout-opt.active { background: var(--accent, #7c5cfc); color: var(--accent-text); }
 
 .screen-share-tile {
   position: relative;
@@ -13634,7 +13638,7 @@ video:-webkit-full-screen {
   padding: 0.125rem 0.5rem !important;
   font-size: 0.6875rem;
   background: var(--danger) !important;
-  color: #fff !important;
+  color: var(--danger-text) !important;
   border-radius: var(--radius-sm);
   cursor: pointer;
   min-height: 0;
@@ -14754,7 +14758,7 @@ ul.chat-list { list-style-type: disc; }
 }
 .connection-setup-actions .btn-sm.btn-accent {
   border-color: var(--accent);
-  color: #fff;
+  color: var(--accent-text);
 }
 .connection-block { margin-bottom: 0.5rem; }
 .connection-block .connection-row { margin-bottom: 0; }
@@ -15372,7 +15376,7 @@ ul.chat-list { list-style-type: disc; }
   font-size: 0.65rem;
   font-weight: 700;
   background: var(--accent, #7289da);
-  color: #fff;
+  color: var(--accent-text);
   padding: 0.0625rem 0.3125rem;
   border-radius: 0.5rem;
   flex-shrink: 0;
@@ -15603,7 +15607,7 @@ ul.chat-list { list-style-type: disc; }
 }
 .role-sidebar-item.active {
   background: var(--accent, #5865f2);
-  color: #fff;
+  color: var(--accent-text);
 }
 /* Separates the synthetic Admin role from the real roles in the sidebar. */
 .role-sidebar-divider {
@@ -18530,7 +18534,7 @@ ul.chat-list { list-style-type: disc; }
 .qs-badge {
   margin-left: auto;
   background: var(--danger, #ed4245);
-  color: #fff;
+  color: var(--danger-text);
   font-size: 0.6875rem;
   font-weight: 700;
   padding: 0.0625rem 0.375rem;
@@ -19087,11 +19091,11 @@ ul.chat-list { list-style-type: disc; }
   height: 1.3rem;
   border-radius: 50%;
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-text);
   font-size: .72rem;
   flex: 0 0 auto;
 }
-.ferry-step-done .ferry-step-num { background: var(--success, #2ecc71); }
+.ferry-step-done .ferry-step-num { background: var(--success, #2ecc71); color: var(--success-text); }
 
 .ferry-status-ok  { color: var(--success, #2ecc71); font-size: .78rem; margin: 8px 0 0; }
 .ferry-status-bad { color: var(--danger, #e74c3c);  font-size: .78rem; margin: 8px 0 0; }

--- a/public/css/voice.css
+++ b/public/css/voice.css
@@ -100,13 +100,13 @@
 }
 
 .btn-voice:hover { background: var(--bg-hover); color: var(--text-primary); }
-.btn-voice.active { background: var(--success); color: white; }
-.btn-voice.btn-danger { background: var(--danger); color: white; padding: 5px 10px; font-size: 14px; }
+.btn-voice.active { background: var(--success); color: var(--success-text); }
+.btn-voice.btn-danger { background: var(--danger); color: var(--danger-text); padding: 5px 10px; font-size: 14px; }
 .btn-voice.btn-danger:hover { background: #d93636; }
-.btn-voice.muted { background: var(--warning); color: #1a1a2e; }
+.btn-voice.muted { background: var(--warning); color: var(--warning-text); }
 .btn-voice.sharing {
   background: var(--danger) !important;
-  color: #fff !important;
+  color: var(--danger-text) !important;
 }
 
 .voice-active-indicator {
@@ -451,7 +451,7 @@
 .voice-panel-btn:hover { background: var(--bg-hover); color: var(--text-primary); border-color: var(--accent); }
 .voice-panel-btn:disabled { opacity: 0.32; cursor: not-allowed; filter: grayscale(0.6); }
 .voice-panel-btn:disabled:hover { background: transparent; border-color: var(--border); color: var(--text-muted); }
-.voice-panel-btn.muted { background: var(--warning); color: #1a1a2e; border-color: var(--warning); position: relative; }
+.voice-panel-btn.muted { background: var(--warning); color: var(--warning-text); border-color: var(--warning); position: relative; }
 .voice-panel-btn.muted::after {
   content: '';
   position: absolute;
@@ -461,8 +461,8 @@
   transform: rotate(-45deg);
   pointer-events: none;
 }
-.voice-panel-btn.sharing { background: var(--success); color: #fff; border-color: var(--success); }
-.voice-panel-btn.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.voice-panel-btn.sharing { background: var(--success); color: var(--success-text); border-color: var(--success); }
+.voice-panel-btn.active { background: var(--accent); color: var(--accent-text); border-color: var(--accent); }
 .voice-panel-divider {
   width: 1px;
   height: 22px;
@@ -470,7 +470,7 @@
   margin: 0 2px;
   flex-shrink: 0;
 }
-.voice-panel-leave { width: 28px; height: 28px; font-size: 12px; background: var(--danger); color: #fff; border-color: var(--danger); }
+.voice-panel-leave { width: 28px; height: 28px; font-size: 12px; background: var(--danger); color: var(--danger-text); border-color: var(--danger); }
 .voice-panel-leave:hover { background: #d93636; color: #fff; border-color: #d93636; }
 
 .voice-panel-header {
@@ -499,8 +499,8 @@
   flex-shrink: 0;
 }
 .voice-header-btn:hover { background: var(--bg-hover); color: var(--text-primary); border-color: var(--accent); }
-.voice-header-btn.active { background: var(--accent); color: #fff; border-color: var(--accent); }
-.voice-header-btn.muted { background: var(--warning); color: #1a1a2e; border-color: var(--warning); position: relative; }
+.voice-header-btn.active { background: var(--accent); color: var(--accent-text); border-color: var(--accent); }
+.voice-header-btn.muted { background: var(--warning); color: var(--warning-text); border-color: var(--warning); position: relative; }
 .voice-header-btn.muted::after {
   content: '';
   position: absolute;
@@ -510,7 +510,7 @@
   transform: rotate(-45deg);
   pointer-events: none;
 }
-.voice-header-leave { background: var(--danger); color: #fff; border-color: var(--danger); }
+.voice-header-leave { background: var(--danger); color: var(--danger-text); border-color: var(--danger); }
 .voice-header-leave:hover { background: #d93636; color: #fff; border-color: #d93636; }
 
 .voice-settings-panel {

--- a/test/themeContract.test.js
+++ b/test/themeContract.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const { parseThemeMetadata } = require('../src/themeMetadata');
 
 const ROOT = path.join(__dirname, '..');
 
@@ -19,6 +20,64 @@ function attributeValues(html, attribute) {
 function declaredProperties(css) {
   const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
   return new Set([...withoutComments.matchAll(/(--[a-z0-9-]+)\s*:/gi)].map(match => match[1]));
+}
+
+function cssRules(css) {
+  const source = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const stack = [];
+  const rules = [];
+  let tokenStart = 0;
+
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === '{') {
+      const prelude = source.slice(tokenStart, i).trim();
+      const entry = prelude.startsWith('@')
+        ? { type: 'at-rule', prelude }
+        : {
+            type: 'rule',
+            selector: prelude,
+            bodyStart: i + 1,
+            atRules: stack.filter(item => item.type === 'at-rule').map(item => item.prelude),
+          };
+      stack.push(entry);
+      tokenStart = i + 1;
+      continue;
+    }
+    if (source[i] === '}') {
+      const entry = stack.pop();
+      if (entry?.type === 'rule') {
+        entry.declarations = source.slice(entry.bodyStart, i);
+        rules.push(entry);
+      }
+      tokenStart = i + 1;
+      continue;
+    }
+    if (source[i] === ';') tokenStart = i + 1;
+  }
+  return rules;
+}
+
+function declarationNames(block) {
+  return [...block.matchAll(/(?:^|;)\s*([a-z-]+)\s*:/gi)].map(match => match[1]);
+}
+
+function declarationMap(block) {
+  return Object.fromEntries(
+    [...block.matchAll(/(?:^|;)\s*([a-z-]+)\s*:\s*([^;]+)/gi)]
+      .map(match => [match[1], match[2].trim()])
+  );
+}
+
+function contrastRatio(first, second) {
+  const luminance = hex => {
+    const channels = hex.slice(1).match(/../g).map(value => parseInt(value, 16) / 255);
+    const linear = channels.map(value => value <= 0.04045
+      ? value / 12.92
+      : ((value + 0.055) / 1.055) ** 2.4);
+    return linear[0] * 0.2126 + linear[1] * 0.7152 + linear[2] * 0.0722;
+  };
+  const values = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (values[0] + 0.05) / (values[1] + 0.05);
 }
 
 const APP_REGIONS = [
@@ -82,8 +141,11 @@ const PUBLIC_TOKENS = [
   '--border',
   '--border-light',
   '--success',
+  '--success-text',
   '--danger',
+  '--danger-text',
   '--warning',
+  '--warning-text',
   '--led-on',
   '--led-off',
   '--led-glow',
@@ -196,6 +258,170 @@ test('the theme template targets Theme API v1 and stable layout regions', () => 
   assert.match(template, /\[data-haven-region="navigation-sidebar"\]/);
   assert.match(template, /\[data-haven-region="context-sidebar"\]/);
   assert.doesNotMatch(template, /(?:^|\n)\s*\.main\s*\{/);
+});
+
+test('the Compact theme stays inside the Theme API v1 contract', () => {
+  const theme = read('themes/compact.theme.css');
+  const metadata = parseThemeMetadata(theme);
+  const properties = declaredProperties(theme);
+  const rules = cssRules(theme);
+  const regions = new Set();
+  const pages = new Set();
+  const publicRegions = new Set([...APP_REGIONS, ...AUTH_REGIONS]);
+  const geometryProperties = new Set([
+    'align-content', 'align-items', 'align-self', 'bottom', 'column-gap',
+    'display', 'flex', 'flex-basis', 'flex-direction', 'flex-flow', 'flex-grow',
+    'flex-shrink', 'flex-wrap', 'gap', 'grid', 'grid-area', 'grid-auto-columns',
+    'grid-auto-flow', 'grid-auto-rows', 'grid-column', 'grid-column-end',
+    'grid-column-gap', 'grid-column-start', 'grid-gap', 'grid-row',
+    'grid-row-end', 'grid-row-gap', 'grid-row-start', 'grid-template',
+    'grid-template-areas', 'grid-template-columns', 'grid-template-rows',
+    'height', 'inset', 'inset-block', 'inset-block-end', 'inset-block-start',
+    'inset-inline', 'inset-inline-end', 'inset-inline-start', 'justify-content',
+    'justify-items', 'justify-self', 'left', 'margin', 'margin-block',
+    'margin-block-end', 'margin-block-start', 'margin-inline',
+    'margin-inline-end', 'margin-inline-start', 'max-height', 'max-width',
+    'min-height', 'min-width', 'order', 'overflow', 'overflow-x', 'overflow-y',
+    'padding', 'padding-block', 'padding-block-end', 'padding-block-start',
+    'padding-inline', 'padding-inline-end', 'padding-inline-start',
+    'place-content', 'place-items', 'place-self', 'position', 'right',
+    'row-gap', 'top', 'transform', 'translate', 'width', 'z-index'
+  ]);
+  const geometryTokens = new Set(['--right-width', '--sidebar-width']);
+
+  assert.equal(metadata.name, 'Compact');
+  assert.equal(metadata.themeApi, 1);
+  assert.equal(metadata.compatibility, 'compatible');
+  assert.match(theme, /@media\s*\(min-width:\s*901px\)/);
+  assert.doesNotMatch(theme, /--msg-(?:pad|avatar|gap|gutter)/);
+  assert.doesNotMatch(theme, /!important/);
+
+  for (const property of properties) {
+    assert.ok(PUBLIC_TOKENS.includes(property), `Compact uses non-public token ${property}`);
+  }
+  for (const token of theme.matchAll(/var\((--[a-z0-9-]+)/gi)) {
+    assert.ok(PUBLIC_TOKENS.includes(token[1]), `Compact reads non-public token ${token[1]}`);
+  }
+
+  for (const rule of rules) {
+    const names = declarationNames(rule.declarations);
+    if (names.some(name => geometryTokens.has(name))) {
+      assert.ok(
+        rule.atRules.some(atRule => /^@media\s*\(min-width:\s*901px\)$/.test(atRule)),
+        'Compact geometry tokens must only change at the desktop breakpoint'
+      );
+    }
+    for (const selector of rule.selector.split(',').map(value => value.trim())) {
+      if (selector === ':root') continue;
+      if (selector === 'html[data-haven-theme-api="1"]') continue;
+      const match = selector.match(/^html\[data-haven-theme-api="1"\] body\[data-haven-page="(app|auth)"\] \[data-haven-region="([a-z-]+)"\]$/);
+      assert.ok(match, `Compact uses selector outside Theme API v1: ${selector}`);
+      pages.add(match[1]);
+      regions.add(match[2]);
+      assert.ok(publicRegions.has(match[2]), `Compact uses non-public region ${match[2]}`);
+
+      if (match[1] === 'app' && names.some(name => geometryProperties.has(name))) {
+        assert.ok(
+          rule.atRules.some(atRule => /^@media\s*\(min-width:\s*901px\)$/.test(atRule)),
+          `Compact changes app geometry outside the desktop breakpoint: ${selector}`
+        );
+      }
+      if (match[2] === 'message-list') {
+        assert.ok(
+          !names.some(name => ['column-gap', 'gap', 'row-gap'].includes(name)),
+          'Compact must preserve message-list density'
+        );
+      }
+    }
+  }
+  assert.deepEqual([...pages].sort(), ['app', 'auth']);
+  assert.ok(regions.size > 0);
+});
+
+test('core semantic fills use their paired foreground tokens', () => {
+  const tokenPairs = new Map([
+    ['--accent', '--accent-text'],
+    ['--accent-hover', '--accent-text'],
+    ['--success', '--success-text'],
+    ['--danger', '--danger-text'],
+    ['--warning', '--warning-text']
+  ]);
+  const fixedMediaForegrounds = new Set([
+    'music.css:.music-search-picker-more',
+    'music.css:.music-search-picker-play'
+  ]);
+  const statePairs = [
+    ['style.css', '.update-banner:hover', '--accent-text'],
+    ['style.css', '.image-queue-remove:hover', '--danger-text'],
+    ['style.css', '.ferry-step-done .ferry-step-num', '--success-text']
+  ];
+  const cssDirectory = path.join(ROOT, 'public/css');
+  const stylesheets = fs.readdirSync(cssDirectory).filter(file => file.endsWith('.css'));
+  const rulesByStylesheet = new Map();
+
+  for (const stylesheet of stylesheets) {
+    const rules = cssRules(fs.readFileSync(path.join(cssDirectory, stylesheet), 'utf8'));
+    rulesByStylesheet.set(stylesheet, rules);
+    for (const rule of rules) {
+      const declarations = declarationMap(rule.declarations);
+      const background = declarations.background || declarations['background-color'];
+      if (!background || !declarations.color) continue;
+
+      for (const [fill, foreground] of tokenPairs) {
+        const fillPattern = new RegExp(`var\\(${fill}(?=[,)])`);
+        const isDirectFill = new RegExp(`^var\\(${fill}(?=[,)])`).test(background);
+        const isGradientFill = /^(?:linear|radial)-gradient\(/.test(background) && fillPattern.test(background);
+        if (!isDirectFill && !isGradientFill) continue;
+        const ruleKey = `${stylesheet}:${rule.selector}`;
+        if (fixedMediaForegrounds.has(ruleKey)) {
+          assert.equal(declarations.color, '#000', `${ruleKey} must preserve its compatible media foreground`);
+          continue;
+        }
+        assert.match(
+          declarations.color,
+          new RegExp(`var\\(${foreground}(?=[,)])`),
+          `${stylesheet}: ${rule.selector} must pair ${fill} with ${foreground}`
+        );
+      }
+    }
+  }
+
+  for (const [stylesheet, selector, foreground] of statePairs) {
+    const rule = rulesByStylesheet.get(stylesheet).find(candidate => candidate.selector === selector);
+    assert.ok(rule, `${stylesheet}: missing semantic state ${selector}`);
+    assert.match(
+      declarationMap(rule.declarations).color || '',
+      new RegExp(`var\\(${foreground}(?=[,)])`),
+      `${stylesheet}: ${selector} must use ${foreground}`
+    );
+  }
+});
+
+test('the Compact palette keeps status text and filled controls readable', () => {
+  const theme = read('themes/compact.theme.css');
+  const rootRule = cssRules(theme).find(rule => rule.selector === ':root' && rule.atRules.length === 0);
+  assert.ok(rootRule, 'Compact is missing its root token rule');
+  const colors = Object.fromEntries(
+    [...rootRule.declarations.matchAll(/(--[a-z-]+)\s*:\s*(#[0-9a-f]{6})\s*;/gi)]
+      .map(match => [match[1], match[2]])
+  );
+
+  const tokenPairs = [
+    ['--accent', '--accent-text'],
+    ['--accent-hover', '--accent-text'],
+    ['--success', '--success-text'],
+    ['--danger', '--danger-text'],
+    ['--warning', '--warning-text']
+  ];
+  for (const [fill, foreground] of tokenPairs) {
+    assert.ok(contrastRatio(colors[fill], colors[foreground]) >= 4.5, `${fill} fails filled-control contrast`);
+  }
+  for (const token of ['--accent', '--success', '--danger', '--warning']) {
+    assert.ok(contrastRatio(colors[token], colors['--bg-secondary']) >= 4.5, `${token} fails secondary-surface contrast`);
+    assert.ok(contrastRatio(colors[token], colors['--bg-card']) >= 4.5, `${token} fails card-surface contrast`);
+  }
+  assert.ok(contrastRatio(colors['--text-muted'], colors['--bg-secondary']) >= 4.5);
+  assert.ok(contrastRatio(colors['--text-muted'], colors['--bg-card']) >= 4.5);
 });
 
 test('the authoring reference covers every public region and token', () => {

--- a/themes/compact.theme.css
+++ b/themes/compact.theme.css
@@ -1,0 +1,212 @@
+/**
+ * @name Compact
+ * @description Dense graphite chrome with narrow panels and crisp cyan accents. Respects the selected message density.
+ * @author bernardokcosta
+ * @version 1.0
+ * @icon C
+ * @haven-theme-api 1
+ */
+
+/*
+  Compact is a pure Theme API v1 theme. It tightens stable application regions
+  on desktop but leaves message geometry to Haven's Layout Density setting and
+  reserves structural changes for a future Compact Layout plugin.
+*/
+
+:root {
+  --bg-primary: #0d1117;
+  --bg-secondary: #151b23;
+  --bg-tertiary: #10161e;
+  --bg-hover: #1d2631;
+  --bg-active: #263342;
+  --bg-input: #0a0f15;
+  --bg-card: #131a22;
+
+  --accent: #63d2ff;
+  --accent-hover: #91e0ff;
+  --accent-glow: rgba(99, 210, 255, 0.3);
+  --accent-text: #071116;
+
+  --text-primary: #e8edf2;
+  --text-secondary: #aeb9c5;
+  --text-muted: #8391a1;
+  --text-link: #84d9ff;
+
+  --border: #283341;
+  --border-light: #3a4859;
+
+  --success: #4bd39b;
+  --success-text: #07110c;
+  --danger: #ff6b7a;
+  --danger-text: #000000;
+  --warning: #f2bd62;
+  --warning-text: #1b1104;
+  --led-on: #4bd39b;
+  --led-off: #465362;
+  --led-glow: rgba(75, 211, 155, 0.32);
+
+  --font-main: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --font-heading: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+
+  --radius: 0.3rem;
+  --radius-sm: 0.2rem;
+  --transition: 0.1s ease-out;
+  --msg-glow: none;
+  --scanline: none;
+}
+
+html[data-haven-theme-api="1"] {
+  color-scheme: dark;
+  background: var(--bg-primary);
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="server-rail"] {
+  background: var(--bg-tertiary);
+  border-inline-end: 1px solid var(--border);
+  scrollbar-color: var(--border-light) transparent;
+  scrollbar-width: thin;
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="navigation-sidebar"],
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="context-sidebar"] {
+  background: var(--bg-secondary);
+  scrollbar-color: var(--border-light) transparent;
+  scrollbar-width: thin;
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="navigation-sidebar"] {
+  border-inline-end: 1px solid var(--border);
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="context-sidebar"] {
+  border-inline-start: 1px solid var(--border);
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="main"],
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="message-area"] {
+  background: var(--bg-primary);
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="channel-header"],
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="composer"] {
+  background: var(--bg-secondary);
+  border-color: var(--border);
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="webcams"],
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="screen-shares"],
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="music-player"],
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="pinned-messages"] {
+  background: var(--bg-card);
+  border-color: var(--border);
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="message-list"],
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="sidebar-content"],
+html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="member-list"] {
+  scrollbar-color: var(--border-light) transparent;
+  scrollbar-width: thin;
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="auth"] [data-haven-region="auth-shell"] {
+  max-width: 23rem;
+  padding: 1rem;
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="auth"] [data-haven-region="auth-card"] {
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  box-shadow: 0 0.75rem 2.5rem rgba(0, 0, 0, 0.32);
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="auth"] [data-haven-region="auth-header"] {
+  margin-block-end: 1.125rem;
+}
+
+html[data-haven-theme-api="1"] body[data-haven-page="auth"] [data-haven-region="theme-picker"] {
+  gap: 0.25rem;
+  margin-block-start: 0.875rem;
+  padding-block-start: 0.625rem;
+}
+
+@media (min-width: 901px) {
+  :root {
+    --sidebar-width: 14.5rem;
+    --right-width: 15.5rem;
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="server-rail"] {
+    gap: 0.375rem;
+    padding: 0.5rem 0.375rem;
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="navigation-sidebar"] {
+    width: var(--sidebar-width);
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="account"] {
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--border);
+    background: var(--bg-tertiary);
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="join-channel"],
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="create-channel"] {
+    padding: 0.5rem 0.75rem;
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="channels"],
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="direct-messages"] {
+    padding: 0.5rem 0.75rem 0;
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="sidebar-footer"] {
+    background: var(--bg-tertiary);
+    border-block-start: 1px solid var(--border);
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="theme-picker"] {
+    gap: 0.25rem;
+    padding-block: 0.125rem;
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="channel-header"] {
+    min-height: 2.75rem;
+    gap: 0.5rem;
+    padding: 0.5rem 0.875rem;
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="message-list"] {
+    padding: 0.625rem 0.875rem;
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="composer"] {
+    gap: 0.375rem;
+    padding: 0.5rem 0.75rem 0.625rem;
+    border-block-start: 1px solid var(--border);
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="context-sidebar"] {
+    width: var(--right-width);
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="voice-roster"],
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="member-list"] {
+    border-block-end: 1px solid var(--border);
+  }
+
+  html[data-haven-theme-api="1"] body[data-haven-page="app"] [data-haven-region="status-bar"] {
+    min-height: 1.375rem;
+    padding-inline: 0.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition: 0s;
+  }
+}

--- a/themes/custom.css.example
+++ b/themes/custom.css.example
@@ -80,8 +80,11 @@
 
   /* ── Status colors ─────────────────────────────── */
   --success:       #43b581;
+  --success-text:  #ffffff;   /* text on success-filled controls */
   --danger:        #f04747;
+  --danger-text:   #ffffff;   /* text on danger-filled controls */
   --warning:       #faa61a;
+  --warning-text:  #1a1a2e;   /* text on warning-filled controls */
 
   /* ── Online indicator LED ──────────────────────── */
   --led-on:        #43b581;


### PR DESCRIPTION
## Summary

- ship an optional CSS-only Compact theme using Theme API v1
- add paired foreground tokens for success, danger, and warning controls
- migrate semantic and accent-filled controls to the appropriate foreground tokens
- document the new theme and public tokens
- add contract tests for selectors, responsive geometry, message density, semantic token pairing, and palette contrast

## Details

Compact uses a graphite and cyan palette with narrower desktop panels, tighter stable layout regions, reduced radii, and faster transitions.

The theme:

- uses only public Theme API v1 tokens, page markers, and layout regions
- applies compact geometry only above the 900px desktop breakpoint
- preserves the user's Layout Density setting
- keeps the existing tablet and mobile panel behavior
- does not include JavaScript or structural layout changes
- leaves structural compaction for a future Compact Layout plugin

The new `--success-text`, `--danger-text`, and `--warning-text` tokens preserve Haven's existing default appearance while allowing themes with bright semantic colors to provide readable foregrounds.

## Testing

- `npm test` — 123 tests passed
- focused theme suites — 38 tests passed
- `node scripts/validate-locales.js` — all 7 locale files passed
- `git diff --check`
- browser validation at 1440x900, 800x900, and 390x844
- login and application pages checked for horizontal overflow
- tablet and mobile off-canvas panels checked
- semantic normal and hover states checked through computed styles