### PR TITLE
Add theme aware style to new-channel-template-row

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -97,7 +97,7 @@
               <span class="section-label-text" style="flex:1" data-i18n="app.sidebar.create_channel">Create Channel</span>
             </h5>
             <div class="collapsible-section-body" id="create-section-body">
-              <div class="input-row" id="new-channel-template-row" style="gap:6px;margin-bottom:4px">
+              <div class="input-row select-row" id="new-channel-template-row" style="gap:6px;margin-bottom:4px">
                 <select id="new-channel-template" data-i18n-title="app.sidebar.templates.hint" title="Start from a template: it ticks the boxes and sets topic, read-only, announcement and slow mode for you" style="flex:1;font-size:0.8rem"></select>
                 <button id="new-channel-template-del" class="btn-sm" type="button" data-i18n-title="app.sidebar.templates.delete_title" title="Delete this saved template" style="display:none">🗑</button>
               </div>


### PR DESCRIPTION
The new `new-channel-template-row` dropdown didn't have any theme aware styling applied and the white background color protruded the boarder.

This simply adds the same class to the element that the settings dropdowns have, allowing the dropdown to be styled similarly.

---

Before:
<img width="331" height="134" alt="image" src="https://github.com/user-attachments/assets/f5616bbf-57a4-460e-b47c-6ab5c3fe798c" />



After:
<img width="338" height="156" alt="image" src="https://github.com/user-attachments/assets/4ed8b678-a572-4723-b7e3-eb5dbbaf4f83" />

