### PR TITLE
Fix reply banners showing [Deleted User] for bot messages.

### DIFF
--- a/server.js
+++ b/server.js
@@ -118,7 +118,7 @@ webpush.setVapidDetails(vapidEmail, process.env.VAPID_PUBLIC_KEY, process.env.VA
 
 const { initDatabase } = require('./src/database');
 const { router: authRoutes, authLimiter, verifyToken } = require('./src/auth');
-const { setupSocketHandlers, sanitizeText, sanitizeBorderTransform } = require('./src/socketHandlers');
+const { setupSocketHandlers, sanitizeText, sanitizeBorderTransform, toReplyContext } = require('./src/socketHandlers');
 const { initFerry, stopFerry } = require('./src/ferry');
 const { canAccessVoiceChannel, getAccessibleVoiceChannels } = require('./src/botVoice');
 const {
@@ -3665,17 +3665,16 @@ app.post('/api/webhooks/:token', webhookLimiter, express.json({ limit: '64kb' })
   if (replyTo) {
     try {
       const r = db.prepare(`
-        SELECT m.id, m.content, m.user_id, m.is_webhook, m.webhook_username,
+        SELECT m.id, m.content, m.user_id, m.is_webhook, m.webhook_username, m.imported_from, m.persona_username,
                COALESCE(u.display_name, u.username) AS username
         FROM messages m LEFT JOIN users u ON m.user_id = u.id
         WHERE m.id = ?
       `).get(replyTo);
       if (r) {
-        replyContext = {
-          id: r.id,
+        replyContext = toReplyContext({
+          ...r,
           content: (r.content || '').slice(0, 200),
-          username: r.is_webhook ? `[BOT] ${r.webhook_username || 'Bot'}` : (r.username || 'Unknown')
-        };
+        });
       }
     } catch { /* best-effort */ }
   }

--- a/src/socketHandlers/helpers.js
+++ b/src/socketHandlers/helpers.js
@@ -200,4 +200,31 @@ function filterIdleOnline(entries, thresholdMs, nowMs) {
   return out;
 }
 
-module.exports = { utcStamp, isString, isInt, sanitizeText, isValidUploadPath, normalizeDisplayName, sanitizeBorderTransform, parseBorderTransform, VALID_ROLE_PERMS, filterIdleOnline };
+// ── Reply banner author (#5564) ─────────────────────────
+// Bot/webhook messages store user_id NULL and the display name on
+// webhook_username. A users-table COALESCE alone becomes "[Deleted User]".
+// Keep this in sync with how message history formats is_webhook / persona /
+// imported_from authors.
+function replyAuthorUsername(row) {
+  if (!row) return '[Deleted User]';
+  if (row.is_webhook) return `[BOT] ${row.webhook_username || 'Bot'}`;
+  if (row.imported_from) return row.webhook_username || 'Unknown';
+  if (row.persona_username) return row.persona_username;
+  return row.username || '[Deleted User]';
+}
+
+function toReplyContext(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    content: row.content,
+    user_id: row.user_id,
+    username: replyAuthorUsername(row),
+  };
+}
+
+module.exports = {
+  utcStamp, isString, isInt, sanitizeText, isValidUploadPath, normalizeDisplayName,
+  sanitizeBorderTransform, parseBorderTransform, VALID_ROLE_PERMS, filterIdleOnline,
+  replyAuthorUsername, toReplyContext,
+};

--- a/src/socketHandlers/index.js
+++ b/src/socketHandlers/index.js
@@ -10,7 +10,7 @@ const { sendFcm, isFcmEnabled } = require('../fcm');
 const { DATA_DIR, UPLOADS_DIR, DELETED_ATTACHMENTS_DIR } = require('../paths');
 const HAVEN_VERSION = require('../../package.json').version;
 
-const { sanitizeText, utcStamp, isString, isInt, isValidUploadPath, sanitizeBorderTransform, parseBorderTransform, VALID_ROLE_PERMS, filterIdleOnline } = require('./helpers');
+const { sanitizeText, utcStamp, isString, isInt, isValidUploadPath, sanitizeBorderTransform, parseBorderTransform, VALID_ROLE_PERMS, filterIdleOnline, toReplyContext } = require('./helpers');
 const { socketClientIp } = require('../clientIp');
 const automod = require('../automod');
 const { resolveSpotifyToYouTube, searchYouTube, fetchYouTubePlaylist, extractYouTubeVideoId, resolveMusicMetadata } = require('./musicResolver');
@@ -2291,4 +2291,4 @@ function setupSocketHandlers(io, db, opts = {}) {
   return { activity, state };
 }
 
-module.exports = { setupSocketHandlers, sanitizeText, sanitizeBorderTransform };
+module.exports = { setupSocketHandlers, sanitizeText, sanitizeBorderTransform, toReplyContext };

--- a/src/socketHandlers/messages.js
+++ b/src/socketHandlers/messages.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const fs   = require('fs');
-const { utcStamp, isString, isInt, sanitizeText, parseBorderTransform } = require('./helpers');
+const { utcStamp, isString, isInt, sanitizeText, parseBorderTransform, toReplyContext } = require('./helpers');
 const { getActiveTokenizer, minQueryChars, buildMatchQuery } = require('../searchIndex');
 
 module.exports = function register(socket, ctx) {
@@ -47,23 +47,6 @@ module.exports = function register(socket, ctx) {
     SELECT m.id, m.content, m.user_id, m.is_webhook, m.webhook_username, m.imported_from, m.persona_username,
            COALESCE(u.display_name, u.username, '[Deleted User]') as username
     FROM messages m LEFT JOIN users u ON m.user_id = u.id`;
-
-  function replyAuthorUsername(row) {
-    if (row.is_webhook) return `[BOT] ${row.webhook_username || 'Bot'}`;
-    if (row.imported_from) return row.webhook_username || 'Unknown';
-    if (row.persona_username) return row.persona_username;
-    return row.username || '[Deleted User]';
-  }
-
-  function toReplyContext(row) {
-    if (!row) return null;
-    return {
-      id: row.id,
-      content: row.content,
-      user_id: row.user_id,
-      username: replyAuthorUsername(row),
-    };
-  }
 
   // ── Get message history ─────────────────────────────────
   // ── Forum channels (#144) ──────────────────────────────

--- a/src/socketHandlers/messages.js
+++ b/src/socketHandlers/messages.js
@@ -41,6 +41,30 @@ module.exports = function register(socket, ctx) {
     } catch { /* file locked or already moved */ }
   }
 
+  // Reply banners must match message rendering: bots live in webhook_* with
+  // user_id NULL, so a users-table COALESCE alone becomes "[Deleted User]".
+  const REPLY_CONTEXT_SELECT = `
+    SELECT m.id, m.content, m.user_id, m.is_webhook, m.webhook_username, m.imported_from, m.persona_username,
+           COALESCE(u.display_name, u.username, '[Deleted User]') as username
+    FROM messages m LEFT JOIN users u ON m.user_id = u.id`;
+
+  function replyAuthorUsername(row) {
+    if (row.is_webhook) return `[BOT] ${row.webhook_username || 'Bot'}`;
+    if (row.imported_from) return row.webhook_username || 'Unknown';
+    if (row.persona_username) return row.persona_username;
+    return row.username || '[Deleted User]';
+  }
+
+  function toReplyContext(row) {
+    if (!row) return null;
+    return {
+      id: row.id,
+      content: row.content,
+      user_id: row.user_id,
+      username: replyAuthorUsername(row),
+    };
+  }
+
   // ── Get message history ─────────────────────────────────
   // ── Forum channels (#144) ──────────────────────────────
   // A forum channel is an ordinary channel whose top-level messages are
@@ -179,11 +203,9 @@ module.exports = function register(socket, ctx) {
     const replyMap = new Map();
     if (replyIds.length > 0) {
       const ph = replyIds.map(() => '?').join(',');
-      db.prepare(`
-        SELECT m.id, m.content, m.user_id, COALESCE(u.display_name, u.username, '[Deleted User]') as username
-        FROM messages m LEFT JOIN users u ON m.user_id = u.id
+      db.prepare(`${REPLY_CONTEXT_SELECT}
         WHERE m.id IN (${ph}) AND m.channel_id = ?
-      `).all(...replyIds, channel.id).forEach(r => replyMap.set(r.id, r));
+      `).all(...replyIds, channel.id).forEach(r => replyMap.set(r.id, toReplyContext(r)));
     }
 
     const reactionMap = new Map();
@@ -1113,10 +1135,9 @@ module.exports = function register(socket, ctx) {
       };
 
       if (replyTo) {
-        message.replyContext = db.prepare(`
-          SELECT m.id, m.content, m.user_id, COALESCE(u.display_name, u.username, '[Deleted User]') as username FROM messages m
-          LEFT JOIN users u ON m.user_id = u.id WHERE m.id = ? AND m.channel_id = ?
-        `).get(replyTo, channel.id) || null;
+        message.replyContext = toReplyContext(db.prepare(`${REPLY_CONTEXT_SELECT}
+          WHERE m.id = ? AND m.channel_id = ?
+        `).get(replyTo, channel.id));
       }
 
       io.to(`channel:${code}`).emit('new-message', { channelCode: code, message });
@@ -1984,10 +2005,9 @@ module.exports = function register(socket, ctx) {
     const replyMap = new Map();
     if (replyIds.length > 0) {
       const ph = replyIds.map(() => '?').join(',');
-      db.prepare(`
-        SELECT m.id, m.content, m.user_id, COALESCE(u.display_name, u.username, '[Deleted User]') as username
-        FROM messages m LEFT JOIN users u ON m.user_id = u.id WHERE m.id IN (${ph})
-      `).all(...replyIds).forEach(r => replyMap.set(r.id, r));
+      db.prepare(`${REPLY_CONTEXT_SELECT}
+        WHERE m.id IN (${ph})
+      `).all(...replyIds).forEach(r => replyMap.set(r.id, toReplyContext(r)));
     }
 
     const reactionMap = new Map();
@@ -2116,10 +2136,9 @@ module.exports = function register(socket, ctx) {
       };
 
       if (replyTo) {
-        message.replyContext = db.prepare(`
-          SELECT m.id, m.content, m.user_id, COALESCE(u.display_name, u.username, '[Deleted User]') as username
-          FROM messages m LEFT JOIN users u ON m.user_id = u.id WHERE m.id = ?
-        `).get(replyTo) || null;
+        message.replyContext = toReplyContext(db.prepare(`${REPLY_CONTEXT_SELECT}
+          WHERE m.id = ?
+        `).get(replyTo));
       }
 
       // Emit to everyone in the channel who has the thread open

--- a/test/replyContext.test.js
+++ b/test/replyContext.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * Reply banner author formatting (#5564).
+ * Bot/webhook parents have user_id NULL; the name lives on webhook_username.
+ */
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  replyAuthorUsername,
+  toReplyContext,
+} = require('../src/socketHandlers/helpers');
+
+test('webhook bot uses [BOT] webhook_username', () => {
+  assert.equal(
+    replyAuthorUsername({
+      is_webhook: 1,
+      webhook_username: 'LOLbot',
+      username: '[Deleted User]',
+    }),
+    '[BOT] LOLbot'
+  );
+});
+
+test('webhook without a name falls back to [BOT] Bot', () => {
+  assert.equal(
+    replyAuthorUsername({ is_webhook: 1, webhook_username: null, username: null }),
+    '[BOT] Bot'
+  );
+});
+
+test('imported messages use webhook_username without the BOT prefix', () => {
+  assert.equal(
+    replyAuthorUsername({
+      is_webhook: 0,
+      imported_from: 'discord',
+      webhook_username: 'Alice',
+      username: '[Deleted User]',
+    }),
+    'Alice'
+  );
+  assert.equal(
+    replyAuthorUsername({
+      imported_from: 'discord',
+      webhook_username: null,
+      username: '[Deleted User]',
+    }),
+    'Unknown'
+  );
+});
+
+test('persona username wins over the real account name', () => {
+  assert.equal(
+    replyAuthorUsername({
+      persona_username: 'SecretSelf',
+      username: 'realuser',
+    }),
+    'SecretSelf'
+  );
+});
+
+test('regular users keep their COALESCE username', () => {
+  assert.equal(
+    replyAuthorUsername({ username: 'andrew', user_id: 3 }),
+    'andrew'
+  );
+});
+
+test('missing user row becomes [Deleted User]', () => {
+  assert.equal(replyAuthorUsername({ username: null, user_id: null }), '[Deleted User]');
+  assert.equal(replyAuthorUsername(null), '[Deleted User]');
+});
+
+test('webhook wins over persona and imported fields', () => {
+  // Webhook rows are a different message type; persona must not override.
+  assert.equal(
+    replyAuthorUsername({
+      is_webhook: 1,
+      webhook_username: 'LOLbot',
+      persona_username: 'ShouldNotWin',
+      imported_from: 'discord',
+      username: 'realuser',
+    }),
+    '[BOT] LOLbot'
+  );
+});
+
+test('toReplyContext maps a SQL row into the banner shape', () => {
+  assert.equal(toReplyContext(null), null);
+  assert.deepEqual(
+    toReplyContext({
+      id: 42,
+      content: 'ping',
+      user_id: null,
+      is_webhook: 1,
+      webhook_username: 'LOLbot',
+      username: '[Deleted User]',
+    }),
+    {
+      id: 42,
+      content: 'ping',
+      user_id: null,
+      username: '[BOT] LOLbot',
+    }
+  );
+});
+
+test('toReplyContext for a normal user keeps user_id and display name', () => {
+  assert.deepEqual(
+    toReplyContext({
+      id: 7,
+      content: 'hello',
+      user_id: 3,
+      is_webhook: 0,
+      username: 'andrew',
+    }),
+    {
+      id: 7,
+      content: 'hello',
+      user_id: 3,
+      username: 'andrew',
+    }
+  );
+});

--- a/test/replyToBot.integration.test.js
+++ b/test/replyToBot.integration.test.js
@@ -1,0 +1,166 @@
+/**
+ * Reply-to-bot banner (#5564): replyContext must show "[BOT] Name", not
+ * "[Deleted User]", for webhook parents with null user_id.
+ *
+ *   node --test test/replyToBot.integration.test.js
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { spawn } = require('node:child_process');
+const { io } = require('socket.io-client');
+
+const PORT = 3399;
+const BASE = `http://127.0.0.1:${PORT}`;
+const DATA = path.join(os.tmpdir(), `haven-reply-bot-${Date.now()}`);
+
+let server;
+
+const post = (p, body) => new Promise((res, rej) => {
+  const d = JSON.stringify(body);
+  const r = http.request({
+    host: '127.0.0.1', port: PORT, path: p, method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(d) },
+  }, (x) => {
+    let b = '';
+    x.on('data', (c) => (b += c));
+    x.on('end', () => {
+      try { res({ status: x.statusCode, body: JSON.parse(b) }); }
+      catch { res({ status: x.statusCode, body: { raw: b } }); }
+    });
+  });
+  r.on('error', rej);
+  r.write(d);
+  r.end();
+});
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function connect(token) {
+  const s = io(BASE, { auth: { token }, transports: ['websocket'], forceNew: true });
+  return new Promise((res, rej) => {
+    s.on('connect', () => res(s));
+    s.on('connect_error', rej);
+  });
+}
+
+function next(sock, event, filter = () => true, ms = 4000) {
+  return new Promise((res) => {
+    const t = setTimeout(() => { sock.off(event, h); res(null); }, ms);
+    const h = (data) => {
+      if (!filter(data)) return;
+      clearTimeout(t);
+      sock.off(event, h);
+      res(data);
+    };
+    sock.on(event, h);
+  });
+}
+
+function history(sock, code) {
+  const p = next(sock, 'message-history', (d) => d && d.channelCode === code);
+  sock.emit('get-messages', { code });
+  return p;
+}
+
+test.before(async () => {
+  fs.mkdirSync(DATA, { recursive: true });
+  server = spawn(process.execPath, ['server.js'], {
+    cwd: path.join(__dirname, '..'),
+    env: {
+      ...process.env,
+      PORT: String(PORT),
+      HOST: '127.0.0.1',
+      FORCE_HTTP: 'true',
+      HAVEN_DATA_DIR: DATA,
+      ADMIN_USERNAME: 'admin',
+    },
+    stdio: 'ignore',
+  });
+  for (let i = 0; i < 60; i++) {
+    try {
+      await new Promise((res, rej) =>
+        http.get(`${BASE}/api/health`, (r) => (r.statusCode === 200 ? res() : rej())).on('error', rej)
+      );
+      return;
+    } catch {
+      await wait(500);
+    }
+  }
+  throw new Error('server did not start');
+});
+
+test.after(() => {
+  server?.kill();
+  try { fs.rmSync(DATA, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+test('replying to a webhook bot keeps [BOT] name in replyContext', async () => {
+  const admin = await post('/api/auth/register', {
+    username: 'admin',
+    password: 'replybottest123',
+    eulaVersion: '2.0',
+    ageVerified: true,
+  });
+  assert.ok(admin.body.token, 'admin registered');
+  const sock = await connect(admin.body.token);
+
+  const list = next(sock, 'channels-list', (chs) => Array.isArray(chs) && chs.some((c) => c.name === 'bots'));
+  sock.emit('create-channel', { name: 'bots' });
+  const channels = await list;
+  assert.ok(channels, 'channel list arrived');
+  const code = channels.find((c) => c.name === 'bots').code;
+
+  const created = next(sock, 'webhook-created', (w) => w && w.name === 'LOLbot');
+  sock.emit('create-webhook', { channelCode: code, name: 'LOLbot' });
+  const webhook = await created;
+  assert.ok(webhook?.token, 'webhook token issued');
+  assert.equal(webhook.token.length, 64);
+
+  sock.emit('enter-channel', { code });
+  await wait(200);
+
+  const botPost = await post(`/api/webhooks/${webhook.token}`, {
+    content: 'lol',
+    username: 'LOLbot',
+  });
+  assert.equal(botPost.status, 200, `bot post failed: ${JSON.stringify(botPost.body)}`);
+  const botId = botPost.body.message_id;
+  assert.ok(botId, 'bot message id returned');
+
+  // Live path: human reply to the bot message.
+  const live = next(
+    sock,
+    'new-message',
+    (d) => d && d.channelCode === code && d.message?.reply_to === botId
+  );
+  sock.emit('send-message', {
+    code,
+    content: 'replying to lolbot',
+    replyTo: botId,
+  });
+  const liveMsg = await live;
+  assert.ok(liveMsg, 'live reply arrived');
+  assert.equal(liveMsg.message.replyContext?.username, '[BOT] LOLbot');
+  assert.equal(liveMsg.message.replyContext?.user_id, null);
+  assert.equal(liveMsg.message.replyContext?.content, 'lol');
+
+  // History path: reload and confirm the same banner author.
+  const h = await history(sock, code);
+  assert.ok(h, 'history arrived');
+  const reply = h.messages.find((m) => m.reply_to === botId);
+  assert.ok(reply, 'reply present in history');
+  assert.equal(reply.replyContext?.username, '[BOT] LOLbot');
+  assert.notEqual(reply.replyContext?.username, '[Deleted User]');
+
+  const bot = h.messages.find((m) => m.id === botId);
+  assert.ok(bot, 'bot message in history');
+  assert.equal(bot.username, '[BOT] LOLbot');
+
+  sock.close();
+});


### PR DESCRIPTION
Fixing https://github.com/ancsemi/Haven/issues/5564 

### Issue
Replying to a webhook bot message (e.g. LOLbot) showed `[Deleted User]` in the reply banner, while the original message correctly showed `[BOT] LOLbot `

Bot messages are stored with `user_id = NULL` and the display name on `webhook_username`. Reply enrichment only joined the users table, so the name fell through to the deleted-user fallback.

### Fix

- Shared `replyAuthorUsername` / `toReplyContext` in src/socketHandlers/helpers.js
- Reply enrichment (channel history, live send, threads) selects webhook/persona fields and formats authors like message rendering: `[BOT] ${webhook_username}`
- Webhook HTTP reply path in server.js uses the same helper

### Validation

- Unit: test/replyContext.test.js (bot / imported / persona / deleted / regular)
- Integration: test/replyToBot.integration.test.js (post as LOLbot → reply → assert live + history replyContext)
- Full suite: 192/192 passing (npm test)

Bug:
<img width="365" height="205" alt="Screenshot 2026-09-04 at 18 43 51" src="https://github.com/user-attachments/assets/94f287c5-48a4-4862-ab27-30b93ca530c3" />

After fix:
<img width="404" height="190" alt="Screenshot 2026-09-04 at 18 54 25" src="https://github.com/user-attachments/assets/4719d536-70ef-4a81-a74b-99068330dab6" />
