### PR TITLE
Markdown link pasting

### DIFF
--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2372,6 +2372,31 @@ _openInviteLinksModal() {
 },
 
 // ═══════════════════════════════════════════════════════
+// markdown link pasting 
+// ═══════════════════════════════════════════════════════
+
+_handleMarkdownLinkPaste(input, event) {
+  const url = event.clipboardData.getData('text/plain').trim();
+  // Only handle pasted URLs.
+  if (!/^https?:\/\/\S+$/i.test(url)) {
+    return;
+  }
+
+  const start = input.selectionStart;
+  const end = input.selectionEnd;
+  // Nothing selected, so allow normal paste behavior.
+  if (start === end) {
+    return;
+  }
+
+  // hijack the paste event and insert markdown link on highlighted text
+  event.preventDefault();
+  const selectedText = input.value.substring(start, end);
+  const markdownLink = `[${selectedText}](${url})`;
+  input.setRangeText(markdownLink, start, end, 'end');
+},
+
+// ═══════════════════════════════════════════════════════
 // @MENTION AUTOCOMPLETE
 // ═══════════════════════════════════════════════════════
 

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -237,10 +237,6 @@ _setupUI() {
     this._checkFerryTrigger();
   });
 
-  msgInput.addEventListener('paste', (event) => {
-    this._handleMarkdownLinkPaste(msgInput, event); 
-  });
-
   document.getElementById('send-btn').addEventListener('click', () => this._sendMessage());
 
   // Join channel
@@ -2201,11 +2197,9 @@ _setupUI() {
         return;
       }
     }
-  });
 
-  // insert a markdown link when a link is pasted over selected text
-  if (dmPipInput) dmPipInput.addEventListener('paste', (event) => {
-    this._handleMarkdownLinkPaste(dmPipInput, event); 
+    // insert a markdown link when a link is pasted over selected text
+    this._handleMarkdownLinkPaste(dmPipInput, e);
   });
 
   // PiP emoji button — positions the picker above the button and targets the PiP input
@@ -2364,10 +2358,9 @@ _setupUI() {
           return;
         }
       }
-    });
-    // insert a markdown link when a link is pasted over selected text
-    threadInput.addEventListener('paste', (event) => {
-      this._handleMarkdownLinkPaste(threadInput, event); 
+
+      // insert a markdown link when a link is pasted over selected text
+      this._handleMarkdownLinkPaste(threadInput, e); 
     });
 
     // Drag & drop parity with the other composers — queue, never insta-post.
@@ -5637,6 +5630,9 @@ _setupImageUpload() {
         return;
       }
     }
+
+    // insert a markdown link when a link is pasted over selected text
+    this._handleMarkdownLinkPaste(msgInput, e);
   });
 
   // Drag & drop — QUEUE instead of uploading immediately

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -237,6 +237,11 @@ _setupUI() {
     this._checkFerryTrigger();
   });
 
+  // insert a markdown link when a link is pasted over selected text
+  msgInput.addEventListener('paste', (event) => {
+    this._handleMarkdownLinkPaste(msgInput, event); 
+  });
+
   document.getElementById('send-btn').addEventListener('click', () => this._sendMessage());
 
   // Join channel
@@ -5630,9 +5635,6 @@ _setupImageUpload() {
         return;
       }
     }
-
-    // insert a markdown link when a link is pasted over selected text
-    this._handleMarkdownLinkPaste(msgInput, e);
   });
 
   // Drag & drop — QUEUE instead of uploading immediately

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -237,6 +237,10 @@ _setupUI() {
     this._checkFerryTrigger();
   });
 
+  msgInput.addEventListener('paste', (event) => {
+    this._handleMarkdownLinkPaste(msgInput, event); 
+  });
+
   document.getElementById('send-btn').addEventListener('click', () => this._sendMessage());
 
   // Join channel

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -2203,6 +2203,11 @@ _setupUI() {
     }
   });
 
+  // insert a markdown link when a link is pasted over selected text
+  if (dmPipInput) dmPipInput.addEventListener('paste', (event) => {
+    this._handleMarkdownLinkPaste(dmPipInput, event); 
+  });
+
   // PiP emoji button — positions the picker above the button and targets the PiP input
   const dmPipEmojiBtn = document.getElementById('dm-pip-emoji-btn');
   if (dmPipEmojiBtn) {
@@ -2359,6 +2364,10 @@ _setupUI() {
           return;
         }
       }
+    });
+    // insert a markdown link when a link is pasted over selected text
+    threadInput.addEventListener('paste', (event) => {
+      this._handleMarkdownLinkPaste(threadInput, event); 
     });
 
     // Drag & drop parity with the other composers — queue, never insta-post.


### PR DESCRIPTION
Adds the ability to paste a link over highlighted text in message input areas to create an embedded markdown link.

This shortcut reduces the need to remember and type out the markdown link formatting directly.