### PR TITLE
Add Inline Message Text Colors

### DIFF
--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2480,8 +2480,8 @@ _handleMarkdownShortcuts(inputEl, event) {
     return this._wrapSelectedText(input, '||', `||`);
   }
 
-  // Text color (Ctrl/Cmd + Shift + C)
-  if (event.shiftKey && key === 'c') {
+  // Text color (Ctrl/Cmd + Shift + F) (F for font, since c for code is already taken)
+  if (event.shiftKey && key === 'f') {
     const colorPrefix = 'c#(51,153,255)'
     if (!this._wrapSelectedText(input, colorPrefix, '#c')) return false;
 

--- a/public/js/modules/app-admin.js
+++ b/public/js/modules/app-admin.js
@@ -2479,6 +2479,17 @@ _handleMarkdownShortcuts(inputEl, event) {
   if (event.shiftKey && key === 'p') {
     return this._wrapSelectedText(input, '||', `||`);
   }
+
+  // Text color (Ctrl/Cmd + Shift + C)
+  if (event.shiftKey && key === 'c') {
+    const colorPrefix = 'c#(51,153,255)'
+    if (!this._wrapSelectedText(input, colorPrefix, '#c')) return false;
+
+    // Move cursor to just before ")" so the user can edit the color
+    const cursorPos = input.selectionStart + (colorPrefix.length - 1);
+    input.setSelectionRange(cursorPos, cursorPos);
+    return true;
+  }
   return false;
 },
 

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -1001,10 +1001,10 @@ _formatContent(str) {
   });
 
   // Render c#RRGGBB...#c color spans (HEX color code)
-  html = html.replace(/c#([0-9a-fA-F]{6})(.+?)#c/g, '<span style="color:#$1">$2</span>');
+  html = html.replace(/c#([0-9a-fA-F]{6})([\s\S]+?)#c/g, '<span style="color:#$1">$2</span>');
 
   // Render c#(R,G,B)...#c color spans (RGB color code)
-  html = html.replace(/c#\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)(.+?)#c/g, (_, r, g, b, text) => {
+  html = html.replace(/c#\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)([\s\S]+?)#c/g, (_, r, g, b, text) => {
     if (r > 255 || g > 255 || b > 255) return _;
     return `<span style="color:rgb(${r},${g},${b})">${text}</span>`;
   });

--- a/public/js/modules/app-utilities.js
+++ b/public/js/modules/app-utilities.js
@@ -1000,6 +1000,15 @@ _formatContent(str) {
     return `\x00BLOCKQUOTE_${idx}\x00`;
   });
 
+  // Render c#RRGGBB...#c color spans (HEX color code)
+  html = html.replace(/c#([0-9a-fA-F]{6})(.+?)#c/g, '<span style="color:#$1">$2</span>');
+
+  // Render c#(R,G,B)...#c color spans (RGB color code)
+  html = html.replace(/c#\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)(.+?)#c/g, (_, r, g, b, text) => {
+    if (r > 255 || g > 255 || b > 255) return _;
+    return `<span style="color:rgb(${r},${g},${b})">${text}</span>`;
+  });
+
   // ── Headings: # H1, ## H2, ### H3 at start of line ──
   html = html.replace(/(^|\n)(#{1,3})\s+(.+)/g, (_, pre, hashes, text) => {
     const level = hashes.length;


### PR DESCRIPTION
Adds a formatting option to render custom colors within the message body.
Two color formats are supported:
- `c#(R,G,B)colored text#c` where R, G, and B are the red, green and blue values respectively in the range of 0-255.
- `c#RRGGBBcolored text#c` where RR, GG, BB are the red, green and blue values respectively in hexadecimal notation.

No dedicated picker modal yet, maybe in the future.. for now colors can be found through sites like [w3schools](https://www.w3schools.com/colors/colors_picker.asp).

Keyboard shortcut `Ctrl/Cmd + Shift + F` (F for "font", since c for code is already taken) inserts the `c#(R,G,B)...#c` formatting around selected text and moves the curser inside the parentheses for convenience to change the color quickly.

I'm open to changing the `c#...#c` formatting wrapper if you think something else is more appropriate. 
I arrived at this wrapper because I think discords color formatting is impossible, requiring external tools to use.. and used "c" for color, and # for hex color codes.