### PR TITLE
Don't invite to all publics

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -3524,7 +3524,6 @@
           </label>
           <div>
             <h6 style="margin:0 0 4px;font-size:0.82rem;font-weight:600" data-i18n="settings.admin.invite_links.channels_granted">Channels this link grants</h6>
-            <small class="settings-hint" data-i18n="settings.admin.invite_links_channels_hint">Leave all checked to grant every public channel.</small>
             <div id="invite-new-channels" style="margin-top:6px;max-height:180px;overflow-y:auto;border:1px solid var(--border);border-radius:6px;padding:6px">
               <p class="muted-text" style="margin:4px 0;font-size:0.85rem" data-i18n="settings.admin.loading_channels">Loading channels…</p>
             </div>

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -4571,14 +4571,14 @@ _setupUI() {
             ? `<span style="color:var(--danger,#e84a4a)">● ${t('settings.admin.invite_links.expired')}</span>`
             : `<span style="color:var(--green,#43b581)">● ${t('settings.admin.invite_links.active')}</span>`;
       const link = `${origin}/?invite=${encodeURIComponent(ic.code)}`;
-      const chCount = (ic.channels && ic.channels.length)
-        ? t(ic.channels.length === 1 ? 'settings.admin.invite_links.channel_one' : 'settings.admin.invite_links.channel_other', { count: ic.channels.length })
-        : t('settings.admin.invite_links.all_public_channels');
+      const chCount = t(ic.channels.length === 1
+          ? 'settings.admin.invite_links.channel_one'
+          : 'settings.admin.invite_links.channel_other', { count: ic.channels.length }
+      );
       const uses = ic.max_uses > 0 ? `${ic.use_count} / ${ic.max_uses}` : `${ic.use_count}`;
       const expiry = ic.expires_at ? new Date(ic.expires_at).toLocaleString() : t('settings.admin.invite_links.never');
       const label = ic.label ? this._escapeHtml(ic.label) : `<em style="opacity:.6">${t('settings.admin.invite_links.no_label')}</em>`;
-      const editorChannels = _inviteChannelChecks('invite-edit-channel-cb',
-        (ic.channels && ic.channels.length) ? new Set(ic.channels) : null);
+      const editorChannels = _inviteChannelChecks('invite-edit-channel-cb', new Set(ic.channels || []));
       return `<div class="invite-code-card" data-id="${ic.id}" style="border:1px solid var(--border);border-radius:8px;padding:10px">
         <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
           <div style="font-weight:600">${label} &nbsp;<code style="font-size:.85rem">${this._escapeHtml(ic.code)}</code></div>

--- a/public/js/modules/app-ui.js
+++ b/public/js/modules/app-ui.js
@@ -4640,7 +4640,7 @@ _setupUI() {
     const total = cbs.length;
     const picked = cbs.filter(cb => cb.checked).map(cb => parseInt(cb.dataset.cid)).filter(Number.isFinite);
     // All checked → [] = "grant all public" (future-proof as new channels appear).
-    const channels = (total > 0 && picked.length === total) ? [] : picked;
+    const channels = picked;
 
     const maxUsesValue = document.getElementById('invite-new-maxuses')?.value;
     const maxUses = maxUsesValue === '' ? 1 : parseInt(maxUsesValue);
@@ -4712,7 +4712,7 @@ _setupUI() {
       const cbs = Array.from(card.querySelectorAll('.invite-edit-channel-cb'));
       const total = cbs.length;
       const picked = cbs.filter(cb => cb.checked).map(cb => parseInt(cb.dataset.cid)).filter(Number.isFinite);
-      const channels = (total > 0 && picked.length === total) ? [] : picked;
+      const channels = picked;
       const maxUses = parseInt(card.querySelector('[data-role="edit-maxuses"]')?.value) || 0;
       const payload = { id, channels, maxUses };
       const exp = parseInt(card.querySelector('[data-role="edit-expiry"]')?.value);

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1988,7 +1988,6 @@
       "invite_links_label": "Label",
       "invite_links_label_hint": "For your reference, e.g. \"Reddit promo\"",
       "invite_links_label_placeholder": "Optional name",
-      "invite_links_channels_hint": "Leave all checked to grant every public channel.",
       "invite_links_max_uses": "Max uses",
       "invite_links_max_uses_hint": "0 = unlimited. Counts distinct people.",
       "invite_links_custom_code": "Custom code",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2040,7 +2040,6 @@
         "active": "Active",
         "channel_one": "{{count}} channel",
         "channel_other": "{{count}} channels",
-        "all_public_channels": "all public channels",
         "never": "Never",
         "no_label": "(no label)",
         "copy_link": "Copy link",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -1980,7 +1980,6 @@
       "invite_links_label": "Rótulo",
       "invite_links_label_hint": "Para sua referência, ex.: \"Promoção no Reddit\"",
       "invite_links_label_placeholder": "Nome opcional",
-      "invite_links_channels_hint": "Deixe todos marcados para conceder todos os canais públicos.",
       "invite_links_max_uses": "Máximo de usos",
       "invite_links_max_uses_hint": "0 = ilimitado. Conta pessoas distintas.",
       "invite_links_custom_code": "Código personalizado",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -2032,7 +2032,6 @@
         "active": "Ativo",
         "channel_one": "{{count}} canal",
         "channel_other": "{{count}} canais",
-        "all_public_channels": "todos os canais públicos",
         "never": "Nunca",
         "no_label": "(sem rótulo)",
         "copy_link": "Copiar link",

--- a/src/socketHandlers/admin.js
+++ b/src/socketHandlers/admin.js
@@ -544,11 +544,11 @@ module.exports = function register(socket, ctx) {
   // Normalise an admin-supplied channel list into a JSON string of positive
   // ints (capped). Returns '' for "all public", or null if the input is invalid.
   const _normaliseInviteChannels = (channels) => {
-    if (channels == null) return '';
+    if (channels == null) return '[]';
     if (!Array.isArray(channels)) return null;
     const ids = [...new Set(channels.map(n => parseInt(n)).filter(n => Number.isInteger(n) && n > 0))];
     if (ids.length > 500) return null;
-    return ids.length ? JSON.stringify(ids) : '';
+    return JSON.stringify(ids);
   };
 
   // hours <= 0 / falsy → never expires (null). Stored as a UTC string that

--- a/src/socketHandlers/channels.js
+++ b/src/socketHandlers/channels.js
@@ -345,21 +345,23 @@ module.exports = function register(socket, ctx) {
       ).all();
       let allowSet = null;
       if (Array.isArray(explicitChannelIds)) {
-        if (explicitChannelIds.length > 0) {
-          allowSet = new Set(explicitChannelIds.map(n => parseInt(n)).filter(n => Number.isFinite(n)));
-        }
-        // empty array → allowSet stays null → "all public"
+        // Managed invite: the invite's channel list is authoritative.
+        // An empty array means no channels.
+        allowSet = new Set(explicitChannelIds.map(n => parseInt(n, 10)).filter(n => Number.isFinite(n)));
       } else {
+        // Legacy server/vanity code: use the global default join-channel
+        // setting when configured. Empty/unset means all public.
         try {
           const djc = db.prepare("SELECT value FROM server_settings WHERE key = 'default_join_channels'").get();
           if (djc && djc.value) {
             const parsed = JSON.parse(djc.value);
             if (Array.isArray(parsed) && parsed.length > 0) {
-              allowSet = new Set(parsed.map(n => parseInt(n)).filter(n => Number.isFinite(n)));
+              allowSet = new Set(parsed.map(n => parseInt(n, 10)).filter(n => Number.isFinite(n)));
             }
           }
         } catch { /* malformed JSON falls through to "all public" */ }
       }
+
       const parents = allowSet ? allParents.filter(p => allowSet.has(p.id)) : allParents;
       return { parents, allowSet };
     };


### PR DESCRIPTION
Fixes #5569

When an invite link had no channels selected to invite to, the invite would include all public channels, even though the user explicitly unchecked all channels.

The invitee would also get put into every public channel when the inviter created the link didn't have access to all public channels, and didn't uncheck any checkboxes.

This PR fixes this by only adding the invitee to the channels that were visible and explicitly selected when the invite link was created.