### PR TITLE
CRT theme text reads the same size as every other theme

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -10,7 +10,7 @@
   <link rel="manifest" href="/manifest.webmanifest">
   <title>Haven</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cG9seWdvbiBwb2ludHM9IjUwLDMgOTMsMjggOTMsNzIgNTAsOTcgNyw3MiA3LDI4IiBmaWxsPSJub25lIiBzdHJva2U9IiM2YjRmZGIiIHN0cm9rZS13aWR0aD0iOCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjx0ZXh0IHg9IjUwIiB5PSI2MyIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9IkFyaWFsLEhlbHZldGljYSxzYW5zLXNlcmlmIiBmb250LXdlaWdodD0iYm9sZCIgZm9udC1zaXplPSIzOCIgZmlsbD0iIzZiNGZkYiIgb3BhY2l0eT0iMC45NSI+SDwvdGV4dD48L3N2Zz4=">
-  <link rel="stylesheet" href="/css/style.css?v=3.52.2">
+  <link rel="stylesheet" href="/css/style.css?v=3.52.3">
   <script src="/js/theme-compat.js?v=4.1.1"></script>
   <script src="/js/theme-init.js?v=4.1.3"></script>
 </head>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -21,6 +21,10 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
+  /* VT323's glyphs sit small in the em box, so CRT read a size smaller than
+     every other theme. Scale the face to Segoe UI's apparent size; layout
+     boxes stay put because font-size is unchanged. */
+  size-adjust: 120%;
   src: url('/fonts/vt323-latin.woff2?v=1') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -29,6 +33,10 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
+  /* VT323's glyphs sit small in the em box, so CRT read a size smaller than
+     every other theme. Scale the face to Segoe UI's apparent size; layout
+     boxes stay put because font-size is unchanged. */
+  size-adjust: 120%;
   src: url('/fonts/vt323-latin-ext.woff2?v=1') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -37,6 +45,10 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
+  /* VT323's glyphs sit small in the em box, so CRT read a size smaller than
+     every other theme. Scale the face to Segoe UI's apparent size; layout
+     boxes stay put because font-size is unchanged. */
+  size-adjust: 120%;
   src: url('/fonts/vt323-vietnamese.woff2?v=1') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
 }


### PR DESCRIPTION
Reported by Dispencer2: the CRT style's font is inconsistent with all the others and far too small.

CRT is the only theme that swaps in VT323, a pixel face whose glyphs sit small in the em box. Measured in Chromium at 16px: cap height 10 vs Segoe UI's 11, and the same line of text 18 percent narrower, with thin single-pixel strokes on top. Nothing compensated for that.

Fix: `size-adjust: 120%` on the three VT323 `@font-face` blocks (latin, latin-ext, vietnamese all match, so mixed-script runs don't jump). That puts cap height and line width on Segoe UI's. `font-size` is unchanged, so padding, gaps and avatar sizes stay put. Supported in Chromium 92+ and Firefox 92+; older engines keep today's rendering. Cache buster bumped for style.css.