### PR TITLE
Fix layout density buttons no longer working after #5582

### DIFF
--- a/public/js/modules/app-media.js
+++ b/public/js/modules/app-media.js
@@ -3692,7 +3692,7 @@ async _uploadBotAvatar(botId, file) {
 },
 
 // Helper function to simplify picker setups
-_setupPicker(pickerId, storageKey, allowedValues, defaultValue, dataKey, onChange, buttonDataKey = dataKey) {
+_setupPicker(pickerId, storageKey, allowedValues, defaultValue, dataKey, onChange, buttonDataKey) {
   if (!allowedValues.includes(defaultValue)) {
     throw new Error(`Invalid default value "${defaultValue}" for ${pickerId}`);
   }
@@ -3701,6 +3701,7 @@ _setupPicker(pickerId, storageKey, allowedValues, defaultValue, dataKey, onChang
   if (!picker) return null;
 
   const dataKeys = Array.isArray(dataKey) ? dataKey : [dataKey];
+  buttonDataKey ??= dataKeys[0];
   const apply = (value, notify = false) => {
     dataKeys.forEach(key => {
       document.documentElement.dataset[key] = value;
@@ -3738,11 +3739,12 @@ _setupDensityPicker() {
   const allowedValues = ['compact', 'cozy', 'spacious'];
   const defaultValue = 'cozy';
   const dataKey = ['density', 'havenDensity'];
+  const buttonDataKey = 'density';
   const onChange = (density) => {
     document.dispatchEvent(new CustomEvent('haven:density-change', {detail: { density }}))
   };
 
-  this._setupPicker(pickerId, storageKey, allowedValues, defaultValue, dataKey, onChange);
+  this._setupPicker(pickerId, storageKey, allowedValues, defaultValue, dataKey, onChange, buttonDataKey);
 },
 
 // ── Channel Scrolling Picker ──


### PR DESCRIPTION
#5582 broke the layout-density settings buttons.
This PR fixes the broken behavior by adding the necessary `buttonDataKey` to the `_setupPicker()` call.

Also fixed: when an array was assigned to `dataKey`, `buttonDataKey` used the value of `dataKey` by default, but didn't handle it as an array. It now defaults to using the the first element of `dataKeys` if `buttonDataKey` isn't provided.

I tested all the pickers after this change, and they are all now working.