### PR TITLE
[feat] Timestamp generator modal

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -554,6 +554,14 @@
                   <line x1="2"  y1="20" x2="22" y2="20"/>
                 </svg>
               </button>
+              <span class="input-actions-divider" id="time-divider"></span>
+              <button id="time-btn" class="btn-poll btn-time" data-i18n-title="app.input_bar.time_btn" title="Insert timestamp">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="9"/>
+                  <line x1="12" y1="12" x2="12" y2="7"/>
+                  <line x1="12" y1="12" x2="15.5" y2="13.5"/>
+                </svg>
+              </button>
               <span class="input-actions-divider" id="burn-divider" style="display:none"></span>
               <button id="burn-btn" class="btn-burn" data-i18n-title="app.input_bar.burn_btn" title="Burn after read (DM only)" style="display:none">🔥</button>
             </div>
@@ -3859,6 +3867,65 @@
         <button class="btn-sm" id="poll-cancel-btn" data-i18n="modals.common.cancel">Cancel</button>
         <button class="btn-sm btn-accent" id="poll-create-btn" data-i18n="modals.poll.create_btn">Create Poll</button>
       </div>
+    </div>
+  </div>
+
+  <!-- Timestamp Modal (/time with no args) -->
+  <div class="modal-overlay" id="time-modal" style="display:none">
+    <div class="modal tsm-modal" style="width:400px">
+      <div class="tsm-header">
+        <div class="tsm-clock" aria-hidden="true">🕐</div>
+        <p class="modal-desc tsm-subtitle" data-i18n="commands.description.time">Insert a time everyone sees in their own timezone</p>
+        <p class="tsm-syntax" data-i18n="commands.time_usage">Usage: /time 8pm</p>
+      </div>
+
+      <!-- Date row -->
+      <div class="tsm-row" role="group" data-i18n-aria-label="modals.time.date_label" aria-label="Date">
+        <div class="tsm-field">
+          <label for="tsm-year" data-i18n="modals.time.year">Year</label>
+          <input type="number" id="tsm-year" class="tsm-input" min="1970" max="9999" step="1" inputmode="numeric" autocomplete="off">
+        </div>
+        <div class="tsm-field">
+          <label for="tsm-month" data-i18n="modals.time.month">Month</label>
+          <input type="number" id="tsm-month" class="tsm-input" min="1" max="12" step="1" inputmode="numeric" autocomplete="off">
+        </div>
+        <div class="tsm-field">
+          <label for="tsm-day" data-i18n="modals.time.day">Day</label>
+          <input type="number" id="tsm-day" class="tsm-input" min="1" max="31" step="1" inputmode="numeric" autocomplete="off">
+        </div>
+        <div class="tsm-field tsm-cal-field">
+          <label aria-hidden="true">&nbsp;</label>
+          <button type="button" id="tsm-cal-btn" class="tsm-cal-btn" data-i18n-title="modals.time.calendar" title="Open calendar">📅</button>
+          <input type="date" id="tsm-cal-input" class="tsm-cal-native" tabindex="-1" aria-hidden="true">
+        </div>
+      </div>
+
+      <!-- Time row -->
+      <div class="tsm-row" role="group" data-i18n-aria-label="modals.time.time_label" aria-label="Time">
+        <div class="tsm-field">
+          <label for="tsm-hour" data-i18n="modals.time.hour">Hour</label>
+          <input type="number" id="tsm-hour" class="tsm-input" min="0" max="23" step="1" inputmode="numeric" autocomplete="off">
+        </div>
+        <div class="tsm-field">
+          <label for="tsm-minute" data-i18n="modals.time.minute">Minute</label>
+          <input type="number" id="tsm-minute" class="tsm-input" min="0" max="59" step="1" inputmode="numeric" autocomplete="off">
+        </div>
+        <div class="tsm-field">
+          <label for="tsm-second" data-i18n="modals.time.second">Second</label>
+          <input type="number" id="tsm-second" class="tsm-input" min="0" max="59" step="1" inputmode="numeric" autocomplete="off">
+        </div>
+        <div class="tsm-field tsm-meridiem-field">
+          <label aria-hidden="true">&nbsp;</label>
+          <div class="tsm-meridiem" role="group" data-i18n-aria-label="modals.time.clock_mode" aria-label="Clock mode">
+            <button type="button" class="tsm-mer-btn" data-mer="24" data-i18n="modals.time.hour_24">24HR</button>
+            <button type="button" class="tsm-mer-btn" data-mer="AM" data-i18n="modals.time.am">AM</button>
+            <button type="button" class="tsm-mer-btn" data-mer="PM" data-i18n="modals.time.pm">PM</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Styles: every format previewed, each with its own insert -->
+      <div class="tsm-styles" id="tsm-styles"></div>
     </div>
   </div>
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9202,6 +9202,141 @@ html:not([data-toolbaricons="emoji"]):not([data-toolbaricons="color"]) .tb-icon-
   cursor: help;
 }
 
+/* ── /time timestamp modal ─────────────────────────────── */
+.tsm-header { margin-bottom: 1rem; }
+.tsm-clock {
+  font-size: 2.25rem;
+  line-height: 1;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+.tsm-subtitle {
+  text-align: center;
+  margin-bottom: 0.375rem;
+  font-size: 0.9375rem;
+  color: var(--text-primary);
+}
+.tsm-syntax {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+}
+
+.tsm-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 0.625rem;
+}
+.tsm-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+.tsm-field > label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+.tsm-input {
+  width: 100%;
+  padding: 0.5rem 0.5rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  text-align: center;
+  transition: border-color var(--transition);
+}
+.tsm-input:focus { border-color: var(--accent); outline: none; }
+
+/* Calendar button reuses the native date input from search: the <input
+   type="date"> stays visually hidden and its picker is opened on demand. */
+.tsm-cal-field { flex: 0 0 auto; position: relative; }
+.tsm-cal-btn {
+  padding: 0.5rem 0.625rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color var(--transition), background var(--transition);
+}
+.tsm-cal-btn:hover { background: var(--bg-hover); border-color: var(--accent); }
+.tsm-cal-native {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+  border: 0;
+  padding: 0;
+}
+
+.tsm-meridiem-field { flex: 0 0 auto; }
+.tsm-meridiem { display: flex; }
+.tsm-mer-btn {
+  padding: 0.5rem 0.5rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-left-width: 0;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+.tsm-mer-btn:first-child {
+  border-left-width: 1px;
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+}
+.tsm-mer-btn:last-child { border-radius: 0 var(--radius-sm) var(--radius-sm) 0; }
+.tsm-mer-btn:hover { color: var(--text-primary); }
+.tsm-mer-btn.active {
+  background: var(--accent);
+  color: var(--accent-text);
+  border-color: var(--accent);
+}
+
+/* Every style previewed on its own row with a dedicated insert button. */
+.tsm-styles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-top: 0.875rem;
+}
+.tsm-style-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4375rem 0.625rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.tsm-style-preview {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+/* Let a long "Full Date/Time" wrap in the row instead of overflowing. */
+.tsm-style-preview .chat-timestamp { white-space: normal; }
+.tsm-style-insert { flex: 0 0 auto; }
+.tsm-style-preview:empty::after { content: "—"; color: var(--text-muted); }
+.tsm-style-preview.tsm-invalid { color: var(--text-muted); }
+
 .mention {
   background: rgba(124, 92, 252, 0.15);
   color: var(--accent);

--- a/public/js/modules/app-channels.js
+++ b/public/js/modules/app-channels.js
@@ -145,6 +145,10 @@ async switchChannel(code) {
   if (_emojiBtn) _emojiBtn.style.display = _textOff ? 'none' : '';
   if (_gifBtn) _gifBtn.style.display = _textOff ? 'none' : '';
   if (_pollBtn) _pollBtn.style.display = _textOff ? 'none' : '';
+  const _timeBtn = document.getElementById('time-btn');
+  const _timeDivider = document.getElementById('time-divider');
+  if (_timeBtn) _timeBtn.style.display = _textOff ? 'none' : '';
+  if (_timeDivider) _timeDivider.style.display = _textOff ? 'none' : '';
   // Upload button tied to media toggle
   const _uploadBtn = document.getElementById('upload-btn');
   if (_uploadBtn) _uploadBtn.style.display = _mediaOff ? 'none' : '';

--- a/public/js/modules/app-messages.js
+++ b/public/js/modules/app-messages.js
@@ -100,6 +100,16 @@ async _sendMessage() {
         return;
       }
       if (cmd === 'time') {
+        // No argument opens the picker modal; the toast is kept for input
+        // that was typed but could not be parsed.
+        if (!arg) {
+          input.value = '';
+          input.style.height = 'auto';
+          this._hideMentionDropdown();
+          this._hideSlashDropdown();
+          this._openTimeModal();
+          return;
+        }
         const token = this._buildTimeToken(arg);
         if (!token) {
           this._showToast(t('commands.time_usage'), 'error');

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -2946,6 +2946,9 @@ _setupUI() {
   document.getElementById('poll-btn').addEventListener('click', () => {
     this._openPollModal();
   });
+  document.getElementById('time-btn')?.addEventListener('click', () => {
+    this._openTimeModal();
+  });
 
   // (#5280) Burn-after-read toggle (DM-only, default 30 s).
   // Persistent toggle: once armed, every outgoing message in the
@@ -2978,6 +2981,36 @@ _setupUI() {
   document.getElementById('poll-modal').addEventListener('click', (e) => {
     if (e.target.id === 'poll-modal') e.target.style.display = 'none';
   });
+
+  // ── /time timestamp picker modal ──
+  const timeModal = document.getElementById('time-modal');
+  if (timeModal) {
+    const refresh = () => this._tsmUpdatePreview();
+    ['tsm-year', 'tsm-month', 'tsm-day', 'tsm-hour', 'tsm-minute', 'tsm-second']
+      .forEach(id => document.getElementById(id)?.addEventListener('input', refresh));
+    timeModal.querySelectorAll('.tsm-mer-btn').forEach(b => {
+      b.addEventListener('click', () => { this._tsmSetMeridiem(b.dataset.mer); refresh(); });
+    });
+    document.getElementById('tsm-cal-btn')?.addEventListener('click', () => {
+      const di = document.getElementById('tsm-cal-input');
+      if (!di) return;
+      const cur = this._tsmBuildDate();
+      // Seed the native picker with the fields' current date so it opens there.
+      if (cur) {
+        const p = n => String(n).padStart(2, '0');
+        di.value = `${cur.getFullYear()}-${p(cur.getMonth() + 1)}-${p(cur.getDate())}`;
+      }
+      try { di.showPicker(); } catch { di.focus(); di.click(); }
+    });
+    document.getElementById('tsm-cal-input')?.addEventListener('change', () => this._tsmSyncFromCalendar());
+    document.getElementById('tsm-styles')?.addEventListener('click', (e) => {
+      const btn = e.target.closest('.tsm-style-insert');
+      if (btn) this._tsmInsert(btn.dataset.style);
+    });
+    timeModal.addEventListener('click', (e) => {
+      if (e.target.id === 'time-modal') e.target.style.display = 'none';
+    });
+  }
 
   // Rename username
   document.getElementById('rename-btn').addEventListener('click', () => {
@@ -6286,6 +6319,159 @@ _submitPoll() {
 
   this.socket.emit('create-poll', { question, options, multiVote, anonymous });
   document.getElementById('poll-modal').style.display = 'none';
+},
+
+/* ── /time timestamp picker modal ───────────────────── */
+// Opened by `/time` with no argument. It builds the very same <t:...> token
+// the text command does, so the render side (_formatTimestampToken) is reused
+// untouched — the modal is only a friendlier way to choose the instant.
+
+/** True when the reader's locale keeps a 24-hour clock. Falls back to 24-hour
+ *  when the browser cannot report an hour cycle, per the feature's default. */
+_tsm24hDefault() {
+  try {
+    const hc = new Intl.DateTimeFormat(this._timeLocale?.(), { hour: 'numeric' })
+      .resolvedOptions().hourCycle;
+    if (hc) return hc === 'h23' || hc === 'h24';
+    // Older engines omit hourCycle: probe whether an afternoon hour prints a
+    // meridiem marker instead.
+    const s = new Date(2020, 0, 1, 13).toLocaleTimeString(this._timeLocale?.(), { hour: 'numeric' });
+    return !/[ap]\.?\s?m/i.test(s);
+  } catch { return true; }
+},
+
+_openTimeModal() {
+  const modal = document.getElementById('time-modal');
+  if (!modal) return;
+  const now = new Date();
+  const set = (id, v) => { const el = document.getElementById(id); if (el) el.value = v; };
+  set('tsm-year', now.getFullYear());
+  set('tsm-month', now.getMonth() + 1);
+  set('tsm-day', now.getDate());
+  set('tsm-minute', now.getMinutes());
+  set('tsm-second', now.getSeconds());
+  // Default the clock mode to the reader's own convention, then seed the hour
+  // field in whatever units that mode expects.
+  this._tsmSetMeridiem(this._tsm24hDefault() ? '24' : (now.getHours() < 12 ? 'AM' : 'PM'), now.getHours());
+  this._tsmRenderStyles();
+  this._tsmUpdatePreview();
+  modal.style.display = 'flex';
+  document.getElementById('tsm-hour')?.focus();
+},
+
+/** Switch the 24HR / AM / PM segmented control. `seedHour24`, when given, is a
+ *  0–23 hour to load into the field in the new mode's units. */
+_tsmSetMeridiem(mode, seedHour24) {
+  this._tsmMeridiem = mode;
+  document.querySelectorAll('#time-modal .tsm-mer-btn').forEach(b => {
+    b.classList.toggle('active', b.dataset.mer === mode);
+  });
+  const hourEl = document.getElementById('tsm-hour');
+  if (!hourEl) return;
+  const cur = Number(hourEl.value);
+  // Reuse whatever hour is already showing when the user flips the toggle, so
+  // "8 PM" stays 8 PM going to 24-hour (→ 20) and back.
+  let h24 = Number.isFinite(seedHour24) ? seedHour24 : this._tsmReadHour24(cur);
+  if (!Number.isFinite(h24)) h24 = 0;
+  if (mode === '24') {
+    hourEl.min = 0; hourEl.max = 23;
+    hourEl.value = h24;
+  } else {
+    hourEl.min = 1; hourEl.max = 12;
+    hourEl.value = ((h24 % 12) || 12);
+  }
+},
+
+/** Convert the hour field's current number into 0–23, honouring the mode. */
+_tsmReadHour24(raw) {
+  const h = Number(raw);
+  if (!Number.isFinite(h)) return NaN;
+  if (this._tsmMeridiem === '24') return h;
+  const base = h % 12;
+  return this._tsmMeridiem === 'PM' ? base + 12 : base;
+},
+
+/** Read all fields into a Date in the sender's own timezone, or null if the
+ *  combination is not a real calendar instant. */
+_tsmBuildDate() {
+  const num = id => Number(document.getElementById(id)?.value);
+  const y = num('tsm-year'), mo = num('tsm-month'), d = num('tsm-day');
+  const mi = num('tsm-minute'), se = num('tsm-second');
+  const h24 = this._tsmReadHour24(document.getElementById('tsm-hour')?.value);
+  if (![y, mo, d, mi, se, h24].every(Number.isFinite)) return null;
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  if (h24 < 0 || h24 > 23 || mi < 0 || mi > 59 || se < 0 || se > 59) return null;
+  const when = new Date(y, mo - 1, d, h24, mi, se, 0);
+  // Reject dates JS silently rolls forward (e.g. 2026-02-31 → March).
+  if (when.getFullYear() !== y || when.getMonth() !== mo - 1 || when.getDate() !== d) return null;
+  return when;
+},
+
+/** Build the seven style rows once — each a live preview plus its own Insert
+ *  button. Order follows the format list the feature documents. */
+_tsmRenderStyles() {
+  const box = document.getElementById('tsm-styles');
+  if (!box || box.childElementCount) return;
+  const label = this._escapeHtml(t('modals.time.insert_btn'));
+  box.innerHTML = ['F', 'f', 'D', 'd', 't', 'T', 'R'].map(s =>
+    `<div class="tsm-style-row" data-style="${s}">` +
+      `<span class="tsm-style-preview"></span>` +
+      `<button type="button" class="btn-sm btn-accent tsm-style-insert" data-style="${s}">${label}</button>` +
+    `</div>`).join('');
+},
+
+/** Refresh every style's preview from the current field values. */
+_tsmUpdatePreview() {
+  const box = document.getElementById('tsm-styles');
+  if (!box) return;
+  const when = this._tsmBuildDate();
+  const secs = when ? Math.floor(when.getTime() / 1000) : null;
+  box.querySelectorAll('.tsm-style-row').forEach(row => {
+    const prev = row.querySelector('.tsm-style-preview');
+    const btn = row.querySelector('.tsm-style-insert');
+    const html = secs !== null ? this._formatTimestampToken(secs, row.dataset.style) : null;
+    if (html) {
+      prev.classList.remove('tsm-invalid');
+      prev.innerHTML = html;
+      if (btn) { btn.disabled = false; btn.setAttribute('aria-label', `${t('modals.time.insert_btn')}: ${prev.textContent}`); }
+    } else {
+      prev.classList.add('tsm-invalid');
+      prev.textContent = '—';
+      if (btn) btn.disabled = true;
+    }
+  });
+},
+
+/** Pull the native date input's YYYY-MM-DD back into the Year/Month/Day
+ *  fields. The picker itself is the search feature's <input type="date">. */
+_tsmSyncFromCalendar() {
+  const v = document.getElementById('tsm-cal-input')?.value; // YYYY-MM-DD
+  if (!v) return;
+  const m = v.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return;
+  document.getElementById('tsm-year').value = Number(m[1]);
+  document.getElementById('tsm-month').value = Number(m[2]);
+  document.getElementById('tsm-day').value = Number(m[3]);
+  this._tsmUpdatePreview();
+},
+
+_tsmInsert(style) {
+  const when = this._tsmBuildDate();
+  if (!when) return;
+  const s = ['F', 'f', 'D', 'd', 't', 'T', 'R'].includes(style) ? style : 'f';
+  const token = `<t:${Math.floor(when.getTime() / 1000)}:${s}>`;
+  const input = document.getElementById('message-input');
+  document.getElementById('time-modal').style.display = 'none';
+  if (!input) return;
+  // Insert at the caret so the token can sit inside a sentence the user is
+  // already writing; fall back to the end when there is no selection.
+  const start = Number.isInteger(input.selectionStart) ? input.selectionStart : input.value.length;
+  const end = Number.isInteger(input.selectionEnd) ? input.selectionEnd : input.value.length;
+  input.value = input.value.slice(0, start) + token + input.value.slice(end);
+  input.style.height = 'auto';
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  input.focus();
+  try { input.setSelectionRange(start + token.length, start + token.length); } catch { /* not a text input */ }
 },
 
 /* ── iOS Keyboard Layout Fix ────────────────────────── */

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -294,6 +294,7 @@
       "gif_btn": "Search GIFs",
       "gif_label": "GIF",
       "poll_btn": "Create Poll",
+      "time_btn": "Insert timestamp",
       "burn_btn": "Burn after read (DM only)",
       "burn_btn_armed": "Burn after read armed — next message self-destructs 30s after viewing"
     },
@@ -2686,6 +2687,22 @@
       "option_placeholder": "Option {{number}}",
       "option_1": "Option 1",
       "option_2": "Option 2"
+    },
+    "time": {
+      "date_label": "Date",
+      "time_label": "Time",
+      "year": "Year",
+      "month": "Month",
+      "day": "Day",
+      "hour": "Hour",
+      "minute": "Minute",
+      "second": "Second",
+      "calendar": "Open calendar",
+      "clock_mode": "Clock mode",
+      "hour_24": "24HR",
+      "am": "AM",
+      "pm": "PM",
+      "insert_btn": "Insert"
     },
     "sub_panel": {
       "title": "Sub-channel Subscriptions",


### PR DESCRIPTION
## Add a /time picker modal for inserting timestamps and a toolbar icon

Builds on the existing `<t:*:*>` timestamp rendering by adding a comprehensive timestamp generating modal.

### Entry points
- `/time` with no argument opens the picker. A typed argument still resolves directly and shows the usage toast on error.
- A clock button in the input toolbar, next to the poll button.

### The modal
- Date and time in labeled fields (Year/Month/Day, Hour/Minute/Second), with the native calendar picker reused from search and a 24HR/AM/PM toggle that defaults to the reader's own clock (via `Intl…hourCycle`, falling back to 24-hour).
- All seven styles are previewed live in the reader's locale, each with its own Insert button that drops the token at the caret, so it works mid-sentence.
- Invalid dates like Feb 31 disable insertion and show a placeholder.

### Notes
- Theme-aware and translation-driven. The usage hint reads straight from `commands.time_usage`, so locale edits flow through automatically.
- The clock button follows the other input controls and hides in media-only channels.
- The rendering pipeline (`_formatTimestampToken`) is reused unchanged. The modal only chooses the instant.