### PR TITLE
Fetch cloudflared when it is missing, and say why Windows refused a port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Haven uses [Sema
 
 ## [Unreleased]
 
+### Fixed
+- **Cloudflare Tunnel on Windows never worked out of the box.** The installer's Cloudflare
+  option says "auto-downloads cloudflared", but nothing downloaded it and the tunnel module
+  only ever ran `cloudflared` from PATH, so a fresh install that picked Cloudflare always
+  ended in "cloudflared binary not found in PATH" (reported by a self-hoster 2026-09-05).
+  The tunnel module now looks on PATH, then in `<data dir>/bin`, and fetches the official
+  release binary into that folder on first start when neither has it (Windows and Linux;
+  macOS gets a `brew install cloudflared` hint). A failed download says exactly which file
+  to drop where. The installer pre-fetches the same file when Cloudflare is chosen.
+- **A refused port on Windows now says why.** `EACCES` on Windows is almost always a port
+  inside a Hyper-V/WSL reserved range rather than a privilege problem; the startup error
+  now points at `netsh interface ipv4 show excludedportrange protocol=tcp` and the
+  `winnat` restart instead of only mentioning ports below 1024.
+
 ### Added
 - **Copy an invite as an email card (#5559).** Each invite link has an envelope
   button that copies a formatted invitation, in your theme and language and with

--- a/Install Haven.ps1
+++ b/Install Haven.ps1
@@ -470,6 +470,19 @@ $ui['btnNext3'].Add_Click({
     try {
         $npmOut = & npm install --no-audit --no-fund 2>&1
         if ($ui['radLT'].IsChecked) { & npm install localtunnel --save 2>&1 | Out-Null }
+        if ($ui['radCF'].IsChecked) {
+            # The Cloudflare option promised an auto-download and never did one; the server
+            # now fetches cloudflared on first use, and this pre-fetch just saves the wait.
+            try {
+                Set-Step 'step2' 'active' 'Downloading cloudflared...'
+                $binDir = Join-Path $DATA_DIR 'bin'
+                if (!(Test-Path $binDir)) { New-Item -ItemType Directory -Path $binDir -Force | Out-Null }
+                $cfArch = if ([Environment]::Is64BitOperatingSystem) { 'amd64' } else { '386' }
+                $cfUrl = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-$cfArch.exe"
+                [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+                (New-Object System.Net.WebClient).DownloadFile($cfUrl, (Join-Path $binDir 'cloudflared.exe'))
+            } catch { Set-Step 'step2' 'active' "cloudflared download skipped ($_); Haven will fetch it on first tunnel start" }
+        }
         Set-Step 'step2' 'done' 'Dependencies installed'
     } catch {
         Set-Step 'step2' 'error' "npm install failed: $_"

--- a/server.js
+++ b/server.js
@@ -6017,7 +6017,9 @@ server.on('error', (err) => {
       ? `port ${PORT} is already in use — is another Haven instance (or other app) running?`
       : err.code === 'EADDRNOTAVAIL'
         ? `this machine has no network interface with address ${HOST} — check HOST in your .env`
-        : `no permission to bind port ${PORT} (ports below 1024 need elevation)`;
+        : process.platform === 'win32'
+          ? `Windows refused port ${PORT}. Ports below 1024 need an elevated prompt; otherwise the port is usually inside a reserved range held by Hyper-V/WSL (see: netsh interface ipv4 show excludedportrange protocol=tcp). Pick another PORT in your .env, or free the range with: net stop winnat && net start winnat`
+          : `no permission to bind port ${PORT} (ports below 1024 need elevation)`;
     console.error(`\n❌ Haven could not start: ${why}`);
     console.error(`   Stop the other process or change PORT in your .env, then start Haven again.`);
     logCrash('Fatal listen error (exiting)', err);

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -4,6 +4,93 @@
 // ═══════════════════════════════════════════════════════════
 
 const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const { DATA_DIR } = require('./paths');
+
+// ── cloudflared location ─────────────────────────────────────
+// The Windows installer advertises "auto-downloads cloudflared", and until
+// now nothing did: this module only ever spawned `cloudflared` from PATH, so
+// every Cloudflare setup on a fresh Windows box ended in "binary not found
+// in PATH". The binary is now looked for on PATH first, then in the data
+// directory's bin/ folder, and fetched from the official GitHub release into
+// that folder when neither has it. Downloads are best-effort and explained;
+// a user can always drop the file in bin/ (or on PATH) by hand.
+const BIN_DIR = path.join(DATA_DIR, 'bin');
+const CLOUDFLARED_RELEASE = 'https://github.com/cloudflare/cloudflared/releases/latest/download/';
+
+// Asset name in the cloudflared release for this platform, or null when the
+// release only ships an archive we would have to unpack (macOS).
+function cloudflaredAssetName(platform = process.platform, arch = process.arch) {
+  if (platform === 'win32') return arch === 'ia32' ? 'cloudflared-windows-386.exe' : 'cloudflared-windows-amd64.exe';
+  if (platform === 'linux') {
+    const map = { x64: 'amd64', arm64: 'arm64', arm: 'arm', ia32: '386' };
+    return map[arch] ? `cloudflared-linux-${map[arch]}` : null;
+  }
+  return null;
+}
+
+function localCloudflaredPath() {
+  return path.join(BIN_DIR, process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared');
+}
+
+function onPath(cmd) {
+  try {
+    const r = spawnSync(cmd, ['--version'], { stdio: 'ignore', windowsHide: true });
+    return !!(r && r.status === 0);
+  } catch { return false; }
+}
+
+// Resolve order: PATH, then <data>/bin. Returns the command to spawn or null.
+function resolveCloudflared({ binDir = BIN_DIR, pathHas = onPath } = {}) {
+  if (pathHas('cloudflared')) return 'cloudflared';
+  const local = path.join(binDir, process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared');
+  if (fs.existsSync(local)) return local;
+  return null;
+}
+
+function fetchToFile(url, dest, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 6) return reject(new Error('too many redirects'));
+    const req = https.get(url, { headers: { 'User-Agent': 'Haven' }, timeout: 30000 }, (resp) => {
+      if ([301, 302, 303, 307, 308].includes(resp.statusCode) && resp.headers.location) {
+        resp.resume();
+        return fetchToFile(new URL(resp.headers.location, url).href, dest, redirects + 1).then(resolve, reject);
+      }
+      if (resp.statusCode !== 200) { resp.resume(); return reject(new Error(`HTTP ${resp.statusCode}`)); }
+      const out = fs.createWriteStream(dest);
+      resp.pipe(out);
+      out.on('finish', () => out.close(resolve));
+      out.on('error', reject);
+      resp.on('error', reject);
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(new Error('download timed out')); });
+  });
+}
+
+// Download the release binary into <data>/bin. Resolves to the binary path.
+async function downloadCloudflared({ binDir = BIN_DIR, fetch = fetchToFile } = {}) {
+  const asset = cloudflaredAssetName();
+  if (!asset) {
+    throw new Error(`no automatic cloudflared download for ${process.platform}/${process.arch}; install it yourself (macOS: brew install cloudflared) or put the binary in ${binDir}`);
+  }
+  fs.mkdirSync(binDir, { recursive: true });
+  const dest = path.join(binDir, process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared');
+  const tmp = dest + '.part';
+  console.log(`[tunnel] cloudflared not found, downloading ${asset} into ${binDir} ...`);
+  try {
+    await fetch(CLOUDFLARED_RELEASE + asset, tmp);
+    fs.renameSync(tmp, dest);
+    if (process.platform !== 'win32') fs.chmodSync(dest, 0o755);
+  } catch (err) {
+    try { fs.unlinkSync(tmp); } catch { /* nothing to clean */ }
+    throw new Error(`could not download cloudflared (${err.message}). Download ${asset} from github.com/cloudflare/cloudflared/releases and save it as ${dest}`);
+  }
+  console.log(`[tunnel] cloudflared ready at ${dest}`);
+  return dest;
+}
 
 let active = null;
 let status = { active: false, url: null, provider: null, error: null };
@@ -13,14 +100,7 @@ function providerAvailable(provider) {
   if (provider === 'localtunnel') {
     try { require.resolve('localtunnel'); return true; } catch { return false; }
   }
-  if (provider === 'cloudflared') {
-    try {
-      const result = spawnSync('cloudflared', ['--version'], { stdio: 'ignore', windowsHide: true });
-      return result && result.status === 0;
-    } catch {
-      return false;
-    }
-  }
+  if (provider === 'cloudflared') return !!resolveCloudflared() || !!cloudflaredAssetName();
   return false;
 }
 
@@ -59,7 +139,7 @@ async function startTunnel(port, provider = 'localtunnel', ssl = false) {
     if (!providerAvailable(provider)) {
       throw new Error(provider === 'localtunnel'
         ? 'localtunnel package not installed (run: npm install localtunnel)'
-        : 'cloudflared binary not found in PATH');
+        : `cloudflared is not installed and cannot be downloaded for this platform; put the binary in ${BIN_DIR} or on PATH`);
     }
 
     if (provider === 'localtunnel') {
@@ -85,7 +165,8 @@ async function startTunnel(port, provider = 'localtunnel', ssl = false) {
     const origin = ssl ? `https://127.0.0.1:${port}` : `http://127.0.0.1:${port}`;
     const args = ['tunnel', '--url', origin, '--no-autoupdate'];
     if (ssl) args.push('--no-tls-verify');
-    const proc = spawn('cloudflared', args, {
+    const cloudflaredCmd = resolveCloudflared() || await downloadCloudflared();
+    const proc = spawn(cloudflaredCmd, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true
     });
@@ -163,4 +244,8 @@ function registerProcessCleanup() {
   process.on('exit', cleanup);
 }
 
-module.exports = { startTunnel, stopTunnel, getTunnelStatus, registerProcessCleanup };
+module.exports = {
+  startTunnel, stopTunnel, getTunnelStatus, registerProcessCleanup,
+  // exported for tests and the installer
+  cloudflaredAssetName, resolveCloudflared, downloadCloudflared, localCloudflaredPath, BIN_DIR
+};

--- a/test/tunnelCloudflared.test.js
+++ b/test/tunnelCloudflared.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// The Windows installer says "auto-downloads cloudflared". Until this change
+// nothing did: the tunnel module only spawned `cloudflared` from PATH, so a
+// fresh Windows install that picked the Cloudflare option always ended in
+// "cloudflared binary not found in PATH" (reported by a self-hoster on 2026-09-05).
+// These tests lock the lookup order and the download fallback.
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tmpData = fs.mkdtempSync(path.join(os.tmpdir(), 'haven-tunnel-'));
+process.env.HAVEN_DATA_DIR = tmpData;
+const tunnel = require('../src/tunnel');
+
+const exe = process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared';
+
+test('release asset name follows the platform', () => {
+  assert.equal(tunnel.cloudflaredAssetName('win32', 'x64'), 'cloudflared-windows-amd64.exe');
+  assert.equal(tunnel.cloudflaredAssetName('win32', 'ia32'), 'cloudflared-windows-386.exe');
+  assert.equal(tunnel.cloudflaredAssetName('linux', 'x64'), 'cloudflared-linux-amd64');
+  assert.equal(tunnel.cloudflaredAssetName('linux', 'arm64'), 'cloudflared-linux-arm64');
+  assert.equal(tunnel.cloudflaredAssetName('darwin', 'arm64'), null, 'macOS ships a tgz; not auto-downloaded');
+});
+
+test('PATH wins, then the data bin folder, then nothing', () => {
+  const binDir = path.join(tmpData, 'bin');
+  assert.equal(tunnel.resolveCloudflared({ binDir, pathHas: () => true }), 'cloudflared');
+  assert.equal(tunnel.resolveCloudflared({ binDir, pathHas: () => false }), null, 'nothing installed yet');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, exe), '');
+  assert.equal(tunnel.resolveCloudflared({ binDir, pathHas: () => false }), path.join(binDir, exe));
+  fs.rmSync(binDir, { recursive: true, force: true });
+});
+
+test('download lands in the data bin folder and is executable', async () => {
+  const binDir = path.join(tmpData, 'bin2');
+  const got = await tunnel.downloadCloudflared({
+    binDir,
+    fetch: async (url, dest) => {
+      assert.match(url, /github\.com\/cloudflare\/cloudflared\/releases\/latest\/download\/cloudflared-/);
+      fs.writeFileSync(dest, 'fake-binary');
+    }
+  });
+  assert.equal(got, path.join(binDir, exe));
+  assert.equal(fs.readFileSync(got, 'utf8'), 'fake-binary');
+  assert.ok(!fs.existsSync(got + '.part'), 'temp file renamed away');
+  if (process.platform !== 'win32') assert.ok(fs.statSync(got).mode & 0o100, 'chmod +x applied');
+});
+
+test('a failed download is explained and leaves no partial file', async () => {
+  const binDir = path.join(tmpData, 'bin3');
+  await assert.rejects(
+    tunnel.downloadCloudflared({ binDir, fetch: async () => { throw new Error('HTTP 503'); } }),
+    (err) => /could not download cloudflared \(HTTP 503\)/.test(err.message) && /releases/.test(err.message)
+  );
+  assert.ok(!fs.existsSync(path.join(binDir, exe + '.part')));
+});
+
+test('cloudflared counts as available when it can be downloaded', () => {
+  const st = tunnel.getTunnelStatus();
+  const expected = !!tunnel.cloudflaredAssetName() || !!tunnel.resolveCloudflared();
+  assert.equal(st.available.cloudflared, expected);
+});


### PR DESCRIPTION
## What broke

A Windows self-hoster picked the **Cloudflare Tunnel** option in `Install Haven.ps1`, whose card reads "Free, no config needed. Auto-downloads cloudflared." Nothing downloads it. `src/tunnel.js` only ever ran `cloudflared` from PATH, so starting the tunnel from the admin panel failed with `cloudflared binary not found in PATH`, and the same person had already lost an afternoon to port forwarding.

## What changed

`src/tunnel.js`
- `resolveCloudflared()` looks on PATH first, then in `<data dir>/bin/cloudflared(.exe)`.
- `downloadCloudflared()` fetches the official release asset for the platform (`cloudflared-windows-amd64.exe`, `-386.exe`, `cloudflared-linux-{amd64,arm64,arm,386}`) from `github.com/cloudflare/cloudflared/releases/latest/download/` into `<data dir>/bin`, following GitHub's redirect, writing to a `.part` file and renaming, `chmod 755` on POSIX. macOS is not auto-downloaded (the release ships a tgz); the error says `brew install cloudflared`.
- `startTunnel('cloudflared')` uses the resolved path and downloads on first use. A failed download names the exact file to fetch and where to put it.
- `providerAvailable('cloudflared')` is true when the binary is present or downloadable, so the admin panel offers the option on a fresh box.

`Install Haven.ps1`: when the Cloudflare radio is chosen, pre-fetch the same file into `%APPDATA%\Haven\bin` (best effort, the server self-heals if it fails).

`server.js`: the `EACCES` bind message on Windows now points at `netsh interface ipv4 show excludedportrange protocol=tcp` and the `winnat` restart. On Windows that error is almost always a Hyper-V/WSL reserved range, and "ports below 1024 need elevation" sends people the wrong way.

## Verified

- `test/tunnelCloudflared.test.js`: asset names per platform, resolve order (PATH, then bin, then null), download into bin with rename and mode, failed download cleans up its `.part` and explains, availability reporting. 5/5.
- Live: with a temp `HAVEN_DATA_DIR`, `downloadCloudflared()` pulled 54,841,128 bytes through the GitHub redirect and the result ran: `cloudflared version 2026.8.3`.
- `Install Haven.ps1` parses (PowerShell AST parser, no errors). Existing `ferry` and `webhookCallback` suites still pass.
