### PR TITLE
[QoL] Remove Login EULA + Persist Modal closure to user-preferences

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,7 @@
           <input type="password" id="login-password" autocomplete="current-password" required>
         </div>
         <button type="submit" class="btn-primary" data-i18n="auth.login.submit">Login</button>
+        <p class="auth-consent-note" data-i18n-html="auth.login.consent_note" style="text-align:center;color:var(--text-muted);font-size:0.72rem;line-height:1.4;margin-top:10px">By clicking "Login", you formally consent to our <a href="#" id="login-tos-link">current ToS</a>, which may be different from the ToS that was effective when you first registered.</p>
         <div class="auth-recovery-links">
           <a href="#" id="forgot-password-show" data-i18n="auth.login.forgot_password">Forgot password?</a>
           <a href="#" id="admin-recover-show" data-i18n="auth.login.locked_out">Locked out? Admin recovery</a>
@@ -277,8 +278,10 @@
         </p>
       </form>
 
-      <!-- EULA acceptance (required before login/register) -->
-      <div class="eula-notice" id="eula-notice">
+      <!-- EULA acceptance. Shown on the account-creation views (register / SSO /
+           guest) only; hidden on the login tab, where consent is instead
+           re-affirmed by the note under the Login button. Toggled in auth.js. -->
+      <div class="eula-notice" id="eula-notice" style="display:none">
         <label class="eula-check-row">
           <input type="checkbox" id="age-checkbox">
           <span data-i18n-html="auth.eula.age_confirm">I confirm that I am <strong>18 years of age or older</strong> (or the age of legal majority in my jurisdiction)</span>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -156,6 +156,7 @@
   const eulaLink = document.getElementById('eula-link');
   const eulaAcceptBtn = document.getElementById('eula-accept-btn');
   const eulaDeclineBtn = document.getElementById('eula-decline-btn');
+  const eulaNotice = document.getElementById('eula-notice');
 
   // Restore EULA acceptance from localStorage (v2.0 requires re-acceptance)
   if (localStorage.getItem('haven_eula_accepted') === '2.0') {
@@ -166,6 +167,16 @@
   eulaLink.addEventListener('click', (e) => {
     e.preventDefault();
     eulaModal.style.display = 'flex';
+  });
+
+  // The login consent note links to the same Terms popup. Its anchor is injected
+  // via data-i18n-html and re-created on every language change, so bind it by
+  // delegation instead of a direct reference a re-render would orphan.
+  document.addEventListener('click', (e) => {
+    if (e.target.closest?.('#login-tos-link')) {
+      e.preventDefault();
+      eulaModal.style.display = 'flex';
+    }
   });
 
   eulaAcceptBtn.addEventListener('click', () => {
@@ -287,6 +298,10 @@
     if (ssoForm) ssoForm.style.display = target === 'sso' ? 'flex' : 'none';
     totpForm.style.display = 'none';
     document.getElementById('recover-form').style.display = 'none';
+    // The age / ToS checkboxes are only for creating an account, so they show on
+    // the register and SSO tabs and stay hidden on login (where the consent note
+    // under the button covers re-affirmation). The guest flow re-shows them.
+    if (eulaNotice) eulaNotice.style.display = (target === 'login') ? 'none' : '';
     hideError();
   }
 
@@ -406,7 +421,10 @@
   loginForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     hideError();
-    if (!checkEula()) return;
+    // No EULA gate on login: an existing account already accepted at
+    // registration (recorded server-side in eula_acceptances). The consent note
+    // under the button covers re-affirmation of the current terms. The account-
+    // creation flows (register / SSO / guest) still call checkEula().
 
     const username = document.getElementById('login-username').value.trim();
     const password = document.getElementById('login-password').value;
@@ -1069,6 +1087,9 @@
       const ssoForm = document.getElementById('sso-form');
       if (ssoForm) ssoForm.style.display = 'none';
       guestForm.style.display = '';
+      // Guest creation still requires consent (guest submit calls checkEula), so
+      // the checkboxes hidden on the login tab must reappear here.
+      if (eulaNotice) eulaNotice.style.display = '';
       const u = document.getElementById('guest-username');
       if (u) u.focus();
     });
@@ -1079,6 +1100,7 @@
       hideError();
       if (guestForm) guestForm.style.display = 'none';
       if (loginForm) loginForm.style.display = '';
+      if (eulaNotice) eulaNotice.style.display = 'none';
     });
   }
   if (guestForm) {

--- a/public/js/modules/app-platform.js
+++ b/public/js/modules/app-platform.js
@@ -237,47 +237,36 @@ _initAndroidBetaBanner() {
 /** Unified first-time-visit popup sequencer. Replaces the previous
  *  uncoordinated `setTimeout`-soup where each promo modal raced the others.
  *  Behavior:
- *    1. Reads a per-popup "seen" map from localStorage. Any popup whose id
- *       is already in the map is skipped forever.
- *    2. Migrates legacy per-popup dismissal keys into the map so users who
- *       hit "Don't show again" in older versions don't see those same
- *       popups again after upgrading.
- *    3. Shows remaining popups one at a time, injecting a footer with
+ *    1. Dismissal state is per-account, stored server-side in user_preferences
+ *       (keys promo_seen_*) — never in localStorage. A popup whose pref is set
+ *       is skipped. State is fetched via get-preferences; the queue waits for
+ *       it before showing anything.
+ *    2. Shows remaining popups one at a time, injecting a footer with
  *       "Next" + "Skip all" so users can click through or bail in one go.
- *    4. Any close action (Next, Skip all, X, overlay click, Maybe Later,
- *       primary CTA) marks the current popup as seen. Skip all also marks
- *       every remaining popup as seen in one shot.
- *    5. NEW popups added in future versions are NOT auto-dismissed by a
- *       previous "Skip all" — only ids the user has actually been shown
- *       (or that pre-existed at migration time) get persisted as seen. */
+ *    3. Persistence is opt-in: a dismissal is written to the account ONLY when
+ *       the user ticks that modal's "Don't show again" box. Any plain close
+ *       (Next, Skip all, X, overlay click, Maybe Later, primary CTA) is
+ *       session-only — the popup returns on the next login. */
 _initWelcomePopups() {
-  // ── Load + migrate dismissal state ──
-  let seen = {};
-  try { seen = JSON.parse(localStorage.getItem('haven_welcome_seen_v1') || '{}') || {}; } catch { seen = {}; }
+  // Run the queue at most once per page load.
+  if (this._welcomePopupsStarted) return;
 
-  // Legacy key migration. Run once on first load after upgrade. Stays
-  // correct on subsequent loads because we only ever set, never clear.
-  if (localStorage.getItem('haven_desktop_promo_dismissed') && !seen.desktop_app_promo) {
-    seen.desktop_app_promo = 1;
+  // Dismissal state lives server-side in user_preferences (fetched via
+  // get-preferences). Wait for it to land before deciding what to show —
+  // otherwise a hardened browser (which wipes localStorage every session and
+  // so never had a client-side record anyway) would re-show a modal the user
+  // already told us to stop showing. No localStorage is read or written here.
+  if (!this._userPrefs) {
+    this.socket.once('preferences', () => this._initWelcomePopups());
+    return;
   }
-  if (localStorage.getItem('haven_ab_promo_nodisplay') && !seen.android_app_promo) {
-    seen.android_app_promo = 1;
-  }
-  if (localStorage.getItem('haven_multi_role_notice_v1')) {
-    // The multi-role popup was removed in 3.22.0; mark as seen defensively
-    // so the migration path is consistent even though the popup is gone.
-    seen.multi_role_notice_v1 = 1;
-  }
-
-  const persist = () => {
-    try { localStorage.setItem('haven_welcome_seen_v1', JSON.stringify(seen)); } catch {}
-  };
-  persist();
+  this._welcomePopupsStarted = true;
 
   // ── Build the queue ──
-  // Each entry: { id, modalId, shouldShow }. Anything in `seen` is filtered
-  // out. shouldShow() handles per-platform skips (e.g. desktop promo is
-  // useless inside the desktop app itself).
+  // Each entry: { id, modalId, prefKey, checkboxId, shouldShow }. A popup is
+  // filtered out only if its persisted "Don't show again" pref is set.
+  // shouldShow() handles per-platform skips (e.g. desktop promo is useless
+  // inside the desktop app itself).
   const isMobile = /Android|iPhone|iPad|iPod|Mobile|Tablet/i.test(navigator.userAgent);
   const isElectron = !!window.havenDesktop || navigator.userAgent.includes('Electron');
 
@@ -285,16 +274,20 @@ _initWelcomePopups() {
     {
       id: 'desktop_app_promo',
       modalId: 'desktop-promo-modal',
+      prefKey: 'promo_seen_desktop',
+      checkboxId: 'desktop-promo-dismiss-check',
       shouldShow: () => !isElectron && !isMobile,
     },
     {
       id: 'android_app_promo',
       modalId: 'android-beta-modal',
+      prefKey: 'promo_seen_android',
+      checkboxId: 'android-beta-dismiss-check',
       shouldShow: () => true,
     },
   ];
 
-  const queue = allEntries.filter(e => !seen[e.id] && e.shouldShow() && document.getElementById(e.modalId));
+  const queue = allEntries.filter(e => this._userPrefs[e.prefKey] !== 'true' && e.shouldShow() && document.getElementById(e.modalId));
   if (!queue.length) return;
 
   // ── Sequencer ──
@@ -338,9 +331,10 @@ _initWelcomePopups() {
     const skipBtn = footer.querySelector('.haven-welcome-queue-skip');
     if (skipBtn) {
       skipBtn.addEventListener('click', () => {
-        // Mark everything still in the queue as seen, then close.
-        for (let i = idx; i < queue.length; i++) seen[queue[i].id] = 1;
-        persist();
+        // Terminate the queue for this session. Nothing is persisted — only an
+        // explicit "Don't show again" tick (handled on close below) survives to
+        // the next login. The current modal's own checkbox is still honoured
+        // because hiding it fires the close handler.
         idx = queue.length; // force terminate
         modal.style.display = 'none';
       });
@@ -357,11 +351,14 @@ _initWelcomePopups() {
       if (d === 'none' || d === '') {
         try { activeObserver.disconnect(); } catch {}
         activeObserver = null;
-        // Always mark the current entry seen on close (the user has now
-        // been shown it; we don't want to nag them every reload). New ids
-        // added in future versions are not affected.
-        seen[entry.id] = 1;
-        persist();
+        // Persist a dismissal only when the user ticked this modal's "Don't
+        // show again" box. A plain close (Next / Done / Maybe Later / overlay)
+        // is session-only: the queue has already advanced past it here, but it
+        // returns on the next login. This is deliberate — see commit rationale.
+        const checkbox = document.getElementById(entry.checkboxId);
+        if (checkbox && checkbox.checked) {
+          this.socket.emit('set-preference', { key: entry.prefKey, value: 'true' });
+        }
         idx++;
         // Tiny delay so the close animation / focus shift completes before
         // the next one opens — feels less jarring than back-to-back flashes.

--- a/public/js/modules/app-socket.js
+++ b/public/js/modules/app-socket.js
@@ -439,10 +439,11 @@ _setupSocketListeners() {
       this.socket.emit('set-status', this._pendingStatus);
       this._pendingStatus = null;
     }
-    // Show recovery-codes feature notice once per user (dismissible)
-    if (!localStorage.getItem('haven_recovery_notice_v1')) {
-      setTimeout(() => this._showRecoveryNotice(), 2500);
-    }
+    // Ask the server whether to surface the recovery-codes notice. It decides:
+    // skipped when the account already has recovery codes, or the user ticked
+    // "never show again" (both checked server-side). Reply is handled by the
+    // 'recovery-notice-state' listener registered in _setupSocketListeners.
+    this.socket.emit('get-recovery-notice-state');
   });
   document.addEventListener('visibilitychange', () => {
     this.socket?.emit('visibility-change', { visible: !document.hidden });
@@ -2347,6 +2348,13 @@ _setupSocketListeners() {
     // Activity toggles live entirely server-side (other clients must honour
     // them), so the UI can only be correct once prefs land.
     this._syncActivityUI?.();
+  });
+
+  // Server's verdict on the recovery-codes notice (see the connect handler's
+  // get-recovery-notice-state emit). Only shows when the account has no
+  // recovery codes and the user hasn't ticked "never show again".
+  this.socket.on('recovery-notice-state', ({ show } = {}) => {
+    if (show) setTimeout(() => this._showRecoveryNotice(), 2500);
   });
 
   // ── Rich presence: linked accounts ─────────────────

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -1050,10 +1050,13 @@ _showToast(message, type = 'info', action = null, duration = 4000) {
   setTimeout(() => toast.remove(), duration);
 },
 
-/** Show a one-time notice about the Account Recovery feature */
+/** Show a one-time notice about the Account Recovery feature.
+ *  Whether to show it at all is decided server-side (no recovery codes yet AND
+ *  not previously dismissed) — see get-recovery-notice-state. This only guards
+ *  against showing twice within a single session (e.g. socket reconnects). */
 _showRecoveryNotice() {
-  // Guard: only show once
-  if (localStorage.getItem('haven_recovery_notice_v1')) return;
+  if (this._recoveryNoticeShown) return;
+  this._recoveryNoticeShown = true;
 
   const overlay = document.createElement('div');
   overlay.className = 'modal-overlay recovery-notice-overlay';
@@ -1078,18 +1081,24 @@ _showRecoveryNotice() {
 
   document.body.appendChild(overlay);
 
-  const dismiss = () => {
+  // Persist "never show again" per-account (not localStorage), same as the
+  // promo modals. A plain close is session-only; the notice returns next login
+  // unless the user generates recovery codes (which the server check suppresses
+  // it on) or ticks the box here.
+  const persistIfChecked = () => {
     if (document.getElementById('recovery-notice-dsa')?.checked) {
-      localStorage.setItem('haven_recovery_notice_v1', '1');
+      this.socket.emit('set-preference', { key: 'recovery_notice_seen', value: 'true' });
     }
+  };
+
+  const dismiss = () => {
+    persistIfChecked();
     overlay.remove();
   };
 
   document.getElementById('recovery-notice-close').addEventListener('click', dismiss);
   document.getElementById('recovery-notice-go').addEventListener('click', () => {
-    if (document.getElementById('recovery-notice-dsa')?.checked) {
-      localStorage.setItem('haven_recovery_notice_v1', '1');
-    }
+    persistIfChecked();
     overlay.remove();
     // Open settings modal and navigate to recovery section
     document.getElementById('open-settings-btn')?.click();

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -20,7 +20,8 @@
       "forgot_password": "Forgot password?",
       "locked_out": "Locked out? Admin recovery",
       "admin_recover_hint": "Enter your admin credentials above and click Recover",
-      "admin_recover_btn": "Recover Admin Access"
+      "admin_recover_btn": "Recover Admin Access",
+      "consent_note": "By clicking \"Login\", you formally consent to our <a href=\"#\" id=\"login-tos-link\">current ToS</a>, which may be different from the ToS that was effective when you first registered."
     },
     "register": {
       "username_label": "Username",

--- a/src/socketHandlers/users.js
+++ b/src/socketHandlers/users.js
@@ -561,6 +561,11 @@ module.exports = function register(socket, ctx) {
       // OFF (absent row = not sharing); the two sub-toggles default ON but
       // only matter once the master is enabled.
       'share_activity', 'share_game_activity', 'share_music_activity',
+      // "Don't show again" for the desktop / mobile promo modals and the
+      // recovery-codes notice. Persisted per-account (not localStorage) so
+      // hardened browsers that wipe local storage every session still honour a
+      // prior dismissal instead of re-showing the modal on every login.
+      'promo_seen_desktop', 'promo_seen_android', 'recovery_notice_seen',
     ];
     if (!allowedKeys.includes(key) || !value || value.length > 50) return;
 
@@ -578,6 +583,30 @@ module.exports = function register(socket, ctx) {
     const ACTIVITY_KEYS = ['share_activity', 'share_game_activity', 'share_music_activity'];
     if ((key === 'hide_score_badge' || ACTIVITY_KEYS.includes(key)) && socket.currentChannel) {
       emitOnlineUsers(socket.currentChannel);
+    }
+  });
+
+  // ── Recovery-codes notice gating ────────────────────────
+  // The client asks whether to surface the one-time "generate recovery codes"
+  // notice; the decision is made entirely server-side. Skip it when the account
+  // already has at least one usable recovery code (nothing to nudge), or when
+  // the user ticked "never show again" (persisted in user_preferences, exactly
+  // like the promo-modal dismissals).
+  socket.on('get-recovery-notice-state', () => {
+    try {
+      const codes = db.prepare(
+        'SELECT COUNT(*) AS c FROM account_recovery_codes WHERE user_id = ? AND used = 0'
+      ).get(socket.user.id);
+      const pref = db.prepare(
+        "SELECT value FROM user_preferences WHERE user_id = ? AND key = 'recovery_notice_seen'"
+      ).get(socket.user.id);
+      const hasCodes = (codes?.c || 0) > 0;
+      const dismissed = pref?.value === 'true';
+      socket.emit('recovery-notice-state', { show: !hasCodes && !dismissed });
+    } catch (err) {
+      console.error('recovery-notice-state error:', err);
+      // Fail closed: never nag if we couldn't determine the state.
+      socket.emit('recovery-notice-state', { show: false });
     }
   });
 


### PR DESCRIPTION
Two QoL improvements to streamline the login flow, especially for privacy-hardened browsers which clear localStorage every session.

## 1. Persist popup dismissals server-side

The desktop-app promo, mobile-app promo, and recovery-codes notice
remembered their dismissed state in localStorage, so browsers that wipe
storage re-showed all three on every login. Dismissal state now lives in
the existing per-account `user_preferences` table (`promo_seen_desktop`,
`promo_seen_android`, `recovery_notice_seen`) over the existing
get/set-preference channel. No schema change.

- Only the "don't show again" checkbox persists. A plain close is
  session-only and returns next login.
- The recovery notice also gates on server state: if the account already
  has recovery codes, it is skipped entirely.
- The top-bar app badges and every modal's call to action are unchanged.

## 2. Drop the consent gate on login

The 18+ and Terms checkboxes gated both registration and login, with
acceptance cached in localStorage, so hardened browsers forced a re-tick
on every login. Consent only needs capturing once, at signup, which the
server already records in `eula_acceptances` (version, IP, timestamp, age
flag). The checkboxes now appear only on the account-creation views
(register, SSO, guest), which still enforce them. Login drops the gate
and shows a note stating that logging in consents to the current Terms,
which may differ from the version accepted at registration, linked to the
Terms popup. Login still sends the version and age flag, so the server
contract is unchanged.

## Testing

Verified on a local instance: checkbox dismissals persist across reload
and a full localStorage wipe; plain closes do not; the recovery notice
respects both existing codes and dismissal; login works with no
checkboxes; registration, SSO, and guest still enforce them.