### PR TITLE
Change chat-image object-fit from "cover" to "contain"

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6840,7 +6840,7 @@ details.sound-section:not([open]) .sound-section-label::before {
   cursor: pointer;
   transition: opacity 0.15s ease;
   display: block;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .chat-image:hover { opacity: 0.85; }


### PR DESCRIPTION
Several people in the community server have complained about wide images cropping in the thumbnail image view.

This PR relieves this concern by changing the object-fit property to eliminate the cropping effect