### PR TITLE
More markdown shortcuts

### DIFF
--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2396,28 +2396,85 @@ _openInviteLinksModal() {
 },
 
 // ═══════════════════════════════════════════════════════
-// markdown link pasting
+// markdown keyboard shortcut helper functions
 // ═══════════════════════════════════════════════════════
 
-_handleMarkdownLinkPaste(input, event) {
-  const url = event.clipboardData.getData('text/plain').trim();
-  // Only handle pasted URLs.
-  if (!/^https?:\/\/\S+$/i.test(url)) {
-    return;
-  }
+_wrapSelectedText(inputEl, before, after, forEachLine = false) {
+  const input = inputEl || document.getElementById('message-input');
 
   const start = input.selectionStart;
   const end = input.selectionEnd;
-  // Nothing selected, so allow normal paste behavior.
-  if (start === end) {
-    return;
+  if (start === end) return false;
+
+  const selectedText = input.value.substring(start, end);
+  const replacement = forEachLine  ? selectedText .split('\n') .map(line => `${before}${line}${after}`) .join('\n') : `${before}${selectedText}${after}`;
+
+  input.setRangeText(replacement, start, end);
+  input.setSelectionRange(start, start + replacement.length);
+  return true;
+},
+
+_handleMarkdownLinkPaste(inputEl, event) {
+  const input = inputEl || document.getElementById('message-input');
+  const url = event.clipboardData.getData('text/plain').trim();
+
+  // Only handle pasted URLs.
+  if (!/^https?:\/\/\S+$/i.test(url)) return false;
+  return this._wrapSelectedText(input, '[', `](${url})`);
+},
+
+_handleMarkdownShortcuts(inputEl, event) {
+  const input = inputEl || document.getElementById('message-input');
+
+  const modifier = event.ctrlKey || event.metaKey;
+  if (!modifier) return false;
+  const key = event.key.toLowerCase();
+
+  // Link (Ctrl/Cmd + K)
+  if (key === 'k') {
+
+    if (this._wrapSelectedText(input, '[', ']()')) {
+      const end = input.selectionEnd;
+      // Place cursor inside the URL parentheses.
+      input.setSelectionRange(end + 2, end + 2);
+      return true;
+    }
+    return false;
   }
 
-  // hijack the paste event and insert markdown link on highlighted text
-  event.preventDefault();
-  const selectedText = input.value.substring(start, end);
-  const markdownLink = `[${selectedText}](${url})`;
-  input.setRangeText(markdownLink, start, end, 'end');
+  // Italic (Ctrl/Cmd + I)
+  if (key === 'i') {
+    return this._wrapSelectedText(input, '*', `*`, true);
+  }
+
+  // Bold (Ctrl/Cmd + B)
+  if (key === 'b') {
+    return this._wrapSelectedText(input, '**', `**`, true);
+  }
+
+  // Code (Ctrl/Cmd + Shift + C)
+  if (event.shiftKey && key === 'c') {
+    const start = input.selectionStart;
+    const end = input.selectionEnd;
+    if (start === end) return false;
+
+    const selectedText = input.value.substring(start, end);
+    if (selectedText.includes('\n')) {
+      return this._wrapSelectedText(input, '```\n', '\n```');
+    }
+    return this._wrapSelectedText(input, '`', '`');
+  }
+
+  // Strikethrough (Ctrl/Cmd + Shift + X)
+  if (event.shiftKey && key === 'x') {
+    return this._wrapSelectedText(input, '~~', `~~`, true);
+  }
+
+  // Spoiler (Ctrl/Cmd + Shift + P)
+  if (event.shiftKey && key === 'p') {
+    return this._wrapSelectedText(input, '||', `||`);
+  }
+  return false;
 },
 
 // ═══════════════════════════════════════════════════════

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2443,7 +2443,11 @@ _handleMarkdownShortcuts(inputEl, event) {
   }
 
   // Italic (Ctrl/Cmd + I)
+  // Alt-Italic (Ctrl/Cmd + Shift + I)
   if (key === 'i') {
+    if (event.shiftKey){
+      return this._wrapSelectedText(input, '_', `_`, true);
+    }
     return this._wrapSelectedText(input, '*', `*`, true);
   }
 

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2443,12 +2443,16 @@ _handleMarkdownShortcuts(inputEl, event) {
   }
 
   // Italic (Ctrl/Cmd + I)
-  // Alt-Italic (Ctrl/Cmd + Shift + I)
   if (key === 'i') {
-    if (event.shiftKey){
-      return this._wrapSelectedText(input, '_', `_`, true);
+    const start = input.selectionStart;
+    const end = input.selectionEnd;
+    if (start === end) return false;
+
+    const selectedText = input.value.substring(start, end);
+    if (selectedText.includes('\n')) {
+      return this._wrapSelectedText(input, '_', `_`);
     }
-    return this._wrapSelectedText(input, '*', `*`, true);
+    return this._wrapSelectedText(input, '*', `*`);
   }
 
   // Bold (Ctrl/Cmd + B)

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2407,7 +2407,7 @@ _wrapSelectedText(inputEl, before, after, forEachLine = false) {
   if (start === end) return false;
 
   const selectedText = input.value.substring(start, end);
-  const replacement = forEachLine  ? selectedText .split('\n') .map(line => `${before}${line}${after}`) .join('\n') : `${before}${selectedText}${after}`;
+  const replacement = forEachLine ? selectedText.split('\n').map(line => line ? `${before}${line}${after}` : line).join('\n') : `${before}${selectedText}${after}`;
 
   input.setRangeText(replacement, start, end);
   input.setSelectionRange(start, start + replacement.length);

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2430,18 +2430,6 @@ _handleMarkdownShortcuts(inputEl, event) {
   if (!modifier) return false;
   const key = event.key.toLowerCase();
 
-  // Link (Ctrl/Cmd + K)
-  if (key === 'k') {
-
-    if (this._wrapSelectedText(input, '[', ']()')) {
-      const end = input.selectionEnd;
-      // Place cursor inside the URL parentheses.
-      input.setSelectionRange(end + 2, end + 2);
-      return true;
-    }
-    return false;
-  }
-
   // Italic (Ctrl/Cmd + I)
   if (key === 'i') {
     return this._wrapSelectedText(input, '*', `*`, true);

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2444,15 +2444,7 @@ _handleMarkdownShortcuts(inputEl, event) {
 
   // Italic (Ctrl/Cmd + I)
   if (key === 'i') {
-    const start = input.selectionStart;
-    const end = input.selectionEnd;
-    if (start === end) return false;
-
-    const selectedText = input.value.substring(start, end);
-    if (selectedText.includes('\n')) {
-      return this._wrapSelectedText(input, '_', `_`);
-    }
-    return this._wrapSelectedText(input, '*', `*`);
+    return this._wrapSelectedText(input, '*', `*`, true);
   }
 
   // Bold (Ctrl/Cmd + B)

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -210,6 +210,12 @@ _setupUI() {
         }
       }
     }
+
+    // Markdown Formatting shortcuts
+    if (this._handleMarkdownShortcuts(msgInput, e)) {
+      e.preventDefault();
+      return;
+    }
   });
 
   msgInput.addEventListener('input', () => {
@@ -239,7 +245,9 @@ _setupUI() {
 
   // insert a markdown link when a link is pasted over selected text
   msgInput.addEventListener('paste', (event) => {
-    this._handleMarkdownLinkPaste(msgInput, event);
+    if (this._handleMarkdownLinkPaste(msgInput, event)) {
+      event.preventDefault();
+    }
   });
 
   document.getElementById('send-btn').addEventListener('click', () => this._sendMessage());
@@ -2194,6 +2202,12 @@ _setupUI() {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       this._sendDMPiPMessage?.();
+      return;
+    }
+    // Markdown Formatting shortcuts
+    if (this._handleMarkdownShortcuts(dmPipInput, e)) {
+      e.preventDefault();
+      return;
     }
   });
   if (dmPipInput) dmPipInput.addEventListener('input', () => {
@@ -2226,7 +2240,9 @@ _setupUI() {
     }
 
     // insert a markdown link when a link is pasted over selected text
-    this._handleMarkdownLinkPaste(dmPipInput, e);
+    if (this._handleMarkdownLinkPaste(dmPipInput, e)) {
+      e.preventDefault();
+    }
   });
 
   // PiP emoji button — positions the picker above the button and targets the PiP input
@@ -2361,6 +2377,12 @@ _setupUI() {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         this._sendThreadMessage();
+        return;
+      }
+      // Markdown Formatting shortcuts
+      if (this._handleMarkdownShortcuts(threadInput, e)) {
+        e.preventDefault();
+        return;
       }
     });
     threadInput.addEventListener('input', () => {
@@ -2387,7 +2409,9 @@ _setupUI() {
       }
 
       // insert a markdown link when a link is pasted over selected text
-      this._handleMarkdownLinkPaste(threadInput, e);
+      if (this._handleMarkdownLinkPaste(threadInput, e)) {
+        e.preventDefault();
+      }
     });
 
     // Drag & drop parity with the other composers — queue, never insta-post.

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -3829,6 +3829,12 @@ _startEditMessage(msgEl, msgId) {
       if (e.key === 'Escape') { this._hideEmojiDropdown(); return; }
     }
 
+    // Markdown formatting shortcuts
+    if (this._handleMarkdownShortcuts(textarea, e)) {
+      e.preventDefault();
+      return;
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       btnRow.querySelector('.edit-save-btn').click();
@@ -3836,6 +3842,13 @@ _startEditMessage(msgEl, msgId) {
     if (e.key === 'Escape') {
       e.preventDefault();
       cancel();
+    }
+  });
+
+  textarea.addEventListener('paste', (e) => {
+    if (this._handleMarkdownLinkPaste(textarea, e)) {
+      e.preventDefault();
+      return;
     }
   });
 


### PR DESCRIPTION
Adds more keyboard shortcuts for markdown formatting over highlighted text in `message-input`, `dm-pip-input`, `thread-input`, and `edit-textarea` fields.
- Italic (Ctrl/Cmd + I)
- Bold (Ctrl/Cmd + B)
- Code (Ctrl/Cmd + Shift + C)
- Strikethrough (Ctrl/Cmd + Shift + X)
- Spoiler (Ctrl/Cmd + Shift + P)

Also added the link paste shortcut to `edit-textarea` fields