### PR TITLE
Add underlines

### DIFF
--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2452,6 +2452,11 @@ _handleMarkdownShortcuts(inputEl, event) {
     return this._wrapSelectedText(input, '*', `*`, true);
   }
 
+  // Underline (Ctrl/Cmd + U).
+  if (key === 'u' && !event.shiftKey) {
+    return this._wrapSelectedText(input, '__', `__`, true);
+  }
+
   // Bold (Ctrl/Cmd + B). Shift+B is the bookmarks bar in Chrome.
   if (key === 'b' && !event.shiftKey) {
     return this._wrapSelectedText(input, '**', `**`, true);

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -974,6 +974,9 @@ _formatContent(str) {
   // Render **bold**
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
 
+  // Render __underline__
+  html = html.replace(/__(.+?)__/g, '<u>$1</u>');
+
   // Render *italic*
   html = html.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '<em>$1</em>');
 

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -966,6 +966,9 @@ _formatContent(str) {
     return match;
   });
 
+  // Render __underline__
+  html = html.replace(/__(.+?)__/g, '<u>$1</u>');
+
   // Render /me action text (italic)
   if (html.startsWith('_') && html.endsWith('_') && html.length > 2) {
     html = `<em class="action-text">${html.slice(1, -1)}</em>`;
@@ -973,9 +976,6 @@ _formatContent(str) {
 
   // Render **bold**
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-
-  // Render __underline__
-  html = html.replace(/__(.+?)__/g, '<u>$1</u>');
 
   // Render *italic*
   html = html.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '<em>$1</em>');


### PR DESCRIPTION
Adds `__underlined text__` 
and `Ctrl/Cmd + U` Keyboard shortcut to apply underlines wrapper around selected text.