### PR TITLE
[feat+QoL] Unified user context menu + profile card re-design 

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6868,9 +6868,9 @@ details.sound-section:not([open]) .sound-section-label::before {
 .image-lightbox {
   position: fixed;
   inset: 0;
-  /* Sit above modal overlays (which use z-index: 100001) so opening a
-     lightbox from inside the media gallery actually appears in front. */
-  z-index: 100010;
+  /* Sit above modal overlays (100001) and the profile card (100010) so opening
+     a lightbox from the media gallery or a profile avatar appears in front. */
+  z-index: 100020;
   background: rgba(0, 0, 0, 0.85);
   display: flex;
   align-items: center;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -5835,22 +5835,6 @@ details.sound-section:not([open]) .sound-section-label::before {
 }
 .profile-edit-btn:hover { background: var(--bg-hover); }
 
-.profile-nick-btn {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  margin-top: 0.375rem;
-  border: 1px solid var(--border-light) !important;
-}
-.profile-nick-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
-
-.profile-gear-btn {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  margin-top: 0.375rem;
-  border: 1px solid var(--border-light) !important;
-}
-.profile-gear-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
-
 /* ── Edit Profile Modal ──────────────────────────── */
 .edit-profile-modal-box {
   width: 23.75rem;
@@ -7059,6 +7043,14 @@ details.sound-section:not([open]) .sound-section-label::before {
 .user-ctx-submenu button:hover {
   background: var(--bg-hover, rgba(124,92,252,0.15));
 }
+/* Section divider + destructive (danger) items, folded in from the old gear menu */
+.user-ctx-divider {
+  height: 0.0625rem;
+  background: var(--border, rgba(255,255,255,0.12));
+  margin: 0.25rem 0.5rem;
+}
+.user-context-menu > button.user-ctx-danger { color: var(--danger); }
+.user-context-menu > button.user-ctx-danger:hover { background: rgba(233,69,96,0.12); color: var(--danger); }
 
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -10545,62 +10537,12 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   background: var(--bg-tertiary);
 }
 
-/* ── User gear dropdown menu ─────────────── */
-.user-gear-menu {
-  position: fixed;
-  /* The menu is appended to <body>, so it stacks against the whole page rather
-     than inside the member list it belongs to. At <= 900px the right sidebar
-     becomes a fixed overlay at z-index 100000, which left this menu (10002)
-     rendering behind the very sidebar it was opened from, so clicking the gear
-     looked like it did nothing (#5462). 100010 matches the value already used
-     elsewhere for popups that must clear modal overlays (100001), which also
-     covers opening this menu from the profile popup. */
-  z-index: 100010;
-  min-width: 10rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: 0 6px 24px rgba(0,0,0,0.5);
-  padding: 0.25rem;
-  display: flex;
-  flex-direction: column;
-  animation: gear-menu-in 0.12s ease-out;
-}
-@keyframes gear-menu-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.gear-menu-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.4375rem 0.625rem;
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
-  background: none;
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: background 0.1s, color 0.1s;
-  width: 100%;
-  text-align: left;
-}
-.gear-menu-item:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-.gear-menu-danger { color: var(--danger); }
-.gear-menu-danger:hover { background: rgba(233,69,96,0.12); color: var(--danger); }
-.gear-menu-divider { height: 0.0625rem; background: var(--border); margin: 0.25rem 0.125rem; }
-
 /* ── Context menu scroll fallback (#5286) ──
    Floating menus (right-click, gear, channel, image, etc.) get capped to the
    viewport with overflow-y: auto so long menus scroll instead of clipping
    or running off-screen. The 16px margin keeps a little breathing room.
    .user-context-menu is omitted because its hover submenu would get clipped
    by overflow:auto; it stays short on its own. */
-.user-gear-menu,
 .channel-ctx-menu,
 .image-context-menu,
 .channel-functions-panel {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -5606,51 +5606,17 @@ details.sound-section:not([open]) .sound-section-label::before {
      uses for exactly this reason (#5462). */
   z-index: 100010;
   width: 20rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius);
-  box-shadow: 0 8px 32px rgba(0,0,0,0.7);
-  overflow: hidden;
-  animation: profile-popup-in 0.18s ease-out;
-  opacity: 1;
-  backdrop-filter: none;
-}
-
-/* Hover-over variant: translucent tooltip, non-interactive */
-.profile-popup-hover {
+  /* Translucent, theme-aware glass — colours come from CSS vars so it tracks
+     the active theme in both light and dark. */
   background: color-mix(in srgb, var(--bg-secondary) 65%, transparent);
   backdrop-filter: blur(20px) saturate(1.3);
   -webkit-backdrop-filter: blur(20px) saturate(1.3);
-  border-color: color-mix(in srgb, var(--border-light) 50%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-light) 50%, transparent);
+  border-radius: var(--radius);
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
-  animation: profile-popup-hover-in 0.15s ease-out;
-  transition: opacity 0.2s ease, transform 0.2s ease;
-  pointer-events: none;  /* can't be interacted with — it's a tooltip */
-}
-.profile-popup-hover .profile-popup-banner {
-  opacity: 0.7;
-}
-.profile-popup-hover .profile-popup-close {
-  display: none;  /* no X button on tooltip */
-}
-.profile-popup-hover .profile-popup-body {
-  background: transparent;
-}
-.profile-popup-hover .profile-popup-actions {
-  display: none;
-}
-
-/* Fade-out for hover popups */
-.profile-popup-fading {
-  opacity: 0 !important;
-  transform: translateY(4px) !important;
-  pointer-events: none !important;
-  transition: opacity 0.2s ease, transform 0.2s ease !important;
-}
-
-@keyframes profile-popup-hover-in {
-  from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
+  overflow: hidden;
+  animation: profile-popup-in 0.18s ease-out;
+  opacity: 1;
 }
 
 @keyframes profile-popup-in {
@@ -5717,7 +5683,7 @@ details.sound-section:not([open]) .sound-section-label::before {
 
 .profile-popup-body {
   padding: 0.625rem 1rem 1rem;
-  background: var(--bg-secondary);
+  background: transparent;
 }
 
 .profile-popup-names {

--- a/public/js/modules/app-context.js
+++ b/public/js/modules/app-context.js
@@ -2,7 +2,7 @@ export default {
 
 // ── User Context Menu (right-click → options) ──
 
-_showUserContextMenu(e, targetUserId) {
+_showUserContextMenu(e, targetUserId, targetNameOverride) {
   this._hideUserContextMenu();
   this._closeProfilePopup();
 
@@ -10,9 +10,10 @@ _showUserContextMenu(e, targetUserId) {
   menu.id = 'user-context-menu';
   menu.className = 'user-context-menu';
 
-  // Find target username from online users
+  // Find target username from online users; fall back to a caller-supplied name
+  // (e.g. the author name on a chat message, whose sender may be offline).
   const targetUser = (this._lastOnlineUsers || []).find(u => u.id === targetUserId);
-  const targetName = targetUser ? targetUser.username : 'User';
+  const targetName = targetUser ? targetUser.username : (targetNameOverride || 'User');
 
   // Header with username
   const header = document.createElement('div');
@@ -20,27 +21,37 @@ _showUserContextMenu(e, targetUserId) {
   header.textContent = targetName;
   menu.appendChild(header);
 
-  // 1) View Profile
-  const profileBtn = document.createElement('button');
-  profileBtn.innerHTML = `👤 ${t('context.view_profile')}`;
-  profileBtn.addEventListener('click', () => {
+  // Helper: append a menu button. `danger` paints it red (destructive action).
+  const addBtn = (label, onClick, danger = false) => {
+    const btn = document.createElement('button');
+    btn.innerHTML = label;
+    if (danger) btn.classList.add('user-ctx-danger');
+    btn.addEventListener('click', onClick);
+    menu.appendChild(btn);
+  };
+  const addDivider = () => {
+    const div = document.createElement('div');
+    div.className = 'user-ctx-divider';
+    menu.appendChild(div);
+  };
+
+  // ── Section 1: profile / social (always available) ──
+
+  // View Profile
+  addBtn(`👤 ${t('context.view_profile')}`, () => {
     this._hideUserContextMenu();
     this._profilePopupAnchor = e.target.closest('.user-item') || e.target;
     this.socket.emit('get-user-profile', { userId: targetUserId });
   });
-  menu.appendChild(profileBtn);
 
-  // 2) Direct Message
-  const dmBtn = document.createElement('button');
-  dmBtn.innerHTML = `💬 ${t('users.direct_message')}`;
-  dmBtn.addEventListener('click', () => {
+  // Direct Message
+  addBtn(`💬 ${t('users.direct_message')}`, () => {
     this._hideUserContextMenu();
     this.socket.emit('start-dm', { targetUserId });
     this._showToast(t('users.opening_dm', { name: this._escapeHtml(targetName) }), 'info');
   });
-  menu.appendChild(dmBtn);
 
-  // 3) Invite to Channel (submenu)
+  // Invite to Channel (submenu)
   // Private channels are excluded for non-admins: regular members can't bypass
   // the code requirement by using the right-click invite menu.
   // Both is_private=1 and code_visibility='private' count as private here.
@@ -92,14 +103,74 @@ _showUserContextMenu(e, targetUserId) {
     menu.appendChild(inviteItem);
   }
 
-  // 4) Set Nickname
-  const nickBtn = document.createElement('button');
-  nickBtn.innerHTML = `🏷️ ${t('users.set_nickname')}`;
-  nickBtn.addEventListener('click', () => {
+  // Set Nickname
+  addBtn(`🏷️ ${t('users.set_nickname')}`, () => {
     this._hideUserContextMenu();
     this._showNicknameDialog(targetUserId, targetName, targetName);
   });
-  menu.appendChild(nickBtn);
+
+  // ── Moderation sections: same gating the old gear menu used ──
+  const isAdmin = this.user.isAdmin;
+  const canMod = isAdmin || this._canModerate();
+  const canPromote = this._hasPerm('promote_user');
+  // The server has always accepted ban_user; a moderator who holds it should
+  // see Ban even when below the level-25 _canModerate() threshold. (v3.43.0)
+  const canBan = isAdmin || this._hasPerm('ban_user');
+
+  // "Add to Channel" mirrors the invite filter but also skips sub-channels and
+  // never targets yourself. Its own picker validates membership server-side.
+  // It used to live inside the mod-only gear menu, so it stays gated on the same
+  // mod-ish powers — regular members use "Invite to Channel" above instead.
+  const addToChannelList = (this.channels || []).filter(ch =>
+    !ch.is_dm && ch.name && !ch.parent_channel_id &&
+    ((!ch.is_private && ch.code_visibility !== 'private') || isAdmin || ch.canInvitePrivate)
+  );
+  const canAddToChannel = (canMod || canPromote || canBan) && addToChannelList.length > 0 && targetUserId !== this.user?.id;
+
+  // ── Section 2: role / channel management ──
+  if (canPromote || canAddToChannel) {
+    addDivider();
+    if (canPromote) addBtn(`👑 ${t('users.gear_menu.role_management')}`, () => {
+      this._hideUserContextMenu();
+      this._openRoleAssignCenter(targetUserId);
+    });
+    if (canAddToChannel) addBtn(`➕ ${t('users.gear_menu.add_to_channel')}`, () => {
+      this._hideUserContextMenu();
+      this._openGearMenuChannelPicker(targetUserId, targetName, addToChannelList);
+    });
+  }
+
+  // ── Section 3: moderation (kick / mute / ban / delete / transfer) ──
+  // Admin password reset stays opt-in: hidden unless the server setting is on
+  // and the target isn't yourself (#5300).
+  const canResetPassword = isAdmin && this.serverSettings?.admin_password_reset_enabled === 'true' && targetUserId !== this.user?.id;
+  if (canMod || canBan || isAdmin) {
+    addDivider();
+    if (canMod) addBtn(`👢 ${t('users.gear_menu.kick')}`, () => {
+      this._hideUserContextMenu();
+      this._showAdminActionModal('kick', targetUserId, targetName);
+    });
+    if (canMod) addBtn(`🔇 ${t('users.gear_menu.mute')}`, () => {
+      this._hideUserContextMenu();
+      this._showAdminActionModal('mute', targetUserId, targetName);
+    });
+    if (canBan) addBtn(`⛔ ${t('users.gear_menu.ban')}`, () => {
+      this._hideUserContextMenu();
+      this._showAdminActionModal('ban', targetUserId, targetName);
+    }, true);
+    if (isAdmin) addBtn(`🗑️ ${t('users.gear_menu.delete_user')}`, () => {
+      this._hideUserContextMenu();
+      this._showAdminActionModal('delete-user', targetUserId, targetName);
+    }, true);
+    if (canResetPassword) addBtn(`🔑 ${t('users.gear_menu.reset_password')}`, () => {
+      this._hideUserContextMenu();
+      this._confirmAdminResetPassword(targetUserId, targetName);
+    }, true);
+    if (isAdmin) addBtn(`🔑 ${t('users.gear_menu.transfer_admin')}`, () => {
+      this._hideUserContextMenu();
+      this._confirmTransferAdmin(targetUserId, targetName);
+    }, true);
+  }
 
   menu.style.left = e.clientX + 'px';
   menu.style.top = e.clientY + 'px';

--- a/public/js/modules/app-context.js
+++ b/public/js/modules/app-context.js
@@ -25,7 +25,6 @@ _showUserContextMenu(e, targetUserId) {
   profileBtn.innerHTML = `👤 ${t('context.view_profile')}`;
   profileBtn.addEventListener('click', () => {
     this._hideUserContextMenu();
-    this._isHoverPopup = false;
     this._profilePopupAnchor = e.target.closest('.user-item') || e.target;
     this.socket.emit('get-user-profile', { userId: targetUserId });
   });

--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -1905,13 +1905,6 @@ _setupSocketListeners() {
   });
 
   // ── User profile popup data ─────────────────────
-  this._isHoverPopup = false;
-  this._hoverProfileTimer = null;
-  this._hoverCloseTimer = null;
-  this._hoverAutoCloseTimer = null;
-  this._hoverFadeTimeout = null;
-  this._hoverTarget = null;
-
   this.socket.on('user-profile', (profile) => {
     this._showProfilePopup(profile);
   });

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -2077,6 +2077,18 @@ _setupUI() {
     if (this._moveSelectionActive) return;
     const msgEl = e.target.closest('.message, .message-compact');
     if (!msgEl || !msgEl.dataset.msgId) return; // empty gutter / unsent rows → native menu
+    // Right-click directly on the author name or avatar → unified user menu,
+    // same as right-clicking the member list. Everything else on the row keeps
+    // the message context menu.
+    const authorTrigger = e.target.closest('.message-author, .message-avatar, .message-avatar-img');
+    if (authorTrigger && !e.target.closest('.msg-toolbar')) {
+      const userId = parseInt(msgEl.dataset.userId);
+      if (!isNaN(userId) && userId !== this.user.id) {
+        e.preventDefault();
+        this._showUserContextMenu(e, userId, msgEl.dataset.username);
+        return;
+      }
+    }
     // Preserve native copy: if text is selected inside this message, defer.
     const sel = window.getSelection?.();
     if (sel && !sel.isCollapsed && msgEl.contains(sel.anchorNode)) return;

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -2917,6 +2917,11 @@ _setupUI() {
     if (!msgEl) return;
     const userId = parseInt(msgEl.dataset.userId);
     if (!isNaN(userId)) {
+      // Toggle: clicking the same user whose card is open closes it.
+      if (this._openProfileUserId === userId && document.getElementById('profile-popup')) {
+        this._closeProfilePopup();
+        return;
+      }
       this._profilePopupAnchor = e.target;
       this.socket.emit('get-user-profile', { userId });
     }
@@ -2930,6 +2935,11 @@ _setupUI() {
     if (!userItem) return;
     const userId = parseInt(userItem.dataset.userId);
     if (!isNaN(userId)) {
+      // Toggle: clicking the same user whose card is open closes it.
+      if (this._openProfileUserId === userId && document.getElementById('profile-popup')) {
+        this._closeProfilePopup();
+        return;
+      }
       this._profilePopupAnchor = userItem;
       this.socket.emit('get-user-profile', { userId });
     }

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -2917,18 +2917,6 @@ _setupUI() {
     if (!msgEl) return;
     const userId = parseInt(msgEl.dataset.userId);
     if (!isNaN(userId)) {
-      clearTimeout(this._hoverProfileTimer);
-      clearTimeout(this._hoverCloseTimer);
-      clearTimeout(this._hoverAutoCloseTimer);
-      clearTimeout(this._hoverFadeTimeout);
-      // If a hover popup is already open, promote it to permanent (no re-fetch)
-      const existingPopup = document.getElementById('profile-popup');
-      if (existingPopup && this._isHoverPopup) {
-        this._promoteHoverPopup(existingPopup);
-        return;
-      }
-      this._isHoverPopup = false;
-      this._hoverTarget = null;
       this._profilePopupAnchor = e.target;
       this.socket.emit('get-user-profile', { userId });
     }
@@ -2942,18 +2930,6 @@ _setupUI() {
     if (!userItem) return;
     const userId = parseInt(userItem.dataset.userId);
     if (!isNaN(userId)) {
-      clearTimeout(this._hoverProfileTimer);
-      clearTimeout(this._hoverCloseTimer);
-      clearTimeout(this._hoverAutoCloseTimer);
-      clearTimeout(this._hoverFadeTimeout);
-      // If a hover popup is already open, promote it to permanent (no re-fetch)
-      const existingPopup = document.getElementById('profile-popup');
-      if (existingPopup && this._isHoverPopup) {
-        this._promoteHoverPopup(existingPopup);
-        return;
-      }
-      this._isHoverPopup = false;
-      this._hoverTarget = null;
       this._profilePopupAnchor = userItem;
       this.socket.emit('get-user-profile', { userId });
     }
@@ -2977,77 +2953,6 @@ _setupUI() {
     if (isNaN(userId) || userId === this.user.id) return;
     e.preventDefault();
     this._showUserContextMenu(e, userId);
-  });
-
-  // ── Profile popup: hover-over on usernames/avatars (translucent preview) ──
-  const setupHoverProfile = (container, getInfo) => {
-    container.addEventListener('mouseover', (e) => {
-      const trigger = getInfo(e);
-      if (!trigger) {
-        // Mouse moved to a non-trigger element — cancel any pending hover
-        clearTimeout(this._hoverProfileTimer);
-        this._hoverTarget = null;
-        // Close hover popup INSTANTLY
-        if (this._isHoverPopup) {
-          clearTimeout(this._hoverCloseTimer);
-          clearTimeout(this._hoverAutoCloseTimer);
-          clearTimeout(this._hoverFadeTimeout);
-          this._closeProfilePopup();
-        }
-        return;
-      }
-      if (trigger.el === this._hoverTarget) return;
-      // Switching to a different trigger — close old hover popup instantly
-      if (this._isHoverPopup) {
-        clearTimeout(this._hoverFadeTimeout);
-        this._closeProfilePopup();
-      }
-      clearTimeout(this._hoverProfileTimer);
-      clearTimeout(this._hoverCloseTimer);
-      clearTimeout(this._hoverAutoCloseTimer);
-      this._hoverTarget = trigger.el;
-
-      // Don't show hover popup if a click-based popup is already open
-      if (document.getElementById('profile-popup') && !this._isHoverPopup) return;
-
-      this._hoverProfileTimer = setTimeout(() => {
-        // Verify the mouse is still over this trigger element
-        if (this._hoverTarget !== trigger.el) return;
-        if (!isNaN(trigger.userId)) {
-          this._profilePopupAnchor = trigger.el;
-          this._isHoverPopup = true;
-          this.socket.emit('get-user-profile', { userId: trigger.userId });
-        }
-      }, 350);
-    });
-
-    container.addEventListener('mouseleave', () => {
-      clearTimeout(this._hoverProfileTimer);
-      clearTimeout(this._hoverAutoCloseTimer);
-      clearTimeout(this._hoverFadeTimeout);
-      this._hoverTarget = null;
-      // Close hover popup INSTANTLY on leaving the container
-      if (this._isHoverPopup) {
-        this._closeProfilePopup();
-      }
-    });
-  };
-
-  setupHoverProfile(document.getElementById('messages'), (e) => {
-    const author = e.target.closest('.message-author');
-    const avatar = e.target.closest('.message-avatar, .message-avatar-img');
-    if (!author && !avatar) return null;
-    if (e.target.closest('.msg-toolbar')) return null;
-    const msgEl = (author || avatar).closest('.message, .message-compact');
-    if (!msgEl) return null;
-    return { el: author || avatar, userId: parseInt(msgEl.dataset.userId) };
-  });
-
-  setupHoverProfile(document.getElementById('online-users'), (e) => {
-    if (e.target.closest('.user-action-btn') || e.target.closest('.user-admin-actions')) return null;
-    const userItem = e.target.closest('.user-item');
-    if (!userItem) return null;
-    return { el: userItem, userId: parseInt(userItem.dataset.userId) };
   });
 
   document.getElementById('cancel-rename-btn').addEventListener('click', () => {

--- a/public/js/modules/app-users.js
+++ b/public/js/modules/app-users.js
@@ -74,18 +74,6 @@ _renderOnlineUsers(users) {
 
   el.innerHTML = html;
 
-  // Bind gear button → dropdown menu with mod actions
-  if (this.user.isAdmin || this._canModerate() || this._hasPerm('promote_user')) {
-    el.querySelectorAll('.user-gear-btn').forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        const userId = parseInt(btn.dataset.uid);
-        const username = btn.dataset.uname;
-        this._showUserGearMenu(btn, userId, username);
-      });
-    });
-  }
-
   // Bind DM buttons
   el.querySelectorAll('.user-dm-btn').forEach(btn => {
     btn.addEventListener('click', (e) => {
@@ -101,100 +89,6 @@ _renderOnlineUsers(users) {
       setTimeout(() => { btn.disabled = false; btn.style.opacity = ''; }, 5000);
     });
   });
-},
-
-_showUserGearMenu(anchorEl, userId, username) {
-  // Close any existing gear menu
-  this._closeUserGearMenu();
-
-  const canMod = this.user.isAdmin || this._canModerate();
-  const canPromote = this._hasPerm('promote_user');
-  const isAdmin = this.user.isAdmin;
-  // Ban was gated on isAdmin here, which meant a moderator holding ban_user
-  // could ban from the admin members list but not from the sidebar they
-  // actually work in. The server has always accepted ban_user; this menu was
-  // the only thing hiding it. (v3.43.0)
-  const canBan = isAdmin || this._hasPerm('ban_user');
-
-  // Mirror of the right-click context menu's invite filter: any non-DM,
-  // non-private channel the user can see (admins also see private channels).
-  // Showing the entry only when there's at least one channel available.
-  // Same rule as the right-click menu: the server accepts invites to a private
-  // channel from its creator or a moderator in it, not admins alone. (#5466)
-  const inviteChannels = (this.channels || []).filter(ch =>
-    !ch.is_dm && ch.name && !ch.parent_channel_id &&
-    ((!ch.is_private && ch.code_visibility !== 'private') || isAdmin || ch.canInvitePrivate)
-  );
-  const canInvite = inviteChannels.length > 0 && userId !== this.user?.id;
-
-  let items = '';
-  if (canPromote) items += `<button class="gear-menu-item" data-action="assign-role">👑 ${t('users.gear_menu.assign_role')}</button>`;
-  if (canInvite) items += `<button class="gear-menu-item" data-action="add-to-channel">➕ ${t('users.gear_menu.add_to_channel')}</button>`;
-  if (canMod) items += `<button class="gear-menu-item" data-action="kick">👢 ${t('users.gear_menu.kick')}</button>`;
-  if (canMod) items += `<button class="gear-menu-item" data-action="mute">🔇 ${t('users.gear_menu.mute')}</button>`;
-  if (canBan) items += `<button class="gear-menu-item gear-menu-danger" data-action="ban">⛔ ${t('users.gear_menu.ban')}</button>`;
-  if (isAdmin) items += `<button class="gear-menu-item gear-menu-danger" data-action="delete-user">🗑️ ${t('users.gear_menu.delete_user')}</button>`;
-  // Admin password reset (#5300): gated on server setting AND target is not self.
-  if (isAdmin && this.serverSettings?.admin_password_reset_enabled === 'true' && userId !== this.user?.id) {
-    items += `<button class="gear-menu-item gear-menu-danger" data-action="reset-password">🔑 ${t('users.gear_menu.reset_password')}</button>`;
-  }
-  if (isAdmin) items += `<div class="gear-menu-divider"></div><button class="gear-menu-item gear-menu-danger" data-action="transfer-admin">🔑 ${t('users.gear_menu.transfer_admin')}</button>`;
-
-  const menu = document.createElement('div');
-  menu.className = 'user-gear-menu';
-  menu.innerHTML = items;
-  document.body.appendChild(menu);
-
-  // Position near the gear button
-  const rect = anchorEl.getBoundingClientRect();
-  menu.style.top = `${rect.bottom + 4}px`;
-  menu.style.left = `${rect.left - 100}px`;
-
-  // Keep in viewport
-  requestAnimationFrame(() => {
-    const mr = menu.getBoundingClientRect();
-    if (mr.right > window.innerWidth - 8) menu.style.left = `${window.innerWidth - mr.width - 8}px`;
-    if (mr.bottom > window.innerHeight - 8) menu.style.top = `${rect.top - mr.height - 4}px`;
-    if (mr.left < 8) menu.style.left = '8px';
-  });
-
-  // Bind item clicks
-  menu.querySelectorAll('.gear-menu-item').forEach(btn => {
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const action = btn.dataset.action;
-      this._closeUserGearMenu();
-      this._closeProfilePopup();
-      if (action === 'assign-role') {
-        this._openRoleAssignCenter(userId);
-      } else if (action === 'add-to-channel') {
-        this._openGearMenuChannelPicker(userId, username, inviteChannels);
-      } else if (action === 'transfer-admin') {
-        this._confirmTransferAdmin(userId, username);
-      } else if (action === 'reset-password') {
-        this._confirmAdminResetPassword(userId, username);
-      } else {
-        this._showAdminActionModal(action, userId, username);
-      }
-    });
-  });
-
-  // Close on outside click
-  setTimeout(() => {
-    this._gearMenuOutsideHandler = (e) => {
-      if (!menu.contains(e.target)) this._closeUserGearMenu();
-    };
-    document.addEventListener('click', this._gearMenuOutsideHandler, true);
-  }, 10);
-},
-
-_closeUserGearMenu() {
-  const existing = document.querySelector('.user-gear-menu');
-  if (existing) existing.remove();
-  if (this._gearMenuOutsideHandler) {
-    document.removeEventListener('click', this._gearMenuOutsideHandler, true);
-    this._gearMenuOutsideHandler = null;
-  }
 },
 
 // Lightweight channel picker for the user gear menu's "Add to Channel"
@@ -322,18 +216,10 @@ _renderUserItem(u, scoreLookup) {
     ? `<button class="user-action-btn user-dm-btn" data-dm-uid="${u.id}" title="${t('users.notes_to_self_hint')}">📝</button>`
     : `<button class="user-action-btn user-dm-btn" data-dm-uid="${u.id}" title="${t('users.direct_message')}">💬</button>`;
 
-  // Show DM + Gear icon. Gear opens a dropdown with mod actions.
-  const canModThis = (this.user.isAdmin || this._canModerate()) && u.id !== this.user.id;
-  const canPromote = this._hasPerm('promote_user') && u.id !== this.user.id;
-  // A moderator whose role grants ban_user but who sits below the level-25
-  // _canModerate() threshold still needs the gear to appear. (v3.43.0)
-  const canBanThis = this._hasPerm('ban_user') && u.id !== this.user.id;
-  const hasGear = canModThis || canPromote || canBanThis;
-  const gearBtn = hasGear
-    ? `<button class="user-action-btn user-gear-btn" data-uid="${u.id}" data-uname="${this._escapeHtml(u.username)}" title="${t('users.more_actions')}">⚙️</button>`
-    : '';
-  const modBtns = (dmBtn || gearBtn)
-    ? `<div class="user-admin-actions">${dmBtn}${gearBtn}</div>`
+  // Mod actions moved to the unified right-click context menu; the sidebar row
+  // keeps just the DM shortcut.
+  const modBtns = dmBtn
+    ? `<div class="user-admin-actions">${dmBtn}</div>`
     : '';
   // The name gets a line to itself. Everything used to sit on one row, so a
   // custom status and an activity together squeezed the username down to a
@@ -923,17 +809,10 @@ _showProfilePopup(profile) {
   // Join date
   const joinDate = profile.createdAt ? new Date(profile.createdAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '';
 
-  // Action buttons
-  const nickBtnLabel = currentNick ? `✏️ ${t('users.edit_nickname')}` : `🏷️ ${t('users.set_nickname')}`;
-  const canMod = this.user.isAdmin || this._canModerate();
-  const canPromote = this._hasPerm('promote_user');
-  const gearVisible = !isSelf && (canMod || canPromote || this.user.isAdmin);
-  const gearBtnHtml = gearVisible
-    ? `<button class="profile-popup-action-btn profile-gear-btn" title="${this._escapeHtml(t('users.more_actions'))}">⚙️ ${t('users.more_actions')}</button>`
-    : '';
+  // Action buttons (nickname lives in the right-click context menu now)
   const actionsHtml = isSelf
     ? `<button class="profile-popup-action-btn profile-edit-btn" id="profile-popup-edit-btn">✏️ ${t('users.edit_profile')}</button><button class="profile-popup-action-btn profile-dm-btn" data-dm-uid="${profile.id}" title="${t('users.notes_to_self')}">📝 ${t('users.notes_to_self')}</button>`
-    : `<button class="profile-popup-action-btn profile-dm-btn" data-dm-uid="${profile.id}">💬 ${t('users.message_btn')}</button><button class="profile-popup-action-btn profile-nick-btn" data-nick-uid="${profile.id}" data-nick-uname="${this._escapeHtml(profile.username)}" data-nick-dname="${this._escapeHtml(profile.displayName)}">${nickBtnLabel}</button>${gearBtnHtml}`;
+    : `<button class="profile-popup-action-btn profile-dm-btn" data-dm-uid="${profile.id}">💬 ${t('users.message_btn')}</button>`;
 
   const popup = document.createElement('div');
   popup.id = 'profile-popup';
@@ -1008,29 +887,6 @@ _showProfilePopup(profile) {
       this.socket.emit('start-dm', { targetUserId: targetId });
       this._closeProfilePopup();
       this._showToast(t('users.opening_dm', { name: profile.displayName }), 'info');
-    });
-  }
-
-  // Nickname button
-  const nickBtnEl = popup.querySelector('.profile-nick-btn');
-  if (nickBtnEl) {
-    nickBtnEl.addEventListener('click', () => {
-      const uid = parseInt(nickBtnEl.dataset.nickUid);
-      const uname = nickBtnEl.dataset.nickUname;
-      const dname = nickBtnEl.dataset.nickDname;
-      this._closeProfilePopup();
-      this._showNicknameDialog(uid, uname, dname);
-    });
-  }
-
-  // Gear / moderation button — opens the same dropdown as the sidebar gear.
-  // Do NOT close the popup first; the anchor element must be in the DOM
-  // so _showUserGearMenu can read its position.
-  const gearBtnEl = popup.querySelector('.profile-gear-btn');
-  if (gearBtnEl) {
-    gearBtnEl.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this._showUserGearMenu(gearBtnEl, profile.id, profile.username);
     });
   }
 

--- a/public/js/modules/app-users.js
+++ b/public/js/modules/app-users.js
@@ -861,6 +861,19 @@ _showProfilePopup(profile) {
   // Close button
   popup.querySelector('.profile-popup-close').addEventListener('click', () => this._closeProfilePopup());
 
+  // Avatar → open the full-resolution image in the lightbox. Only real avatars
+  // are clickable; the letter fallback (a div) isn't an <img> so it's skipped.
+  // The card stays open behind the lightbox; the outside-click handler below
+  // ignores clicks that land on the lightbox so closing it keeps the card.
+  const avatarImgEl = popup.querySelector('img.profile-popup-avatar');
+  if (avatarImgEl) {
+    avatarImgEl.style.cursor = 'zoom-in';
+    avatarImgEl.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._openLightbox(profile.avatar);
+    });
+  }
+
   // Bio toggle
   const bioToggle = popup.querySelector('.profile-bio-toggle');
   if (bioToggle) {
@@ -900,9 +913,13 @@ _showProfilePopup(profile) {
     });
   }
 
-  // Close on outside click (delay to avoid instant close)
+  // Close on outside click (delay to avoid instant close). Clicks on the image
+  // lightbox (opened by clicking the avatar) are ignored so dismissing the
+  // lightbox leaves the card open.
   setTimeout(() => {
     this._profilePopupOutsideHandler = (e) => {
+      const lightbox = document.getElementById('image-lightbox');
+      if (lightbox && lightbox.contains(e.target)) return;
       if (!popup.contains(e.target)) this._closeProfilePopup();
     };
     document.addEventListener('click', this._profilePopupOutsideHandler);

--- a/public/js/modules/app-users.js
+++ b/public/js/modules/app-users.js
@@ -883,9 +883,6 @@ _profileActivityHtml(activity) {
 // ── Profile Popup (Discord-style mini profile) ────────
 
 _showProfilePopup(profile) {
-  // If this was a hover-triggered popup but the mouse already left, abort
-  if (this._isHoverPopup && !this._hoverTarget) return;
-
   this._closeProfilePopup();
 
   const isSelf = profile.id === this.user.id;
@@ -966,14 +963,6 @@ _showProfilePopup(profile) {
     </div>
   `;
 
-  // Hover mode: add translucent class — popup is non-interactive (tooltip)
-  if (this._isHoverPopup) {
-    popup.classList.add('profile-popup-hover');
-    // pointer-events:none is set via CSS on .profile-popup-hover so
-    // the user can't accidentally interact with it; close is driven
-    // entirely by setupHoverProfile's mouseover/mouseleave.
-  }
-
   document.body.appendChild(popup);
 
   // Opening the profile card is a trigger context: flag the card so the freeze
@@ -989,14 +978,6 @@ _showProfilePopup(profile) {
   this._openProfileStatusKey = profile.statusText || '';
   this._openProfileActivityKey = JSON.stringify(profile.activity || null);
   this._startActivityProgress(popup);
-
-  // Hover-mode: no interactive handlers needed — the popup is pointer-events:none.
-  // Safety-net auto-close in case the mouseover handler misses.
-  if (this._isHoverPopup) {
-    this._hoverAutoCloseTimer = setTimeout(() => {
-      if (this._isHoverPopup) this._closeProfilePopup();
-    }, 3000);
-  }
 
   // Close button
   popup.querySelector('.profile-popup-close').addEventListener('click', () => this._closeProfilePopup());
@@ -1063,37 +1044,7 @@ _showProfilePopup(profile) {
     });
   }
 
-  // Close on outside click (delay to avoid instant close) — skip for hover popups
-  if (!this._isHoverPopup) {
-    setTimeout(() => {
-      this._profilePopupOutsideHandler = (e) => {
-        if (!popup.contains(e.target)) this._closeProfilePopup();
-      };
-      document.addEventListener('click', this._profilePopupOutsideHandler);
-    }, 50);
-  }
-},
-
-// Convert a hover popup to a permanent (click-based) popup in-place
-_promoteHoverPopup(popup) {
-  this._isHoverPopup = false;
-  this._hoverTarget = null;
-  clearTimeout(this._hoverAutoCloseTimer);
-  clearTimeout(this._hoverFadeTimeout);
-  // Remove hover styling
-  popup.classList.remove('profile-popup-hover', 'profile-popup-fading');
-  popup.style.pointerEvents = '';
-  // Show close button
-  const closeBtn = popup.querySelector('.profile-popup-close');
-  if (closeBtn) closeBtn.style.display = '';
-  // Show action buttons
-  const actions = popup.querySelector('.profile-popup-actions');
-  if (actions) actions.style.display = '';
-  // Re-run entrance animation for the full card
-  popup.style.animation = 'none';
-  popup.offsetHeight; // force reflow
-  popup.style.animation = '';
-  // Add close-on-outside-click handler
+  // Close on outside click (delay to avoid instant close)
   setTimeout(() => {
     this._profilePopupOutsideHandler = (e) => {
       if (!popup.contains(e.target)) this._closeProfilePopup();
@@ -1145,19 +1096,6 @@ _closeProfilePopup() {
     document.removeEventListener('click', this._profilePopupOutsideHandler);
     this._profilePopupOutsideHandler = null;
   }
-  if (this._hoverMousemoveHandler) {
-    document.removeEventListener('mousemove', this._hoverMousemoveHandler);
-    this._hoverMousemoveHandler = null;
-  }
-  // NOTE: do NOT reset _isHoverPopup here.  It is only cleared by
-  // explicit user actions (click, promote, context-menu).  Resetting it
-  // on close caused a race: hover request in-flight → mouseout closes
-  // popup/resets flag → stale server response arrives with
-  // _isHoverPopup=false → guard fails → permanent popup appears.
-  this._hoverTarget = null;
-  clearTimeout(this._hoverCloseTimer);
-  clearTimeout(this._hoverAutoCloseTimer);
-  clearTimeout(this._hoverFadeTimeout);
 },
 
 _openEditProfileModal(profile) {

--- a/public/js/modules/app-users.js
+++ b/public/js/modules/app-users.js
@@ -1070,18 +1070,17 @@ _positionProfilePopup(popup) {
   const ph = popup.offsetHeight;
   const margin = 8;
 
-  let left = rect.left + rect.width / 2 - pw / 2;
-  let top = rect.bottom + margin;
-
-  // Clamp horizontally within the viewport.
-  left = Math.max(margin, Math.min(left, window.innerWidth - pw - margin));
-
-  // Flip above the anchor if it overflows the bottom; if it fits neither way
-  // (very short viewport) clamp so the top edge stays on-screen.
-  if (top + ph > window.innerHeight - margin) {
-    const above = rect.top - ph - margin;
-    top = above >= margin ? above : Math.max(margin, window.innerHeight - ph - margin);
+  // Place the card to the right of the clicked element (the icon or the name).
+  // Flip to the left side only if it would overflow the right viewport edge.
+  let left = rect.right + margin;
+  if (left + pw > window.innerWidth - margin) {
+    const leftSide = rect.left - pw - margin;
+    left = leftSide >= margin ? leftSide : Math.max(margin, window.innerWidth - pw - margin);
   }
+
+  // Vertically align the top of the card with the clicked element, then clamp
+  // so it stays fully on-screen in short viewports.
+  let top = Math.max(margin, Math.min(rect.top, window.innerHeight - ph - margin));
 
   popup.style.left = left + 'px';
   popup.style.top = top + 'px';

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -4263,7 +4263,7 @@ _showAdminActionModal(action, userId, username) {
 // gates on the target user having 2FA enabled, (3) reveal modal that
 // shows the temp password once for the admin to transmit out-of-band.
 _confirmAdminResetPassword(userId, username) {
-  this._closeUserGearMenu();
+  this._hideUserContextMenu();
   this._closeProfilePopup();
   const safeName = this._escapeHtml(username);
   const overlay = document.createElement('div');
@@ -4408,7 +4408,7 @@ _confirmTransferAdmin(userId, username) {
   // An SSO admin has no Haven password, so they confirm with an authenticator
   // code instead. The server decides which it will accept and rejects the
   // wrong one, this only picks which field to put in front of you. (#5539)
-  this._closeUserGearMenu();
+  this._hideUserContextMenu();
   const ssoConfirm = !!this.user?.isSso;
   const overlay = document.createElement('div');
   overlay.className = 'modal-overlay transfer-admin-overlay';

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -549,6 +549,7 @@
     "bio_placeholder": "Erzähl den Leuten von dir…",
     "gear_menu": {
       "assign_role": "Rolle zuweisen",
+      "role_management": "Rollenverwaltung",
       "kick": "Kicken",
       "mute": "Stummschalten",
       "ban": "Bannen",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -912,6 +912,7 @@
     "bio_placeholder": "Tell people about yourself…",
     "gear_menu": {
       "assign_role": "Assign Role",
+      "role_management": "Role Management",
       "add_to_channel": "Add to Channel",
       "kick": "Kick",
       "mute": "Mute",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -549,6 +549,7 @@
     "bio_placeholder": "Cuéntale a la gente sobre ti…",
     "gear_menu": {
       "assign_role": "Asignar rol",
+      "role_management": "Gestión de roles",
       "kick": "Expulsar",
       "mute": "Silenciar",
       "ban": "Banear",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -549,6 +549,7 @@
     "bio_placeholder": "Parlez de vous…",
     "gear_menu": {
       "assign_role": "Attribuer un rôle",
+      "role_management": "Gestion des rôles",
       "kick": "Expulser",
       "mute": "Mettre en sourdine",
       "ban": "Bannir",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -572,6 +572,7 @@
     "bio_placeholder": "Opowiedz coś o sobie…",
     "gear_menu": {
       "assign_role": "Przypisz rolę",
+      "role_management": "Zarządzanie rolami",
       "kick": "Wyrzuć",
       "mute": "Wycisz",
       "ban": "Zablokuj",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -912,6 +912,7 @@
     "bio_placeholder": "Conte um pouco sobre você…",
     "gear_menu": {
       "assign_role": "Atribuir cargo",
+      "role_management": "Gerenciamento de cargos",
       "add_to_channel": "Adicionar ao canal",
       "kick": "Expulsar",
       "mute": "Silenciar",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -576,6 +576,7 @@
     "bio_placeholder": "Расскажите о себе…",
     "gear_menu": {
       "assign_role": "Назначить роль",
+      "role_management": "Управление ролями",
       "add_to_channel": "Добавить в канал",
       "kick": "Выгнать",
       "mute": "Заглушить",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -549,6 +549,7 @@
     "bio_placeholder": "向大家介绍一下自己…",
     "gear_menu": {
       "assign_role": "分配角色",
+      "role_management": "角色管理",
       "kick": "踢出",
       "mute": "禁言",
       "ban": "封禁",


### PR DESCRIPTION
## Overview

Reworks the user profile card and consolidates every user-action menu into a single right-click context menu. Removes the redundant hover card and the scattered gear-icon menus, and makes the card's avatar open full-resolution.

## Changes

### Profile card
- **Removed the hover card.** The translucent hover-over preview is gone; hovering no longer pops anything up. The click card now uses that same translucent, theme-aware glass styling (was solid).
- **Anchored positioning.** The card opens to the right of whatever you clicked (avatar or name), vertically aligned with it, instead of centering above/below the cursor and covering content at high zoom. Falls back to the left side when it would overflow the right edge.
- **Click-to-toggle.** Clicking the same user whose card is open closes it; clicking a different user switches.
- **Clickable avatar.** Clicking a real avatar (not the letter fallback) opens the full-resolution image in the existing lightbox — for other users and yourself. The card stays open behind the lightbox, and dismissing the image keeps the card.
- **Removed** the card's "Set Nickname" and "More Actions" (gear) buttons — both now live in the context menu.

### Unified user context menu
Right-clicking a user  in the member list or directly on a message author's name/avatar in chat, opens one menu with everything, gated exactly as before.

- Section dividers only render when their section has visible items, so lower-permission users get a clean, shorter menu.
- Right-clicking your **own** message author falls through to the normal message context menu.
- The old mod-only gear menu (`_showUserGearMenu`) and all gear-icon entry points (profile card + member-list sidebar) are removed. `"Assign Role"` is relabeled **"Role Management"** across all 8 locales.

## Testing
- `node --test test/i18n.test.js` passes (12/12); all locale JSON validates.
- All modified frontend modules parse clean.
- Manually verified: hover card gone; card styling / positioning / toggle; avatar lightbox (opens over card, backdrop-dismiss keeps card); unified menu from both the member list and chat; permission gating per role; and the message menu still works for own / non-author right-clicks.