### PR TITLE
Ferry: relay a stream bot's link and thumbnail, not just its ping line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ## [Unreleased]
 
+### Fixed
+- **Stream and video announcement bots bridged through Ferry lost their link and
+  thumbnail.** CouchBot-style promotion bots type the ping line ("X is now live")
+  and put the stream link, title, and thumbnail in a rich embed. Ferry only read
+  the embed when the Discord message had no text, so Haven got the ping line and
+  nothing to click or look at. Rich (bot-composed) embeds are now read alongside
+  the typed text: the Twitch / YouTube / Kick link and the thumbnail come through
+  with it. The promoted link is checked against the link policy on its own, so an
+  allowlist server that has not added a host (kick.com is not in the starter list)
+  drops just that link and still relays the announcement and its picture. Discord's
+  own unfurl of a typed link is still ignored so Haven does not preview it twice.
+
 ### Added
 - **Three Braid spacing levels, either side of the shipped one.** Settings → Braid spacing (and Menu → Braid spacing, which cycles) offers Compact, Cozy, and Spacious. Cozy is exactly what shipped; the other two take roughly a fifth off or add a fifth on. Message runs and channel rows move together, and the rounded card shapes are identical at all three levels — only padding, gutters, avatar size, and sidebar width change. The continuation gutter is derived from inset + avatar + row gap, so a smaller avatar can't drift a run out of alignment with its own leader.
 

--- a/src/ferry.js
+++ b/src/ferry.js
@@ -601,9 +601,25 @@ function buildHavenContent(msg) {
   for (const sticker of msg.sticker_items || []) {
     media.push(`https://media.discordapp.net/stickers/${sticker.id}.png`);
   }
-  // A link-only message arrives with an empty body and one embed. Without this
-  // it would relay as nothing at all. This counts as authored: the person chose
-  // to post the link, Discord only unfurled it.
+  // Discord attaches two kinds of embed, and they mean different things.
+  //
+  // A bot composes a 'rich' embed itself, and for a stream or video
+  // announcement bot that embed IS the message: the typed line is
+  // "@everyone X is live", while the stream link sits in embed.url and the
+  // thumbnail in embed.image. Reading the embed only when the body was empty
+  // relayed that line alone, so Haven got a bare "X is live" with nothing to
+  // click and nothing to look at. Rich embeds are read whether or not the bot
+  // also typed something, and their url is kept because the link is the thing
+  // being promoted. That link is checked against the link policy on its own,
+  // so an allowlist server that has not added, say, kick.com drops just the
+  // link and still relays the announcement and its picture.
+  //
+  // Everything else ('link', 'video', 'article', 'image', 'gifv') is Discord's
+  // own unfurl of a link already in the text, so it is only worth reading
+  // when there is no text at all, otherwise Haven would unfurl the same link
+  // a second time. That is the link-only message shape: an empty body and one
+  // embed, which would otherwise relay as nothing at all. It counts as
+  // authored: the person chose to post the link, Discord only unfurled it.
   //
   // Image bots (SaucyBot and friends) are the other shape here: the picture is
   // the point of the message and it lives in embed.image, with the source page
@@ -619,17 +635,33 @@ function buildHavenContent(msg) {
   // because whether a viewer's browser actually fetches the image is decided by
   // the preview allowlist at render time, which is the control that exists to
   // stop a third-party host seeing everyone who scrolls past.
-  if (!authored.length && !media.length && (msg.embeds || []).length) {
-    const embeds = msg.embeds.slice(0, 10);
+  const allEmbeds = (msg.embeds || []).filter(Boolean).slice(0, 10);
+  const richEmbeds = allEmbeds.filter(e => e.type === 'rich');
+  const embeds = richEmbeds.length ? richEmbeds
+    : (!authored.length && !media.length ? allEmbeds : []);
+  if (embeds.length) {
     for (const e of embeds) {
       const image = (e.image && e.image.url) || (e.thumbnail && e.thumbnail.url);
       if (image) media.push(image);
     }
     const e = embeds[0];
-    // Once the image is coming through, e.url is the link that would be
-    // unfurled, so it is dropped and the readable parts are kept for context.
-    const parts = media.length ? [e.title, e.description] : [e.title, e.url, e.description];
-    const summary = parts.filter(Boolean).join(' ');
+    let link = typeof e.url === 'string' ? e.url : '';
+    if (e.type === 'rich') {
+      // The promoted link stands or falls on its own, never taking the
+      // announcement down with it.
+      try {
+        if (link && automod.checkText(link, { surface: 'message' }).ok === false) link = '';
+      } catch { /* an automod fault must never take the bridge down */ }
+    } else if (media.length) {
+      // Once the image is coming through, e.url is the link that would be
+      // unfurled, so it is dropped and the readable parts are kept for context.
+      link = '';
+    }
+    // A bot that already typed the title or the link gets it once, not twice.
+    const typed = authored.join('\n');
+    const parts = [e.title, link, e.description]
+      .filter(p => typeof p === 'string' && p.trim() && !typed.includes(p.trim()));
+    const summary = parts.join(' ');
     if (summary) authored.push(summary.slice(0, 500));
   }
 

--- a/test/ferry.test.js
+++ b/test/ferry.test.js
@@ -166,6 +166,56 @@ test('an image bot embed relays the picture instead of a link to unfurl', () => 
   );
 });
 
+test('a stream announcement bot relays its link and thumbnail next to the text', () => {
+  // The CouchBot / stream-notifier shape: the bot types the ping line and puts
+  // everything worth having (stream link, title, thumbnail) in a rich embed.
+  // Reading the embed only for empty bodies relayed the ping line alone.
+  const live = {
+    content: '@everyone Streamer is now live!',
+    embeds: [{
+      type: 'rich',
+      title: 'Streamer is playing Spira Speedruns',
+      url: 'https://www.twitch.tv/streamer',
+      description: 'Come hang out',
+      image: { url: 'https://static-cdn.jtvnw.net/previews-ttv/live_user_streamer-1280x720.jpg' },
+    }],
+  };
+  const out = buildHavenContent(live);
+  assert.ok(out.startsWith('@everyone Streamer is now live!'));
+  assert.ok(out.includes('https://www.twitch.tv/streamer'));
+  assert.ok(out.includes('Streamer is playing Spira Speedruns'));
+  assert.ok(out.includes('https://static-cdn.jtvnw.net/previews-ttv/live_user_streamer-1280x720.jpg'));
+
+  // Thumbnail-shaped previews (YouTube, Kick) count as the picture too.
+  const video = buildHavenContent({
+    content: 'New upload!',
+    embeds: [{
+      type: 'rich',
+      url: 'https://www.youtube.com/watch?v=abc123',
+      thumbnail: { url: 'https://i.ytimg.com/vi/abc123/maxresdefault.jpg' },
+    }],
+  });
+  assert.ok(video.includes('https://www.youtube.com/watch?v=abc123'));
+  assert.ok(video.includes('https://i.ytimg.com/vi/abc123/maxresdefault.jpg'));
+
+  // A bot that already typed the link does not get it twice.
+  const typed = buildHavenContent({
+    content: 'Live now https://kick.com/streamer',
+    embeds: [{ type: 'rich', url: 'https://kick.com/streamer', title: 'Live now' }],
+  });
+  assert.equal(typed, 'Live now https://kick.com/streamer');
+
+  // Discord's own unfurl of a typed link is still ignored, or Haven would
+  // unfurl the same link a second time.
+  assert.equal(
+    buildHavenContent({
+      content: 'watch https://www.youtube.com/watch?v=abc123',
+      embeds: [{ type: 'video', url: 'https://www.youtube.com/watch?v=abc123', thumbnail: { url: 'https://i.ytimg.com/vi/abc123/hq.jpg' } }],
+    }),
+    'watch https://www.youtube.com/watch?v=abc123'
+  );
+});
+
 test('Discord custom emotes become readable shortcodes', () => {
   // Relayed raw these read as "<:blue_heart:1178833036244652178>" mid-sentence.
   assert.equal(buildHavenContent({ content: 'hi <:wave:1178833036244652178> there' }), 'hi :wave: there');

--- a/test/ferryAutomod.test.js
+++ b/test/ferryAutomod.test.js
@@ -98,3 +98,37 @@ test('an allowed domain the user typed still passes', () => {
     'clip https://www.youtube.com/watch?v=abc'
   );
 });
+
+test('a promoted stream link is kept when the allowlist permits it', () => {
+  const out = buildHavenContent({
+    content: '@everyone Streamer is live!',
+    embeds: [{
+      type: 'rich',
+      title: 'Streamer on Twitch',
+      url: 'https://www.twitch.tv/streamer',
+      image: { url: 'https://static-cdn.jtvnw.net/previews-ttv/live_user_streamer-1280x720.jpg' },
+    }],
+  });
+  assert.equal(
+    out,
+    '@everyone Streamer is live!\nStreamer on Twitch https://www.twitch.tv/streamer\nhttps://static-cdn.jtvnw.net/previews-ttv/live_user_streamer-1280x720.jpg'
+  );
+});
+
+test('a promoted link off the allowlist drops just the link, not the announcement', () => {
+  // kick.com is not in the starter allowlist. The old path would have fed the
+  // link through with the text and lost the whole message.
+  const out = buildHavenContent({
+    content: '@everyone Streamer is live on Kick!',
+    embeds: [{
+      type: 'rich',
+      title: 'Streamer on Kick',
+      url: 'https://kick.com/streamer',
+      image: { url: 'https://images.kick.com/video_thumbnails/streamer/720.webp' },
+    }],
+  });
+  assert.equal(
+    out,
+    '@everyone Streamer is live on Kick!\nStreamer on Kick\nhttps://images.kick.com/video_thumbnails/streamer/720.webp'
+  );
+});


### PR DESCRIPTION
## What broke

Stream and video promotion bots (CouchBot and friends) bridged through Ferry arrived in Haven as just the ping line. The Twitch / YouTube / Kick link and the thumbnail were gone.

Those bots type "@everyone X is now live" and put everything worth having in a **rich embed**: `embed.url` is the stream link, `embed.title` the stream title, `embed.image` / `embed.thumbnail` the preview picture. `buildHavenContent` only read embeds when the Discord message had **no** text, so the embed was skipped whenever the bot also typed a line, which is every promotion bot. And since 08e7417 an embed carrying an image drops `embed.url` on purpose, so even the text-less shape lost the stream link.

## What changed

`src/ferry.js` `buildHavenContent`:

- **Rich (bot-composed) embeds are read alongside the typed text.** Title, promoted link, and description join the message; the image / thumbnail goes into `media` and renders as an ordinary chat image (same path as Discord attachments, so it is not fed through the link filter).
- **The promoted link is policy-checked on its own.** On an allowlist server the link stands or falls by itself: twitch.tv and youtube.com are in the starter list so they come through, kick.com is not so that link is dropped while the announcement and its thumbnail still relay. Before, a blocked link would have taken the whole message down.
- **Discord's own unfurls are still ignored** when there is typed text (`type` of `link`, `video`, `article`, `image`, `gifv`), so Haven does not preview the same link twice. The link-only and SaucyBot shapes behave exactly as before.
- Title / link / description already present in the typed text are not repeated.

## Tests

- `test/ferry.test.js`: text + rich embed relays link, title, and thumbnail (Twitch image and YouTube thumbnail shapes); typed link is not duplicated; a typed link's Discord unfurl stays ignored.
- `test/ferryAutomod.test.js` (allowlist on): Twitch link kept; Kick link dropped, announcement and thumbnail kept.
- All three new tests fail on the unpatched `src/ferry.js`; 27/27 pass with the patch. The full suite shows the same 5 pre-existing failures on untouched `main` in my environment (audio inspection, forum channels, group E2E), unrelated to this change.

Rendering on the web client was already handled by #5550 (media proxy + raw URL decoding), so once Ferry hands the URLs over, desktop and mobile both show the picture.
